### PR TITLE
Fix listing for .BLOCK 1, which currently emits no bytes

### DIFF
--- a/logic/asm/pas/src/pas/operations/pepp/bytes.cpp
+++ b/logic/asm/pas/src/pas/operations/pepp/bytes.cpp
@@ -24,7 +24,8 @@ quint16 asciiToBytes(const pas::ast::Node &node, quint8 *dest, quint64 length) {
 
 quint16 blockToBytes(const pas::ast::Node &node, quint8 *dest, quint64 length) {
   auto argument = node.get<pas::ast::generic::Argument>().value;
-  auto size = argument->size();
+  quint16 size = 0;
+  argument->value(reinterpret_cast<quint8 *>(&size), 2, pas::bits::hostOrder());
   if (length < size)
     return 0;
   memset(dest, 0, size);

--- a/logic/asm/pas/test/operations/pepp/listing.test.cpp
+++ b/logic/asm/pas/test/operations/pepp/listing.test.cpp
@@ -84,7 +84,7 @@ private slots:
     QTest::addRow("BLOCK 0")
         << "s: .BLOCK 0" << QStringList{"0000        s:       .BLOCK  0"};
     QTest::addRow("BLOCK 1")
-        << ".BLOCK 1" << QStringList{"0000                .BLOCK  1"};
+        << ".BLOCK 1" << QStringList{"0000     00         .BLOCK  1"};
     QTest::addRow("BLOCK 0x2")
         << ".BLOCK 0x2" << QStringList{"0000   0000         .BLOCK  0x0002"};
     QTest::addRow("BLOCK 4")
@@ -123,9 +123,9 @@ private slots:
         << "s: .EQUATE \"hi\""
         << QStringList{"            s:       .EQUATE \"hi\""};
     QTest::addRow("ORG") << ".BLOCK 1\n.ORG 0x8000\n.BLOCK 1"
-                         << QStringList{"0000                .BLOCK  1",
+                         << QStringList{"0000     00         .BLOCK  1",
                                         "                    .ORG    0x8000",
-                                        "8000                .BLOCK  1"};
+                                        "8000     00         .BLOCK  1"};
     for (auto &str :
          {".IMPORT", ".EXPORT", ".SCALL", ".USCALL", ".INPUT", ".OUTPUT"}) {
       QTest::addRow("%s", str)


### PR DESCRIPTION
Did not emit bytes into listing when it should.

Closes #124.

Grabbed the wrong value (argument size vs argument value) from arg.