### PR TITLE
Suppress generation of `tmp.elf`

### DIFF
--- a/bin/term/src/run.cpp
+++ b/bin/term/src/run.cpp
@@ -58,8 +58,16 @@ bool RunTask::loadToElf() {
   if (!bytes)
     return false;
   _elf = helper.elf(*bytes);
-  _elf->save("tmp.elf");
-  _elf->load("tmp.elf");
+  // Need to reload to properly compute segment addresses. Store in temp
+  // directory to prevent clobbering local file contents.
+  {
+    QTemporaryDir dir;
+    if (!dir.isValid())
+      return false;
+    auto path = dir.filePath("tmp.elf").toStdString();
+    _elf->save(path);
+    _elf->load(path);
+  }
   return true;
 }
 

--- a/logic/targets/test/isa3-pep10/figs.cpp
+++ b/logic/targets/test/isa3-pep10/figs.cpp
@@ -98,9 +98,15 @@ private slots:
     auto elf = pas::obj::pep10::createElf();
     assemble(*elf, os, {.pep = userPep, .pepo = userPepo}, reg);
 
-    // Need to reload to properly compute segment addresses.
-    elf->save("tmp.elf");
-    elf->load("tmp.elf");
+    // Need to reload to properly compute segment addresses. Store in temp
+    // directory to prevent clobbering local file contents.
+    {
+      QTemporaryDir dir;
+      QVERIFY(dir.isValid());
+      auto path = dir.filePath("tmp.elf").toStdString();
+      elf->save(path);
+      elf->load(path);
+    }
     // Skip loading, to save on cycles. However, can't skip dispatch, or
     // main's stack will be wrong.
     auto system = targets::pep10::isa::systemFromElf(*elf, isBM);


### PR DESCRIPTION
Prevents clobbering contents of working directory.

Closes #201.