### PR TITLE
Allow symbol pointers outside current hierarchy

### DIFF
--- a/logic/asm/symbol/src/symbol/fork.cpp
+++ b/logic/asm/symbol/src/symbol/fork.cpp
@@ -49,9 +49,9 @@ void forkSymbolValues(symbol::ForkMap &map,
     auto fromSymbol = fromSymbolPair.second;
     auto toSymbol = map.map(&*fromSymbol);
     if (auto asPointerVal =
-            dynamic_cast<symbol::value::Pointer *>(&*fromSymbol->value);
+            dynamic_cast<symbol::value::InternalPointer *>(&*fromSymbol->value);
         asPointerVal != nullptr) {
-      toSymbol->value = QSharedPointer<symbol::value::Pointer>::create(
+      toSymbol->value = QSharedPointer<symbol::value::InternalPointer>::create(
           map.map(&*asPointerVal->symbol_pointer));
     } else {
       toSymbol->value = fromSymbol->value->clone();

--- a/logic/asm/symbol/src/symbol/table.cpp
+++ b/logic/asm/symbol/src/symbol/table.cpp
@@ -27,6 +27,20 @@ symbol::Table::child_const_iterator symbol::Table::cend() const {
 }
 
 std::optional<symbol::Table::entry_ptr_t>
+symbol::Table::import(Table &other, const QString &name) {
+  auto extSym = other.get(name);
+  if (extSym == std::nullopt)
+    return std::nullopt;
+  auto intSym = this->define(name);
+  intSym->binding = symbol::Binding::kImported;
+  auto value = QSharedPointer<symbol::value::ExternalPointer>::create();
+  value->symbol_pointer = extSym.value();
+  value->symbol_table = other.sharedFromThis();
+  intSym->value = value;
+  return intSym;
+}
+
+std::optional<symbol::Table::entry_ptr_t>
 symbol::Table::get(const QString &name) const {
   if (auto item = _name_to_entry.find(name); item != _name_to_entry.end())
     return item.value();

--- a/logic/asm/symbol/src/symbol/table.cpp
+++ b/logic/asm/symbol/src/symbol/table.cpp
@@ -70,7 +70,7 @@ symbol::Table::entry_ptr_t symbol::Table::reference(const QString &name) {
     for (auto &other : symbols) {
       if (other->binding == symbol::Binding::kGlobal) {
         local_definition->value =
-            QSharedPointer<symbol::value::Pointer>::create(other);
+            QSharedPointer<symbol::value::InternalPointer>::create(other);
         // Mark the symbol as imported, so that we can tell the difference
         // between our global symbols and others' globals.
         local_definition->binding = symbol::Binding::kImported;
@@ -103,7 +103,8 @@ symbol::Table::entry_ptr_t symbol::Table::define(const QString &name) {
       if (&other->parent == &*this)
         continue;
       else if (other->binding == symbol::Binding::kImported) {
-        other->value = QSharedPointer<symbol::value::Pointer>::create(entry);
+        other->value =
+            QSharedPointer<symbol::value::InternalPointer>::create(entry);
         // Mark the symbol as imported, so that we can tell the difference
         // between our global symbols and others' globals.
         other->binding = symbol::Binding::kImported;
@@ -141,7 +142,8 @@ void symbol::Table::markGlobal(const QString &name) {
       other->state = symbol::DefinitionState::kExternalMultiple;
       symbol->state = symbol::DefinitionState::kExternalMultiple;
     } else if (other->binding == symbol::Binding::kLocal) {
-      other->value = QSharedPointer<symbol::value::Pointer>::create(symbol);
+      other->value =
+          QSharedPointer<symbol::value::InternalPointer>::create(symbol);
       // Mark the symbol as imported, so that we can tell the difference between
       // our global symbols and others' globals.
       other->binding = symbol::Binding::kImported;

--- a/logic/asm/symbol/src/symbol/table.hpp
+++ b/logic/asm/symbol/src/symbol/table.hpp
@@ -107,6 +107,14 @@ public:
   child_const_iterator cend() const;
 
   /*!
+   * \brief Create a symbol locally that points to a symbol in an external
+   * table. Handles setting various symbol flags correctly for import.
+   * \returns a define()'ed symbol if name is in other, else nullopt if not
+   * found.
+   */
+  std::optional<entry_ptr_t> import(symbol::Table &other, const QString &name);
+
+  /*!
    * \brief Unlike reference, get() will not create an entry in the table if
    * the symbol fails to be found. \returns Pointer to found symbol or
    * nullopt if not found.

--- a/logic/asm/symbol/test/two_table.test.cpp
+++ b/logic/asm/symbol/test/two_table.test.cpp
@@ -119,6 +119,26 @@ private slots:
     QCOMPARE(x->state, symbol::DefinitionState::kExternalMultiple);
     QCOMPARE(y->state, symbol::DefinitionState::kExternalMultiple);
   }
+
+  void externalSymbolTable() {
+    auto st1 = QSharedPointer<symbol::Table>::create();
+    auto st2 = QSharedPointer<symbol::Table>::create();
+
+    auto x = st1->define("hello");
+    auto x_val = QSharedPointer<symbol::value::Constant>::create();
+    x_val->setValue({.byteCount = 2, .bitPattern = 0xfeed, .mask = 0x8FFF});
+    x->value = x_val;
+    st1->markGlobal("hello");
+
+    auto maybe_y = st2->import(*st1, "hello");
+    QVERIFY(maybe_y.has_value());
+    auto y = maybe_y.value();
+    QCOMPARE(x->binding, symbol::Binding::kGlobal);
+    QCOMPARE(y->binding, symbol::Binding::kImported);
+    QCOMPARE(x->state, symbol::DefinitionState::kSingle);
+    QCOMPARE(y->state, symbol::DefinitionState::kSingle);
+    QCOMPARE(x->value->value(), y->value->value());
+  }
 };
 #include "two_table.test.moc"
 QTEST_MAIN(Symbol2Table)

--- a/logic/asm/symbol/test/values.test.cpp
+++ b/logic/asm/symbol/test/values.test.cpp
@@ -58,7 +58,8 @@ private slots:
     QCOMPARE(value.value()(), base + end_offset);
     QVERIFY(value.relocatable());
   }
-  // Can't test external symbol value here, as it will require a symbol table.
+  // Can't test internal or external symbol pointer value here, as it will
+  // require a symbol table.
 };
 
 #include "values.test.moc"


### PR DESCRIPTION
Eases implementation of macro assembler.

Closes #61, #62, #63.