### PR TITLE
Add `--bm` flag to `asm` and `run` in term

### DIFF
--- a/bin/term/src/asm/asm.cpp
+++ b/bin/term/src/asm/asm.cpp
@@ -9,6 +9,8 @@
 AsmTask::AsmTask(int ed, std::string userFname, QObject *parent)
     : Task(parent), ed(ed), userIn(userFname) {}
 
+void AsmTask::setBm(bool forceBm) { this->forceBm = forceBm; }
+
 void AsmTask::setOsFname(std::string fname) { osIn = fname; }
 
 void AsmTask::setErrName(std::string fname) { errOut = fname; }
@@ -41,7 +43,10 @@ void AsmTask::run() {
 
   // If no OS, default to full.
   QString osContents;
-  if (osIn->empty()) {
+  if (this->forceBm) {
+    auto os = book->findFigure("os", "pep10baremetal");
+    osContents = os->typesafeElements()["pep"]->contents;
+  } else if (osIn->empty()) {
     auto os = book->findFigure("os", "pep10os");
     osContents = os->typesafeElements()["pep"]->contents;
   } else {

--- a/bin/term/src/asm/asm.hpp
+++ b/bin/term/src/asm/asm.hpp
@@ -4,6 +4,7 @@
 class AsmTask : public Task {
 public:
   AsmTask(int ed, std::string userFname, QObject *parent = nullptr);
+  void setBm(bool forceBm);
   void setOsFname(std::string fname);
   void setErrName(std::string fname);
   void setPepoName(std::string fname);
@@ -15,6 +16,7 @@ public:
 private:
   int ed;
   std::string userIn;
+  bool forceBm = false;
   std::optional<std::string> osIn, peplOut, elfOut, osListOut, errOut, pepoOut;
   std::list<std::string> macroDirs;
 };

--- a/bin/term/src/run.cpp
+++ b/bin/term/src/run.cpp
@@ -30,7 +30,10 @@ bool RunTask::loadToElf() {
   if (book.isNull())
     return false;
   QString osContents;
-  if (!_osIn.has_value()) {
+  if (_forceBm && _ed == 6) {
+    auto os = book->findFigure("os", "pep10baremetal");
+    osContents = os->typesafeElements()["pep"]->contents;
+  } else if (!_osIn.has_value()) {
     auto os = book->findFigure("os", "pep10os");
     osContents = os->typesafeElements()["pep"]->contents;
   } else {
@@ -224,6 +227,8 @@ void RunTask::setCharIn(std::string fname) { this->_charIn = fname; }
 void RunTask::setMemDump(std::string fname) { _memDump = fname; }
 
 void RunTask::setMaxSteps(quint64 maxSteps) { this->_maxSteps = maxSteps; }
+
+void RunTask::setBm(bool forceBm) { _forceBm = forceBm; }
 
 void RunTask::setOsIn(std::string fname) { _osIn = fname; }
 

--- a/bin/term/src/run.hpp
+++ b/bin/term/src/run.hpp
@@ -12,6 +12,7 @@ public:
   void setCharIn(std::string fname);
   void setMemDump(std::string fname);
   void setMaxSteps(quint64 maxSteps);
+  void setBm(bool forceBm);
   void setOsIn(std::string fname);
   void setSkipLoad(bool skip);
   void setSkipDispatch(bool skip);
@@ -24,6 +25,6 @@ private:
   std::string _charOut, _charIn, _memDump;
   quint64 _maxSteps;
   std::optional<std::string> _osIn;
-  bool _skipLoad = false, _skipDispatch = false;
+  bool _skipLoad = false, _skipDispatch = false, _forceBm = false;
   QMap<std::string, quint16> _regOverrides;
 };

--- a/bin/term/test/asmrun.py
+++ b/bin/term/test/asmrun.py
@@ -8,6 +8,32 @@ executable = ""
 
 
 class TestCase(unittest.TestCase):
+    def test_baremetal_flag_flags(self):
+        with tempfile.TemporaryDirectory() as cwd:
+            try:
+                with open(f"{cwd}/in.pep", "wb") as f:
+                    f.write(b"SCALL 0,i")
+            except IOError:
+                self.fail("Writing contents should not fail")
+
+            ret = subprocess.run([executable,
+                                  "asm",
+                                  "-s",
+                                  "in.pep",
+                                  "--bm",
+                                  "-o",
+                                  "out.pepo"],
+                                 cwd=cwd,
+                                 capture_output=True)
+            self.assertEqual(ret.returncode, 0)
+
+            ret = subprocess.run(
+                [executable, "run", "--bm","-s", "out.pepo"], cwd=cwd, capture_output=True)
+            self.assertEqual(ret.returncode, 0)
+            self.assertEqual(
+                ret.stdout,
+                b"Cannot use system calls in bare metal mode\n")
+
     def test_baremetal(self):
         with tempfile.TemporaryDirectory() as cwd:
             ret = subprocess.run(


### PR DESCRIPTION
Allow direct use of bare metal mode OS without first exporting to file. Added two test cases to `asmrun.py` to test new flags.

This is a convenient shorthand for Stan in early assignments, as these will use the bare metal mode.

Must be present in both `asm` and `run`, because Stan will use pepo files to bridge the commands. pepo files do not contain OS information, and must be explicitly supplied when using a non-default OS.

This changes saves Stan from having to `get --ch os --fig pep10baremetal > os.pep` on every early assignment.

Closes #306.