### PR TITLE
Collect & report AST parse errors in pepp::createParser

### DIFF
--- a/logic/asm/pas/src/pas/driver/pepp.hpp
+++ b/logic/asm/pas/src/pas/driver/pepp.hpp
@@ -2,6 +2,7 @@
 #include "./common.hpp"
 #include "pas/ast/node.hpp"
 #include "pas/driver/common.hpp"
+#include "pas/operations/generic/errors.hpp"
 #include "pas/operations/generic/include_macros.hpp"
 #include "pas/parse/pepp/node_from_parse_tree.hpp"
 #include "pas/parse/pepp/rules_lines.hpp"
@@ -52,7 +53,11 @@ createParser(bool hideEnd) {
       return ret;
     }
     ret.root = pas::parse::pepp::toAST<ISA>(result, parent, hideEnd);
-    ret.hadError = false;
+    auto errors = ops::generic::CollectErrors();
+    ast::apply_recurse(*ret.root, errors);
+    ret.hadError = errors.errors.size() != 0;
+    for (auto &error : errors.errors)
+      ret.errors.push_back(error.second.message);
     return ret;
   };
 }

--- a/logic/asm/pas/test/operations/pepp/size.test.cpp
+++ b/logic/asm/pas/test/operations/pepp/size.test.cpp
@@ -154,7 +154,7 @@ private slots:
 
   void byteSize() {
     auto ret = pas::driver::pepp::createParser<Pep10ISA>(false)(
-        u".BYTE 0\n .BYTE 1\n.BYTE 0xFFFF"_qs, nullptr);
+        u".BYTE 0\n .BYTE 1\n.BYTE 0xFF"_qs, nullptr);
     QVERIFY(!ret.hadError);
     auto children = ret.root->get<pas::ast::generic::Children>().value;
     QCOMPARE(children.size(), 3);


### PR DESCRIPTION
API previously depended on the user to collect errors, which was unlikely to happen.