### PR TITLE
Split ast::Node::apply into self,recursive variants

### DIFF
--- a/logic/asm/pas/src/pas/ast/node.cpp
+++ b/logic/asm/pas/src/pas/ast/node.cpp
@@ -10,10 +10,6 @@ pas::ast::Node::Node(const pas::ast::generic::Type type,
   set<generic::Children>({});
 }
 
-bool pas::ast::Node::apply(ops::ConstOp<bool> &predicate) {
-  return predicate(*this);
-}
-
 QWeakPointer<const pas::ast::Node> pas::ast::parent(const Node &node) {
   return node.get<generic::Parent>().value;
 }

--- a/logic/asm/pas/src/pas/ast/node.hpp
+++ b/logic/asm/pas/src/pas/ast/node.hpp
@@ -10,16 +10,17 @@ class Node {
 public:
   explicit Node(const pas::ast::generic::Type type,
                 QWeakPointer<Node> parent = {});
-  template <typename T> void set(T attribute);
-  template <typename T> const T get() const;
   template <typename T> bool has() const;
-  // Recursive
-  void apply(ops::ConstOp<bool> &predicate,
-             ops::ConstOp<void> &transform) const;
-  // Recursive
-  void apply(ops::ConstOp<bool> &predicate, ops::MutatingOp<void> &transform);
-  // This only
-  bool apply(ops::ConstOp<bool> &predicate);
+  template <typename T> const T get() const;
+  template <typename T> void set(T attribute);
+  template <typename T> T apply_self(ops::ConstOp<T> &transform) const;
+  template <typename T> T apply_self(ops::MutatingOp<T> &transform);
+  template <typename T>
+  std::optional<T> apply_self(ops::ConstOp<bool> &predicate,
+                              ops::ConstOp<T> &transform) const;
+  template <typename T>
+  std::optional<T> apply_self(ops::ConstOp<bool> &predicate,
+                              ops::MutatingOp<T> &transform);
 
 private:
   QVariantMap _attributes;
@@ -41,6 +42,14 @@ template <typename T> void Node::set(T attribute) {
   _attributes[T::attributeName] = QVariant::fromValue(attribute);
 }
 
+template <typename T> T Node::apply_self(ops::ConstOp<T> &transform) const {
+  return transform(*this);
+}
+
+template <typename T> T Node::apply_self(ops::MutatingOp<T> &transform) {
+  return transform(*this);
+}
+
 QWeakPointer<const Node> parent(const Node &node);
 QWeakPointer<Node> parent(Node &node);
 void setParent(Node &node, QWeakPointer<Node> parent);
@@ -50,4 +59,38 @@ const generic::Type type(const Node &node);
 QList<QSharedPointer<Node>> children(const Node &node);
 QList<QSharedPointer<Node>> children(Node &node);
 void addChild(Node &parent, QSharedPointer<Node> child);
+
+template <typename T>
+std::optional<T> apply_self_if(const Node &node, ops::ConstOp<bool> &predicate,
+                               ops::ConstOp<T> &transform) {
+  if (!node.apply_self(predicate))
+    return std::nullopt;
+  return node.apply_self(transform);
+}
+
+template <typename T>
+std::optional<T> apply_if(Node &node, ops::ConstOp<bool> &predicate,
+                          ops::MutatingOp<T> &transform) {
+  if (!node.apply_self(predicate))
+    return std::nullopt;
+  return node.apply_self(transform);
+}
+
+// If there is a result, it must be accumulated inside transform.
+template <typename T>
+void apply_recurse(const Node &node, ops::ConstOp<bool> &predicate,
+                   ops::ConstOp<T> &transform) {
+  apply_self_if(node, predicate, transform);
+  for (auto &child : children(node))
+    apply_recurse(child, predicate, transform);
+}
+
+// If there is a result, it must be accumulated inside transform.
+template <typename T>
+void apply_recurse(Node &node, ops::ConstOp<bool> &predicate,
+                   ops::MutatingOp<T> &transform) {
+  apply_self_if(node, predicate, transform);
+  for (auto &child : children(node))
+    apply_recurse(child, predicate, transform);
+}
 } // namespace pas::ast

--- a/logic/asm/pas/src/pas/ast/node.hpp
+++ b/logic/asm/pas/src/pas/ast/node.hpp
@@ -78,19 +78,19 @@ std::optional<T> apply_if(Node &node, ops::ConstOp<bool> &predicate,
 
 // If there is a result, it must be accumulated inside transform.
 template <typename T>
-void apply_recurse(const Node &node, ops::ConstOp<bool> &predicate,
-                   ops::ConstOp<T> &transform) {
+void apply_recurse_if(const Node &node, ops::ConstOp<bool> &predicate,
+                      ops::ConstOp<T> &transform) {
   apply_self_if(node, predicate, transform);
   for (auto &child : children(node))
-    apply_recurse(child, predicate, transform);
+    apply_recurse_if(child, predicate, transform);
 }
 
 // If there is a result, it must be accumulated inside transform.
 template <typename T>
-void apply_recurse(Node &node, ops::ConstOp<bool> &predicate,
-                   ops::MutatingOp<T> &transform) {
+void apply_recurse_if(Node &node, ops::ConstOp<bool> &predicate,
+                      ops::MutatingOp<T> &transform) {
   apply_self_if(node, predicate, transform);
   for (auto &child : children(node))
-    apply_recurse(child, predicate, transform);
+    apply_recurse_if(child, predicate, transform);
 }
 } // namespace pas::ast

--- a/logic/asm/pas/test/operations/pepp/node_from_parse_tree.test.cpp
+++ b/logic/asm/pas/test/operations/pepp/node_from_parse_tree.test.cpp
@@ -98,7 +98,7 @@ private slots:
     QVERIFY_THROWS_NO_EXCEPTION(
         [&]() { node = result[0].apply_visitor(visit); }());
     QCOMPARE_NE(node.data(), nullptr);
-    bool ret = node->apply(*fn);
+    bool ret = node->apply_self(*fn);
     QCOMPARE(ret, true);
   };
   void testVisitor_data() {


### PR DESCRIPTION
Right now, recursion or not depends on what overload you pick via parameters.

This is a counter-intuitive API.