### PR TITLE
Allow `run` to skip loader/dispatcher; allow direct register init

### DIFF
--- a/bin/term/src/run.hpp
+++ b/bin/term/src/run.hpp
@@ -13,6 +13,9 @@ public:
   void setMemDump(std::string fname);
   void setMaxSteps(quint64 maxSteps);
   void setOsIn(std::string fname);
+  void setSkipLoad(bool skip);
+  void setSkipDispatch(bool skip);
+  void addRegisterOverride(std::string name, quint16 value);
 
 private:
   int _ed;
@@ -21,4 +24,6 @@ private:
   std::string _charOut, _charIn, _memDump;
   quint64 _maxSteps;
   std::optional<std::string> _osIn;
+  bool _skipLoad = false, _skipDispatch = false;
+  QMap<std::string, quint16> _regOverrides;
 };


### PR DESCRIPTION
Closes #242, #246.