### PR TITLE
Fix compilation errors for wasm

### DIFF
--- a/logic/asm/pas/src/pas/ast/value/character.cpp
+++ b/logic/asm/pas/src/pas/ast/value/character.cpp
@@ -50,10 +50,11 @@ pas::ast::value::Character::clone() const {
 
 void pas::ast::value::Character::value(bits::span<quint8> dest,
                                        bits::Order destEndian) const {
+  using size_type = bits::span<const quint8>::size_type;
   bits::memcpy_endian(
       dest, destEndian,
       bits::span<const quint8>{
-          reinterpret_cast<const quint8 *>(_valueAsBytes.constData()), size()},
+          reinterpret_cast<const quint8 *>(_valueAsBytes.constData()), static_cast<size_type>(size())},
       bits::hostOrder());
 }
 

--- a/logic/asm/pas/src/pas/ast/value/numeric.cpp
+++ b/logic/asm/pas/src/pas/ast/value/numeric.cpp
@@ -27,9 +27,11 @@ pas::ast::value::Numeric::Numeric(qint64 value, quint8 size)
 
 void pas::ast::value::Numeric::value(bits::span<quint8> dest,
                                      bits::Order destEndian) const {
+  using size_type = bits::span<const quint8>::size_type;
   bits::memcpy_endian(dest, destEndian,
                       bits::span<const quint8>{
-                          reinterpret_cast<const quint8 *>(&_value), size()},
+                          reinterpret_cast<const quint8 *>(&_value),
+                          static_cast<size_type>(size())},
                       bits::hostOrder());
 }
 

--- a/logic/asm/pas/src/pas/ast/value/string.cpp
+++ b/logic/asm/pas/src/pas/ast/value/string.cpp
@@ -51,10 +51,12 @@ pas::ast::value::ShortString::clone() const {
 
 void pas::ast::value::ShortString::value(bits::span<quint8> dest,
                                          bits::Order destEndian) const {
+  using size_type = bits::span<const quint8>::size_type;
   bits::memcpy_endian(
       dest, destEndian,
       bits::span<const quint8>{
-          reinterpret_cast<const quint8 *>(_valueAsBytes.data()), size()},
+          reinterpret_cast<const quint8 *>(_valueAsBytes.data()),
+          static_cast<size_type>(size())},
       bits::hostOrder());
 }
 
@@ -97,10 +99,12 @@ pas::ast::value::LongString::clone() const {
 
 void pas::ast::value::LongString::value(bits::span<quint8> dest,
                                         bits::Order destEndian) const {
+  using size_type = bits::span<const quint8>::size_type;
   bits::memcpy_endian(
       dest, destEndian,
       bits::span<const quint8>{
-          reinterpret_cast<const quint8 *>(_valueAsBytes.data()), size()},
+          reinterpret_cast<const quint8 *>(_valueAsBytes.data()),
+          static_cast<size_type>(size())},
       bits::hostOrder());
 }
 

