### PR TITLE
Add fork operation to symbol table

### DIFF
--- a/logic/asm/symbol/src/symbol/fork.cpp
+++ b/logic/asm/symbol/src/symbol/fork.cpp
@@ -1,0 +1,69 @@
+#include "./fork.hpp"
+#include "symbol/entry.hpp"
+#include "symbol/table.hpp"
+#include "symbol/value.hpp"
+#include "value.hpp"
+void symbol::ForkMap::addMapping(const Table *from, QSharedPointer<Table> to) {
+  _tableMap[from] = to;
+}
+
+void symbol::ForkMap::addMapping(const symbol::Entry *from,
+                                 QSharedPointer<symbol::Entry> to) {
+  _symbolMap[from] = to;
+}
+
+QSharedPointer<symbol::Table> symbol::ForkMap::map(const Table *from) {
+  return _tableMap.value(from, nullptr);
+}
+
+QSharedPointer<symbol::Entry> symbol::ForkMap::map(const Entry *from) {
+  return _symbolMap.value(from, nullptr);
+}
+
+void forkTables(symbol::ForkMap &map, QSharedPointer<const symbol::Table> from,
+                QSharedPointer<symbol::Table> toParent) {
+
+  map.addMapping(&*from, toParent);
+  for (auto childIt = from->cbegin(); childIt != from->cend(); ++childIt)
+    forkTables(map, (*childIt), toParent);
+}
+void forkSymbolRefs(symbol::ForkMap &map,
+                    QSharedPointer<const symbol::Table> from,
+                    QSharedPointer<symbol::Table> toParent) {
+  for (const auto &fromSymbolPair : from->entries()) {
+    QSharedPointer<symbol::Entry> fromSymbol = fromSymbolPair.second;
+    auto toSymbol = toParent->reference(fromSymbol->name);
+    toSymbol->binding = fromSymbol->binding;
+    toSymbol->state = fromSymbol->state;
+    toSymbol->section_index = fromSymbol->section_index;
+    map.addMapping(&*(fromSymbol), toSymbol);
+  }
+  for (auto childIt = from->cbegin(); childIt != from->cend(); ++childIt)
+    forkSymbolRefs(map, (*childIt), toParent);
+}
+
+void forkSymbolValues(symbol::ForkMap &map,
+                      QSharedPointer<const symbol::Table> from,
+                      QSharedPointer<symbol::Table> toParent) {
+  for (const auto &fromSymbolPair : from->entries()) {
+    auto fromSymbol = fromSymbolPair.second;
+    auto toSymbol = map.map(&*fromSymbol);
+    if (auto asPointerVal =
+            dynamic_cast<symbol::value::Pointer *>(&*fromSymbol->value);
+        asPointerVal != nullptr) {
+      toSymbol->value = QSharedPointer<symbol::value::Pointer>::create(
+          map.map(&*asPointerVal->symbol_pointer));
+    } else {
+      toSymbol->value = fromSymbol->value->clone();
+    }
+  }
+}
+
+symbol::ForkMap symbol::fork(QSharedPointer<const Table> from) {
+  auto map = ForkMap();
+  auto to = QSharedPointer<symbol::Table>::create();
+  forkTables(map, from, to);
+  forkSymbolRefs(map, from, to);
+  forkSymbolValues(map, from, to);
+  return map;
+}

--- a/logic/asm/symbol/src/symbol/fork.hpp
+++ b/logic/asm/symbol/src/symbol/fork.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <QtCore>
+namespace symbol {
+class Table;
+class Entry;
+class ForkMap {
+public:
+  void addMapping(const Table *from, QSharedPointer<Table> to);
+  void addMapping(const Entry *from, QSharedPointer<Entry> to);
+  QSharedPointer<Table> map(const Table *from);
+  QSharedPointer<Entry> map(const Entry *from);
+
+private:
+  QMap<const Table *, QSharedPointer<Table>> _tableMap;
+  QMap<const Entry *, QSharedPointer<Entry>> _symbolMap;
+};
+
+ForkMap fork(QSharedPointer<const symbol::Table> from);
+} // namespace symbol

--- a/logic/asm/symbol/src/symbol/table.cpp
+++ b/logic/asm/symbol/src/symbol/table.cpp
@@ -12,6 +12,20 @@ QList<QSharedPointer<symbol::Table>> symbol::Table::children() {
   return _children;
 }
 
