### PR TITLE
Add trap handler, missing memory vectors to bare metal OS

### DIFF
--- a/logic/asm/builtins2/books/cs6e/contents/bmos/os.pep
+++ b/logic/asm/builtins2/books/cs6e/contents/bmos/os.pep
@@ -1,8 +1,29 @@
          .SECTION "stack", "rwz"
-bp:      .WORD bp
-
+bmRAM:   .BLOCK  2
+;
+         .SECTION "text", "wx"
+;
+;******* Trap Handler
+;While bare metal mode is not supposed to have a trap handler,
+;failure to provide one could cause user-programs to enter an infinite loop.
+;This trap handler will print out an error message before terminating execution.
+trp:     LDWX    0,i         ;X <- 0
+prntMore:LDBA    msg,x       ;Test next char
+         BREQ    exitPrnt    ;If null then exit
+         STBA    charOut,d   ;else print
+         ADDX    1,i         ;X <- X + 1 for next character
+         BR      prntMore
+exitPrnt:LDWA    0xDEAD, i
+         STBA    pwrOff, d
+hang:    BR      hang
+msg:     .ASCII "Cannot use system calls in bare metal mode\x00"
+;
+trpHnd:   .WORD  trp
+initPC:  .WORD   0x0000
+;
          .SECTION "memvec", "rw"
-         .ORG    0xFFFC
+         .ORG    0xFFFA
+initSP:  .WORD   bmRAM
          .INPUT  diskIn
 diskIn:  .BLOCK  1
          .INPUT  charIn

--- a/logic/asm/pas/test/e2e/pep10.test.cpp
+++ b/logic/asm/pas/test/e2e/pep10.test.cpp
@@ -134,7 +134,14 @@ private slots:
     auto osRoot = osTarget->bodies[pas::driver::repr::Nodes::name]
                       .value<pas::driver::repr::Nodes>()
                       .value;
-
+    if (pipeline->pipelines[0].first->stage != pas::driver::pep10::Stage::End) {
+      auto lines = pas::ops::pepp::formatListing<isa::Pep10>(*osRoot);
+      for (auto &line : lines)
+        qCritical() << line;
+      for (auto &error : pas::ops::generic::collectErrors(*osRoot))
+        qCritical() << "OS:   " << error.second.message;
+      QVERIFY(false);
+    }
     auto userTarget = pipeline->pipelines[1].first;
     QVERIFY(userTarget->bodies.contains(pas::driver::repr::Nodes::name));
     auto userRoot = userTarget->bodies[pas::driver::repr::Nodes::name]


### PR DESCRIPTION
Without memory vectors, don't know how to init SP/PC.
Without trap handler, U/SCALL will enter infinite loop.