--- a/logic/asm/pas/src/pas/ast/value/symbolic.cpp
+++ b/logic/asm/pas/src/pas/ast/value/symbolic.cpp
@@ -52,8 +52,10 @@ QSharedPointer<pas::ast::value::Base> pas::ast::value::Symbolic::clone() const {
 void pas::ast::value::Symbolic::value(bits::span<quint8> dest,
                                       bits::Order destEndian) const {
   auto src = _value->value->value()();
+  using size_type = bits::span<const quint8>::size_type;
   auto srcSpan =
-      bits::span<const quint8>{reinterpret_cast<const quint8 *>(&src), size()};
+      bits::span<const quint8>{reinterpret_cast<const quint8 *>(&src),
+                               static_cast<size_type>(size())};
   bits::memcpy_endian(dest, destEndian, srcSpan, bits::hostOrder());
 }
 

--- a/logic/obj/src/obj/bytes.cpp
+++ b/logic/obj/src/obj/bytes.cpp
@@ -24,6 +24,7 @@ struct Buffer {
 };
 
 QList<quint8> obj::segmentAsAsciiHex(const ELFIO::segment *segment) {
+  using size_type=std::span<const quint8>::size_type;
   static const QList<bits::SeparatorRule> rules = {
       {.skipFirst = false, .separator = ' ', .modulus = 1}};
   QList<Buffer> buffered;
@@ -45,7 +46,8 @@ QList<quint8> obj::segmentAsAsciiHex(const ELFIO::segment *segment) {
       throw std::logic_error("Dest buffer too small");
     auto i = bits::bytesToAsciiHex(
         {(char *)ret.data() + it, ret.length() - it},
-        {reinterpret_cast<const quint8 *>(buffer.src), buffer.srcLength},
+        {reinterpret_cast<const quint8 *>(buffer.src),
+         static_cast<size_type>(buffer.srcLength)},
         rules);
     it += i;
   }

--- a/logic/obj/src/obj/mmio.cpp
+++ b/logic/obj/src/obj/mmio.cpp
@@ -228,6 +228,7 @@ found:
 }
 
 std::optional<quint16> obj::getBootFlagsAddress(const ELFIO::elfio &elf) {
+    using size_type = std::span<const quint8>::size_type;
   auto noteSec = getMMIONoteSection(elf);
   if (noteSec == nullptr)
     return {};
@@ -255,7 +256,7 @@ std::optional<quint16> obj::getBootFlagsAddress(const ELFIO::elfio &elf) {
         bits::Order::BigEndian);
     quint64 tmp = 0;
     bits::memcpy_endian(
-        bits::span<quint8>{reinterpret_cast<quint8 *>(&tmp), size},
+        bits::span<quint8>{reinterpret_cast<quint8 *>(&tmp), static_cast<size_type>(size)},
         bits::hostOrder(),
         bits::span<const quint8>{reinterpret_cast<const quint8 *>(&addr),
                                  sizeof(addr)},

--- a/logic/targets/src/targets/pep10/isa3/system.cpp
+++ b/logic/targets/src/targets/pep10/isa3/system.cpp
@@ -85,7 +85,8 @@ targets::pep10::isa::System::System(QList<obj::MemoryRegion> regions,
       auto size = seg->get_file_size();
       if (fileData == nullptr)
         continue;
-      mem->write(base, {reinterpret_cast<const quint8 *>(fileData), size}, gs);
+      using size_type = bits::span<const quint8>::size_type;
+      mem->write(base, {reinterpret_cast<const quint8 *>(fileData), static_cast<size_type>(size)}, gs);
       base += size;
     }
   }
@@ -217,6 +218,7 @@ targets::pep10::isa::System::output(QString name) {
 QSharedPointer<targets::pep10::isa::System>
 targets::pep10::isa::systemFromElf(const ELFIO::elfio &elf,
                                    bool loadUserImmediate) {
+  using size_type = bits::span<const quint8>::size_type;
   auto segs = obj::getLoadableSegments(elf);
   auto memmap = obj::mergeSegmentRegions(segs);
   auto mmios = obj::getMMIODeclarations(elf);
@@ -234,7 +236,7 @@ targets::pep10::isa::systemFromElf(const ELFIO::elfio &elf,
       if (ptr == nullptr)
         continue;
       const auto ret =
-          bus->write(address, {ptr, buffer.seg->get_memory_size()}, gs);
+          bus->write(address, {ptr, static_cast<size_type>(buffer.seg->get_memory_size())}, gs);
       Q_ASSERT(ret.completed);
       Q_ASSERT(ret.error == sim::api::memory::Error::Success);
       address += buffer.seg->get_memory_size();


### PR DESCRIPTION
These mostly revolve around uint64 being bigger than a platform's size_type (32-bits on WASM).

Truncating during a memcpy could only cause an issue if we want to copy more bytes than can be counted with size_type. However, if we have 2^32 + n bytes of data in a 32 bit environment, the program will crash.

Therefore I will apply the static cast solution rather than modify the bits API.

Needed for #359.