### PR TITLE
Fix memory leak of MacroParseResult

### DIFF
--- a/bin/demo-macro-parse/src/parser.cpp
+++ b/bin/demo-macro-parse/src/parser.cpp
@@ -13,10 +13,12 @@ QString MacroParseResult::name() const { return _name; }
 quint8 MacroParseResult::argc() const { return _argc; }
 
 MacroParseResult *MacroParser::parse(QString arg) {
+  // Parent should be nullptr, as we want to explicitly transfer ownership to
+  // caller.
   auto parse = macro::analyze_macro_definition(arg);
   if (!std::get<0>(parse))
-    return new MacroParseResult(this);
+    return new MacroParseResult(nullptr);
   else
-    return new MacroParseResult(this, true, std::get<1>(parse),
+    return new MacroParseResult(nullptr, true, std::get<1>(parse),
                                 std::get<2>(parse));
 }

--- a/bin/demo-macro-parse/src/parser.hpp
+++ b/bin/demo-macro-parse/src/parser.hpp
@@ -21,5 +21,6 @@ public:
 class MacroParser : public QObject {
   Q_OBJECT
 public:
+  // Ownership of parse result is transfered to caller.
   Q_INVOKABLE MacroParseResult *parse(QString arg);
 };


### PR DESCRIPTION
Q_INVOKABLE transfers ownership to caller, unless it has a parent. 
JS engine won't delete something with parent.
So, when we set the parent to a long-living object, we leak memory.