+symbol::Table::child_iterator symbol::Table::begin() {
+  return _children.begin();
+}
+
+symbol::Table::child_iterator symbol::Table::end() { return _children.end(); }
+
+symbol::Table::child_const_iterator symbol::Table::cbegin() const {
+  return child_const_iterator(_children.cbegin());
+}
+
+symbol::Table::child_const_iterator symbol::Table::cend() const {
+  return child_const_iterator(_children.cend());
+}
+
 std::optional<symbol::Table::entry_ptr_t>
 symbol::Table::get(const QString &name) const {
   if (auto item = _name_to_entry.find(name); item != _name_to_entry.end())
@@ -148,4 +162,23 @@ auto symbol::Table::entries() const -> symbol::Table::const_range {
 symbol::Table::range symbol::Table::entries() {
   return _name_to_entry.asKeyValueRange();
   ;
+}
+
+symbol::Table::child_const_iterator::child_const_iterator(iter_t init)
+    : it(init) {}
+
+symbol::Table::child_const_iterator &
+symbol::Table::child_const_iterator::operator++() {
+  ++it;
+  return *this;
+}
+
+const QSharedPointer<const symbol::Table>
+symbol::Table::child_const_iterator::operator*() const {
+  return it->constCast<const symbol::Table>();
+}
+
+bool symbol::Table::child_const_iterator::operator!=(
+    const child_const_iterator &rhs) const {
+  return it != rhs.it;
 }

--- a/logic/asm/symbol/src/symbol/table.hpp
+++ b/logic/asm/symbol/src/symbol/table.hpp
@@ -68,12 +68,24 @@ public:
   using map_t = QMap<QString, entry_ptr_t>;
   using range = decltype(std::declval<map_t &>().asKeyValueRange());
   using const_range = detail::asConstKeyValueRange<const map_t>;
+
+  // See: https://stackoverflow.com/a/54127343
+  struct child_const_iterator {
+    using iter_t =
+        typename QList<QSharedPointer<symbol::Table>>::const_iterator;
+    iter_t it;
+    child_const_iterator(iter_t init);
+    child_const_iterator &operator++();
+    const QSharedPointer<const symbol::Table> operator*() const;
+    bool operator!=(const child_const_iterator &rhs) const;
+  };
+  using child_iterator = QList<QSharedPointer<symbol::Table>>::iterator;
   //! Default constructor only used for top level Tables
   Table() = default;
   [[maybe_unused]] explicit Table(QSharedPointer<Table> parent);
   ~Table() = default;
 
-  //	Copying and move OK
+  //  Copying and move OK
   Table(const Table &) = default;
   Table &operator=(const Table &) = default;
   Table(Table &&) noexcept = default;
@@ -89,11 +101,15 @@ public:
    * Please don't abuse the fact that children are non-const.
    */
   QList<QSharedPointer<Table>> children();
+  child_iterator begin();
+  child_iterator end();
+  child_const_iterator cbegin() const;
+  child_const_iterator cend() const;
 
   /*!
-   * \brief Unlike reference, get() will not create an entry in the table if the
-   * symbol fails to be found.
-   * \returns Pointer to found symbol or nullopt if not found.
+   * \brief Unlike reference, get() will not create an entry in the table if
+   * the symbol fails to be found. \returns Pointer to found symbol or
+   * nullopt if not found.
    */
   std::optional<entry_ptr_t> get(const QString &name) const;
 

--- a/logic/asm/symbol/src/symbol/value.hpp
+++ b/logic/asm/symbol/src/symbol/value.hpp
@@ -34,8 +34,8 @@ class Entry;
 }
 namespace symbol::value {
 struct SYMBOL_EXPORT MaskedBits {
-  quint8 byteCount;
-  quint64 bitPattern, mask;
+  quint8 byteCount = 0;
+  quint64 bitPattern = 0, mask = 0;
   quint64 operator()();
   bool operator==(const MaskedBits &other) const;
 };
@@ -84,6 +84,12 @@ public:
    * otherwise.
    */
   virtual bool relocatable() const { return false; }
+
+  /*!
+   *
+   * \returns A shallow copy of the derived class
+   */
+  virtual QSharedPointer<Abstract> clone() const = 0;
 };
 
 /*!
@@ -91,10 +97,22 @@ public:
  */
 class SYMBOL_EXPORT Empty : public Abstract {
 public:
+  explicit Empty();
   explicit Empty(quint8 bytes);
+  Empty(const Empty &other);
+  Empty(Empty &&other) noexcept;
+  Empty &operator=(Empty other);
+  friend void swap(Empty &first, Empty &second) {
+    using std::swap;
+    // swap((Abstract &)first, (Abstract &)second); // Add if data in base class
+    // gets data
+    swap(first._bytes, second._bytes);
+  }
   virtual ~Empty() override = default;
+
   MaskedBits value() const override;
   Type type() const override;
+  QSharedPointer<Abstract> clone() const override;
 
 private:
   quint8 _bytes;
@@ -108,10 +126,20 @@ private:
  */
 class SYMBOL_EXPORT Deleted : public Abstract {
 public:
-  Deleted() = default;
+  explicit Deleted();
+  Deleted(Deleted &&other) noexcept;
+  Deleted(const Deleted &other);
+  Deleted &operator=(Deleted other);
+  friend void swap(Deleted &first, Deleted &second) {
+    using std::swap;
+    // swap((Abstract &)first, (Abstract &)second); // Add if data in base class
+    // gets data.
+  }
   virtual ~Deleted() override = default;
+
   MaskedBits value() const override;
   symbol::Type type() const override;
+  QSharedPointer<Abstract> clone() const override;
 };
 
 /*!
@@ -121,10 +149,22 @@ class SYMBOL_EXPORT Constant : public Abstract {
   MaskedBits _value;
 
 public:
+  explicit Constant();
   explicit Constant(MaskedBits value);
+  Constant(const Constant &other);
+  Constant(Constant &&other) noexcept;
+  Constant &operator=(Constant other);
+  friend void swap(Constant &first, Constant &second) {
+    using std::swap;
+    // swap((Abstract &)first, (Abstract &)second); // Add if data in base class
+    // gets data.
+    swap(first._value, second._value);
+  }
   virtual ~Constant() override = default;
+
   MaskedBits value() const override;
   symbol::Type type() const override;
+  QSharedPointer<Abstract> clone() const override;
 
   /*!
    * \brief Overwrite the internal value of this object using the given
@@ -146,14 +186,30 @@ public:
 class SYMBOL_EXPORT Location : public Abstract {
 
 public:
+  // Type defaults to kConstant, to avoid participation in relocation.
+  explicit Location();
   // Type must be kCode or kObject.
   explicit Location(quint8 bytes, quint64 base, quint64 offset,
                     symbol::Type type);
+  Location(const Location &other);
+  Location(Location &&other) noexcept;
+  Location &operator=(Location other);
+  friend void swap(Location &first, Location &second) {
+    using std::swap;
+    // swap((Abstract &)first, (Abstract &)second); // Add if data in base class
+    // gets data.
+    swap(first._bytes, second._bytes);
+    swap(first._base, second._base);
+    swap(first._offset, second._offset);
+    swap(first._type, second._type);
+  }
   virtual ~Location() override = default;
+
   // Inherited via value.
   virtual MaskedBits value() const override;
   symbol::Type type() const override;
   bool relocatable() const override;
+  QSharedPointer<Abstract> clone() const override;
 
   /*!
    * \brief Increment the existing offset of this object.
@@ -182,9 +238,9 @@ public:
   quint64 base() const;
 
 private:
-  quint8 _bytes;
-  quint64 _base, _offset;
-  symbol::Type _type;
+  quint8 _bytes = 0;
+  quint64 _base = 0, _offset = 0;
+  symbol::Type _type = symbol::Type::kConstant;
 };
 
 /*!
@@ -197,14 +253,26 @@ private:
  */
 class SYMBOL_EXPORT Pointer : public Abstract {
 public:
+  explicit Pointer();
   explicit Pointer(QSharedPointer<const symbol::Entry> ptr);
+  Pointer(const Pointer &other);
+  Pointer(Pointer &&other) noexcept;
+  Pointer &operator=(Pointer other);
+  friend void swap(Pointer &first, Pointer &second) {
+    using std::swap;
+    // swap((Abstract &)first, (Abstract &)second); // Add if data in base class
+    // gets data.
+    swap(first.symbol_pointer, second.symbol_pointer);
+  }
   ~Pointer() override = default;
+
   // Inherited via value.
   MaskedBits value() const override;
   symbol::Type type() const override;
+  QSharedPointer<Abstract> clone() const override;
 
   //! Symbol whose value is to be taken on. Does not need to belong to the same
   //! table.
-  QSharedPointer<const symbol::Entry> symbol_pointer;
+  QSharedPointer<const symbol::Entry> symbol_pointer = {};
 };
 }; // namespace symbol::value


### PR DESCRIPTION
Provides a deep clone of a symbol table, it children, and all contained symbols.

Needed to enable cloning of AST.
Without this, modifications to symbol values in a cloned AST would modify the source AST.