### PR TITLE
Fix parser bug related to default values

### DIFF
--- a/logic/asm/pas/src/pas/parse/pepp/rules_lines.hpp
+++ b/logic/asm/pas/src/pas/parse/pepp/rules_lines.hpp
@@ -51,7 +51,7 @@ inline rule<class nonunary, NonUnaryType, true> nonunary = "nonunary";
 // -thing doesn't work, so fake it by injecting an empty string into struct.
 const auto nonunary_def =
     skip(space)[(symbol | attr(std::string{})) >> identifier_def >> argument >>
-                -("," >> identifier_def) >>
+                (("," >> identifier_def) | (attr(std::string{}))) >>
                 (comment_def[setComment] | attr(std::string{}))];
 BOOST_SPIRIT_DEFINE(nonunary);
 

--- a/logic/asm/pas/src/pas/parse/pepp/rules_lines.hpp
+++ b/logic/asm/pas/src/pas/parse/pepp/rules_lines.hpp
@@ -60,10 +60,10 @@ BOOST_SPIRIT_DEFINE(nonunary);
 // semantic actions.
 inline rule<class directive, DirectiveType, true> directive = "directive";
 // -thing doesn't work, so fake it by injecting an empty string into struct.
-const auto directive_def =
-    skip(space)[(symbol | attr(std::string{})) >>
-                lexeme["." >> identifier_def] >> *(argument % ",") >>
-                (comment_def[setComment] | attr(std::string{}))];
+const auto directive_def = skip(
+    space)[(symbol | attr(std::string{})) >> lexeme["." >> identifier_def] >>
+           ((argument % ",") | attr(std::vector<Value>{})) >>
+           (comment_def[setComment] | attr(std::string{}))];
 BOOST_SPIRIT_DEFINE(directive);
 
 // Directive Line
@@ -71,10 +71,10 @@ BOOST_SPIRIT_DEFINE(directive);
 // semantic actions.
 inline rule<class macro, MacroType, true> macro = "macro";
 // -thing doesn't work, so fake it by injecting an empty string into struct.
-const auto macro_def =
-    skip(space)[(symbol | attr(std::string{})) >>
-                lexeme["@" >> identifier_def] >> *(argument % ",") >>
-                (comment_def[setComment] | attr(std::string{}))];
+const auto macro_def = skip(
+    space)[(symbol | attr(std::string{})) >> lexeme["@" >> identifier_def] >>
+           ((argument % ",") | attr(std::vector<Value>{})) >>
+           (comment_def[setComment] | attr(std::string{}))];
 BOOST_SPIRIT_DEFINE(macro);
 
 // Lines

--- a/logic/asm/pas/src/pas/parse/pepp/rules_values.hpp
+++ b/logic/asm/pas/src/pas/parse/pepp/rules_values.hpp
@@ -8,6 +8,7 @@ namespace pas::parse::pepp {
 using boost::spirit::x3::char_;
 using boost::spirit::x3::char_range;
 using boost::spirit::x3::digit;
+using boost::spirit::x3::eol;
 using boost::spirit::x3::eps;
 using boost::spirit::x3::int_;
 using boost::spirit::x3::lexeme;
@@ -19,6 +20,7 @@ using boost::spirit::x3::rule;
 using boost::spirit::x3::space;
 using boost::spirit::x3::uint_parser;
 using boost::spirit::x3::ulong_long;
+
 // character / string components
 const auto escape_codes = lit("\\b") | lit("\\f") | lit("\\n") | lit("\\r") |
                           lit("\\t") | lit("\\v") | lit("\\\"") | lit("\\'");
@@ -39,7 +41,7 @@ BOOST_SPIRIT_DEFINE(strings);
 
 // Identifier
 const auto ident_char = char_ - (space | "\"" | lit("'") | lit(":") | lit(";") |
-                                 lit(",") | lit(".") | lit("-"));
+                                 lit(",") | lit(".") | lit("-") | eol);
 inline rule<class identifier, Identifier> identifier = "identifier";
 const auto identifier_def = lexeme[raw[(ident_char - digit) >> *ident_char]];
 BOOST_SPIRIT_DEFINE(identifier);

--- a/logic/asm/pas/test/parse/pepp/node_from_parse_tree/error.test.cpp
+++ b/logic/asm/pas/test/parse/pepp/node_from_parse_tree/error.test.cpp
@@ -29,10 +29,11 @@ private slots:
     // Convert input string to parsed lines.
     std::vector<pas::parse::pepp::LineType> result;
     bool success = true;
+    auto current = asStd.begin();
     QVERIFY_THROWS_NO_EXCEPTION([&]() {
-      success =
-          parse(asStd.begin(), asStd.end(), pas::parse::pepp::line, result);
+      success = parse(current, asStd.end(), pas::parse::pepp::line, result);
     }());
+    QVERIFY2(current == asStd.end(), "Partial parse failure");
     QVERIFY2(success, "Failed to parse");
 
     auto root = pas::parse::pepp::toAST<pas::isa::Pep10ISA>(result);

--- a/logic/asm/pas/test/parse/pepp/node_from_parse_tree/error.test.cpp
+++ b/logic/asm/pas/test/parse/pepp/node_from_parse_tree/error.test.cpp
@@ -260,15 +260,16 @@ private slots:
 
     // Section
     // - exactly 1 arg (an identifier)
-    QTest::addRow("SECTION: min 1 argument")
-        << u"SECTION"_qs << QList<Error>{makeFatal(0, E::invalidMnemonic)};
-    QTest::addRow("SECTION: max 1 argument")
-        << u"SECTION 0x00, 0x01"_qs
-        << QList<Error>{makeFatal(0, E::invalidMnemonic)};
+    QTest::addRow(".SECTION: min 1 argument")
+        << u".SECTION"_qs
+        << QList<Error>{makeFatal(0, E::expectNArguments.arg(1))};
+    QTest::addRow(".SECTION: max 1 argument")
+        << u".SECTION 0x00, 0x01"_qs
+        << QList<Error>{makeFatal(0, E::expectNArguments.arg(1))};
     // - no symbol
-    QTest::addRow("SECTION: no symbol")
-        << u"ret: SECTION 1"_qs
-        << QList<Error>{makeFatal(0, E::invalidMnemonic)};
+    QTest::addRow(".SECTION: no symbol")
+        << u"ret: .SECTION \"data\""_qs
+        << QList<Error>{makeFatal(0, E::noDefineSymbol.arg(".SECTION"))};
 
     // Word
     // - exactly 1 arg

--- a/logic/asm/pas/test/parse/pepp/node_from_parse_tree/error.test.cpp
+++ b/logic/asm/pas/test/parse/pepp/node_from_parse_tree/error.test.cpp
@@ -133,7 +133,7 @@ private slots:
         << u".ASCII -42"_qs << QList<Error>{makeFatal(0, ascii)};
     // - exactly 1 arg
     QTest::addRow(".ASCII: max 1 argument")
-        << u".ASCII \"Bad\" \"Beef\""_qs << QList<Error>{makeFatal(0, arg1)};
+        << u".ASCII \"Bad\", \"Beef\""_qs << QList<Error>{makeFatal(0, arg1)};
 
     // BLOCK
     // - no signed


### PR DESCRIPTION
The `-` operator does not seem to work consistently.
Instead, I can have a `(match | attr(default_value))` construct which exhibits the same behavior, albeit more verbosely.