### PR TITLE
refactor(asm.pas)!: remove .END directive from Pep/10

### DIFF
--- a/logic/asm/pas/src/pas/isa/pep10.cpp
+++ b/logic/asm/pas/src/pas/isa/pep10.cpp
@@ -172,9 +172,8 @@ bool pas::isa::Pep10ISA::canElideAddressingMode(Mnemonic mnemonic,
 }
 
 bool pas::isa::Pep10ISA::isLegalDirective(QString directive) {
-  static const auto valid =
-      QSet<QString>{"ALIGN",  "ASCII",  "BLOCK",   "BYTE",   "END",
-                    "EQUATE", "EXPORT", "IMPORT",  "INPUT",  "OUTPUT",
-                    "ORG",    "SCALL",  "SECTION", "USCALL", "WORD"};
+  static const auto valid = QSet<QString>{
+      "ALIGN", "ASCII",  "BLOCK", "BYTE",  "EQUATE",  "EXPORT", "IMPORT",
+      "INPUT", "OUTPUT", "ORG",   "SCALL", "SECTION", "USCALL", "WORD"};
   return valid.contains(directive.toUpper());
 }

--- a/logic/asm/pas/src/pas/operations/pepp/whole_program_sanity.hpp
+++ b/logic/asm/pas/src/pas/operations/pepp/whole_program_sanity.hpp
@@ -80,7 +80,7 @@ bool checkWholeProgramSanity(ast::Node &node, Features features) {
     // Add error to all nodes with OS features
     errorOnOSFeatures(node);
     return false;
-  } else if (ops::generic::findFirst(node, pas::ops::pepp::findUnhiddenEnd) ==
+  } /*else if (ops::generic::findFirst(node, pas::ops::pepp::findUnhiddenEnd) ==
              nullptr) {
     // Add error to first "real" node if present
     auto target =
@@ -93,7 +93,8 @@ bool checkWholeProgramSanity(ast::Node &node, Features features) {
                   {.severity = pas::ast::generic::Message::Severity::Fatal,
                    .message = pas::errors::pepp::missingEnd});
     return false;
-  } else if (errorOnUndefinedSymbolicArgument(node))
+  }*/
+  else if (errorOnUndefinedSymbolicArgument(node))
     // Visitor adds its own errors, just signal error
     return false;
   else if (errorOnMultipleSymbolDefiniton(node))

--- a/logic/asm/pas/test/operations/pepp/whole_program_sanity.test.cpp
+++ b/logic/asm/pas/test/operations/pepp/whole_program_sanity.test.cpp
@@ -11,7 +11,7 @@ class PasOpsPepp_WholeProgramSanity : public QObject {
   Q_OBJECT
 private slots:
   void noBurn() {
-    QString source = ".BURN 0xFFFF\n.BLOCK 1\n.END";
+    QString source = ".BURN 0xFFFF\n.BLOCK 1\n";
     auto parsed = pas::driver::pepp::createParser<pas::isa::Pep10ISA>(false)(
         source, nullptr);
     pas::ops::pepp::assignAddresses<pas::isa::Pep10ISA>(*parsed.root);
@@ -22,7 +22,7 @@ private slots:
     QCOMPARE(errors[0].second.message, E::illegalDirective.arg(".BURN"));
   }
   void size0xFFFF() {
-    QString source = ".BLOCK 0xFFFF\n.END";
+    QString source = ".BLOCK 0xFFFF\n";
     auto parsed = pas::driver::pepp::createParser<pas::isa::Pep10ISA>(false)(
         source, nullptr);
     pas::ops::pepp::assignAddresses<pas::isa::Pep10ISA>(*parsed.root);
@@ -30,7 +30,7 @@ private slots:
         *parsed.root, {.allowOSFeatures = false}));
   }
   void size0x10000() {
-    QString source = ".BLOCK 0xFFFF\n.BLOCK 2\n.END";
+    QString source = ".BLOCK 0xFFFF\n.BLOCK 2\n";
     auto parsed = pas::driver::pepp::createParser<pas::isa::Pep10ISA>(false)(
         source, nullptr);
     pas::ops::pepp::assignAddresses<pas::isa::Pep10ISA>(*parsed.root);
@@ -42,7 +42,7 @@ private slots:
   }
   void noOSFeatures() {
     QFETCH(QString, op);
-    QString source = u".%1 s\ns:.block 1\n.END"_qs.arg(op);
+    QString source = u".%1 s\ns:.block 1\n"_qs.arg(op);
     auto parsed = pas::driver::pepp::createParser<pas::isa::Pep10ISA>(false)(
         source, nullptr);
     pas::ops::pepp::assignAddresses<pas::isa::Pep10ISA>(*parsed.root);
@@ -65,7 +65,7 @@ private slots:
     QTest::addRow("SCALL") << "SCALL";
   }
 
-  void requireEnd() {
+  /*void requireEnd() {
     QString source = ".BLOCK 2";
     auto parsed = pas::driver::pepp::createParser<pas::isa::Pep10ISA>(false)(
         source, nullptr);
@@ -75,9 +75,21 @@ private slots:
     auto errors = pas::ops::generic::collectErrors(*parsed.root);
     QCOMPARE(errors.size(), 1);
     QCOMPARE(errors[0].second.message, E::missingEnd);
+  }*/
+  void noRequiresEnd() {
+    QString source = ".BLOCK 2\n.END";
+    auto parsed = pas::driver::pepp::createParser<pas::isa::Pep10ISA>(false)(
+        source, nullptr);
+    pas::ops::pepp::assignAddresses<pas::isa::Pep10ISA>(*parsed.root);
+    QVERIFY(!pas::ops::pepp::checkWholeProgramSanity<pas::isa::Pep10ISA>(
+        *parsed.root, {.allowOSFeatures = false}));
+    auto errors = pas::ops::generic::collectErrors(*parsed.root);
+    QCOMPARE(errors.size(), 1);
+    QCOMPARE(errors[0].second.message, E::illegalDirective.arg(".END"));
   }
+
   void noUndefinedDefinedArg() {
-    QString source = "LDWA s,i\n.END";
+    QString source = "LDWA s,i\n";
     auto parsed = pas::driver::pepp::createParser<pas::isa::Pep10ISA>(false)(
         source, nullptr);
     pas::ops::pepp::assignAddresses<pas::isa::Pep10ISA>(*parsed.root);
@@ -88,7 +100,7 @@ private slots:
     QCOMPARE(errors[0].second.message, E::undefinedSymbol.arg("s"));
   }
   void noMultiplyDefined() {
-    QString source = "s:.BLOCK 2\ns:.block 2\n.END";
+    QString source = "s:.BLOCK 2\ns:.block 2\n";
     auto parsed = pas::driver::pepp::createParser<pas::isa::Pep10ISA>(false)(
         source, nullptr);
     pas::ops::pepp::assignAddresses<pas::isa::Pep10ISA>(*parsed.root);


### PR DESCRIPTION
As per #147, we no longer want a .END directive.

It will remain a part of the Pep/9 and Pep/8 languages, but will no longer be part of Pep/10.

BREAKING CHANGE: .END is no longer a valid directive