### PR TITLE
Add non-modifying trace types

### DIFF
--- a/logic/sim/src/sim/device/dense.hpp
+++ b/logic/sim/src/sim/device/dense.hpp
@@ -190,7 +190,7 @@ sim::memory::Dense<Address>::write(Address address, const quint8 *src,
   if (op.effectful && _tb) {
     // Attempt to allocate space in the buffer for local trace packet.
     auto [size, flags] = detail::info<Address>(length);
-    api::trace::Buffer::Guard<true> guard(_tb, size, _device.id, flags);
+    api::trace::Buffer::Guard<false> guard(_tb, size, _device.id, flags);
     // Even with success we might get nullptr, in which case the Buffer is
     // telling us it doesn't want our trace.
     if (guard) {

--- a/logic/sim/src/sim/device/simple_bus.hpp
+++ b/logic/sim/src/sim/device/simple_bus.hpp
@@ -196,14 +196,12 @@ quint8 SimpleBus<Address>::packetSize(api::packet::Flags flags) const {
 template <typename Address>
 bool SimpleBus<Address>::applyTrace(void *payload, quint8 size,
                                     api::packet::Flags flags) {
-
   throw std::logic_error("unimplemented");
 }
 
 template <typename Address>
 bool SimpleBus<Address>::unapplyTrace(void *payload, quint8 size,
                                       api::packet::Flags flags) {
-
   throw std::logic_error("unimplemented");
 }
 

--- a/logic/sim/src/sim/trace/common.hpp
+++ b/logic/sim/src/sim/trace/common.hpp
@@ -5,40 +5,47 @@
 /*
  *                   00 -- All must end in 00, because these are 8 bit flags
  *                         that are global structures.
- *            0000'0000 -- Empty packet
- *            0010'0100 -- Addressable Packet w 1B address, 1B data
- *            0010'1000 -- Addressable Packet w 1B address, 2B data
- *            0010'1100 -- Addressable Packet w 1B address, 4B data
- *            0011'0000 -- Addressable Packet w 1B address, 8B data
- *            0011'0100 -- Addressable Packet w 1B address, 16B data
- *            0011'1000 -- Addressable Packet w 1B address, 32B data
- *            0011'1100 -- Addressable Packet w 1B address, 64B data
- *            0100'0100 -- Addressable Packet w 2B address, 1B data
- *            0100'1000 -- Addressable Packet w 2B address, 2B data
- *            0100'1100 -- Addressable Packet w 2B address, 4B data
- *            0101'0000 -- Addressable Packet w 2B address, 8B data
- *            0101'0100 -- Addressable Packet w 2B address, 16B data
- *            0101'1000 -- Addressable Packet w 2B address, 32B data
- *            0101'1100 -- Addressable Packet w 2B address, 64B data
- *            1000'0100 -- Addressable Packet w 4B address, 1B data
- *            1000'1000 -- Addressable Packet w 4B address, 2B data
- *            1000'1100 -- Addressable Packet w 4B address, 4B data
- *            1001'0000 -- Addressable Packet w 4B address, 8B data
- *            1001'0100 -- Addressable Packet w 4B address, 16B data
- *            1001'1000 -- Addressable Packet w 4B address, 32B data
- *            1001'1100 -- Addressable Packet w 4B address, 64B data
- *            1010'0100 -- Addressable Packet w 8B address, 1B data
- *            1010'1000 -- Addressable Packet w 8B address, 2B data
- *            1010'1100 -- Addressable Packet w 8B address, 4B data
- *            1011'0000 -- Addressable Packet w 8B address, 8B data
- *            1011'0100 -- Addressable Packet w 8B address, 16B data
- *            1011'1000 -- Addressable Packet w 8B address, 32B data
- *            1011'1100 -- Addressable Packet w 8B address, 64B data
- *            1100'0000 -- Default value
- *            1100'0100 -- Unused
- *            1100'1000 -- Unused
- *            1100'1100 -- Unused
- *            1101'xx00 -- Unused
+ *            0000'0000 -- Empty         Packet
+ *            0010'0000 -- Read          Packet w 1B address
+ *            0010'0100 -- Addressable   Packet w 1B address, 1B data
+ *            0010'1000 -- Addressable   Packet w 1B address, 2B data
+ *            0010'1100 -- Addressable   Packet w 1B address, 4B data
+ *            0011'0000 -- Addressable   Packet w 1B address, 8B data
+ *            0011'0100 -- Addressable   Packet w 1B address, 16B data
+ *            0011'1000 -- Addressable   Packet w 1B address, 32B data
+ *            0011'1100 -- Addressable   Packet w 1B address, 64B data
+ *            0100'0000 -- Read          Packet w 2B address
+ *            0100'0100 -- Addressable   Packet w 2B address, 1B data
+ *            0100'1000 -- Addressable   Packet w 2B address, 2B data
+ *            0100'1100 -- Addressable   Packet w 2B address, 4B data
+ *            0101'0000 -- Addressable   Packet w 2B address, 8B data
+ *            0101'0100 -- Addressable   Packet w 2B address, 16B data
+ *            0101'1000 -- Addressable   Packet w 2B address, 32B data
+ *            0101'1100 -- Addressable   Packet w 2B address, 64B data
+ *            1000'0000 -- Read          Packet w 4B address
+ *            1000'0100 -- Addressable   Packet w 4B address, 1B data
+ *            1000'1000 -- Addressable   Packet w 4B address, 2B data
+ *            1000'1100 -- Addressable   Packet w 4B address, 4B data
+ *            1001'0000 -- Addressable   Packet w 4B address, 8B data
+ *            1001'0100 -- Addressable   Packet w 4B address, 16B data
+ *            1001'1000 -- Addressable   Packet w 4B address, 32B data
+ *            1001'1100 -- Addressable   Packet w 4B address, 64B data
+ *            1010'0000 -- Read          Packet w 8B address
+ *            1010'0100 -- Addressable   Packet w 8B address, 1B data
+ *            1010'1000 -- Addressable   Packet w 8B address, 2B data
+ *            1010'1100 -- Addressable   Packet w 8B address, 4B data
+ *            1011'0000 -- Addressable   Packet w 8B address, 8B data
+ *            1011'0100 -- Addressable   Packet w 8B address, 16B data
+ *            1011'1000 -- Addressable   Packet w 8B address, 32B data
+ *            1011'1100 -- Addressable   Packet w 8B address, 64B data
+ *            1100'0000 -- Write-through Packet w 1B address
+ *            1100'0100 -- Write-through Packet w 2B address
+ *            1100'1000 -- Write-through Packet w 4B address
+ *            1100'1100 -- Write-through Packet w 8B address
+ *            1101'0000 --!Default value Packet (unimplemented)
+ *            1101'0100 -- Unused
+ *            1101'1000 -- Unused
+ *            1101'1100 -- Unused
  *            111x'xx00 -- Unused
  *  xxxx'xxxx'xxxx'xxx1 -- Unused
  */
@@ -79,6 +86,42 @@ template <typename Address, Pow2 Data> struct AddressedPayload {
     quint8 addrBits = (flags.kind >> 3) & 0b111;
     quint8 dataBits = flags.kind & 0b111;
     return (1 << (addrBits - 1)) + (1 << (dataBits - 1));
+  };
+};
+
+template <typename Address> struct ReadPayload {
+  Address address, length;
+  static constexpr sim::api::packet::Flags flags() {
+    sim::api::packet::Flags flags;
+    flags.dyn = 0;
+    flags.kind = ((bits::ceil_log2((sizeof(Address)) + 1) & 0b111) << 3) | 0;
+    flags.scope = 0;
+    flags.u16 = 0;
+
+    // assert(quint8(flags) != 0);
+    return flags;
+  }
+  inline quint8 payload_size(sim::api::packet::Flags flags) {
+    quint8 addrBits = (flags.kind >> 3) & 0b111;
+    return 2 * (1 << (addrBits - 1));
+  };
+};
+
+template <typename Address> struct WriteThroughPayload {
+  Address address, length;
+  static constexpr sim::api::packet::Flags flags() {
+    sim::api::packet::Flags flags;
+    flags.dyn = 0;
+    flags.kind = 0b110'000 | ((bits::ceil_log2((sizeof(Address)) + 1) & 0b11));
+    flags.scope = 0;
+    flags.u16 = 0;
+
+    // assert(quint8(flags) != 0);
+    return flags;
+  }
+  inline quint8 payload_size(sim::api::packet::Flags flags) {
+    quint8 addrBits = flags.kind & 0b11;
+    return 2 * (1 << (addrBits - 1));
   };
 };
 } // namespace sim::trace

--- a/logic/sim/src/sim/trace/common.hpp
+++ b/logic/sim/src/sim/trace/common.hpp
@@ -43,7 +43,7 @@
  *  xxxx'xxxx'xxxx'xxx1 -- Unused
  */
 // clang-format on
-namespace bits::trace {
+namespace sim::trace {
 template <typename Data>
 concept Pow2 = std::has_single_bit(sizeof(Data));
 struct DefaultValue {
@@ -61,26 +61,24 @@ struct DefaultValue {
 template <typename Address, Pow2 Data> struct AddressedPayload {
   Address address;
   Data data;
+
+  static constexpr sim::api::packet::Flags flags() {
+    // Only have 3 bits to store pow^2, so we can only stor up to 64.
+    static_assert(sizeof(Data) <= 64);
+    sim::api::packet::Flags flags;
+    flags.dyn = 0;
+    flags.kind = ((bits::ceil_log2((sizeof(Address)) + 1) & 0b111) << 3) |
+                 ((bits::ceil_log2(sizeof(Data)) + 1) & 0b111);
+    flags.scope = 0;
+    flags.u16 = 0;
+
+    // assert(quint8(flags) != 0);
+    return flags;
+  }
+  inline quint8 payload_size(sim::api::packet::Flags flags) {
+    quint8 addrBits = (flags.kind >> 3) & 0b111;
+    quint8 dataBits = flags.kind & 0b111;
+    return (1 << (addrBits - 1)) + (1 << (dataBits - 1));
+  };
 };
-
-template <typename Address, Pow2 Data>
-constexpr sim::api::packet::Flags flags() {
-  // Only have 3 bits to store pow^2, so we can only stor up to 64.
-  static_assert(sizeof(Data) <= 64);
-  sim::api::packet::Flags flags;
-  flags.dyn = 0;
-  flags.kind = ((bits::ceil_log2((sizeof(Address)) + 1) & 0b111) << 3) |
-               ((bits::ceil_log2(sizeof(Data)) + 1) & 0b111);
-  flags.scope = 0;
-  flags.u16 = 0;
-
-  // assert(quint8(flags) != 0);
-  return flags;
-}
-
-inline quint8 payload_size(sim::api::packet::Flags flags) {
-  quint8 addrBits = (flags.kind >> 3) & 0b111;
-  quint8 dataBits = flags.kind & 0b111;
-  return (1 << (addrBits - 1)) + (1 << (dataBits - 1));
-};
-} // namespace bits::trace
+} // namespace sim::trace


### PR DESCRIPTION
Allows me to notify buffer that a read/write occurred, but the local device does not have any locally updated state.

Will let me move a bunch of tracing code to a streaming analyzer.