### PR TITLE
Fix compiler warnings on Windows

### DIFF
--- a/logic/asm/pas/src/pas/parse/pepp/types_lines.hpp
+++ b/logic/asm/pas/src/pas/parse/pepp/types_lines.hpp
@@ -19,7 +19,6 @@
 #include "./types_values.hpp"
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/spirit/home/x3.hpp>
-#include <climits>
 #include <string>
 #include "pas/pas_globals.hpp"
 
@@ -61,7 +60,19 @@ typedef boost::variant<BlankType, CommentType, UnaryType, NonUnaryType,
     LineType;
 } // namespace pas::parse::pepp
 
+// Platform specific code to ignore warnings from too few args to macro invocation.
+// No literature on how to fix this correctly, and I couldn't determine a proper fix
+// due to all the layered preprocessor magic here. I tried to use BOOST_FUSION_ADAPT_STRUCT_BASE, BOOST_FUSION_ADAPT_STRUCT_C
+// directly, but still ended up with strange warnings.
+#if defined(_MSC_VER)
+#pragma warning( push )
+#pragma warning( disable : 4003)
+#endif
 BOOST_FUSION_ADAPT_STRUCT(pas::parse::pepp::BlankType);
+#if defined(_MSC_VER)
+#pragma warning( push )
+#endif
+
 BOOST_FUSION_ADAPT_STRUCT(pas::parse::pepp::CommentType, comment);
 BOOST_FUSION_ADAPT_STRUCT(pas::parse::pepp::UnaryType, symbol, identifier,
                           comment);

--- a/logic/asm/symbol/src/symbol/visit.cpp
+++ b/logic/asm/symbol/src/symbol/visit.cpp
@@ -19,13 +19,13 @@
 #include "visit.hpp"
 
 #include <sstream>
-#include <string>
 
 #include "table.hpp"
 // Bitflags for determining which symbols to access during operations
-enum SelectMode {
+enum SelectMode : quint8 {
   kSelf = 1,
   kChildren = 2,
+  kError = 255,
 };
 
 // "bit shift" the children bit into self.
@@ -44,9 +44,10 @@ SelectMode policyToMode(symbol::TraversalPolicy policy) {
   case symbol::TraversalPolicy::kChildrenOnly:
     return static_cast<SelectMode>(kChildren);
     break;
-  default:
-    qFatal("Unhandled traversal policy");
+  //default: // MSVC isn't smart enough to determine that all code paths will return/exit.
   }
+  qFatal("Unhandled traversal policy");
+  return SelectMode::kError;
 }
 
 // Get the proper root for a given traversal policy
@@ -62,9 +63,10 @@ policyToTargetTable(symbol::TraversalPolicy policy,
     return symbol::parent(table);
   case symbol::TraversalPolicy::kWholeTree:
     return symbol::rootTable(table);
-  default:
-    qFatal("Unhandled traversal policy");
+  //default: // MSVC isn't smart enough to determine that all code paths will return/exit.
   }
+  qFatal("Unhandled traversal policy");
+  return nullptr;
 }
 
 QSharedPointer<const symbol::Table>

--- a/logic/help/about/test/dependencies.cpp
+++ b/logic/help/about/test/dependencies.cpp
@@ -7,7 +7,7 @@ class About_Dependencies : public QObject {
 private slots:
   void smoke() {
     auto deps = about::dependencies();
-    QCOMPARE(deps.length(), 5);
+    QCOMPARE(deps.length(), 6);
     for (const auto &dep : deps)
       QCOMPARE_NE(dep.licenseText.size(), 0);
   }

--- a/logic/help/about/test/dependencies.cpp
+++ b/logic/help/about/test/dependencies.cpp
@@ -7,7 +7,7 @@ class About_Dependencies : public QObject {
 private slots:
   void smoke() {
     auto deps = about::dependencies();
-    QCOMPARE(deps.length(), 6);
+    QCOMPARE(deps.length(), 5);
     for (const auto &dep : deps)
       QCOMPARE_NE(dep.licenseText.size(), 0);
   }

--- a/logic/sim/test/device/mmo.cpp
+++ b/logic/sim/test/device/mmo.cpp
@@ -39,8 +39,10 @@ class SimDevice_MMO : public QObject {
   Q_OBJECT
 private slots:
   void smoke() {
+    auto test= [](){auto x=QSharedPointer<sim::memory::Output<quint16>>::create(desc, span, 0);};
     QVERIFY_THROWS_NO_EXCEPTION(
-        QSharedPointer<sim::memory::Output<quint16>>::create(desc, span, 0));
+         test();
+    );
   }
 
   void write() {


### PR DESCRIPTION
All of the changes fix the underlying issue, except for the FUSION change. Boost's docs don't indicate how to fix this properly.