### PR TITLE
Add info about git tags and working directory cleanliness to `about` info

### DIFF
--- a/logic/help/about/CMakeLists.txt
+++ b/logic/help/about/CMakeLists.txt
@@ -7,6 +7,24 @@ target_link_libraries(about PUBLIC "Qt6::Core" )
 
 include(git.cmake)
 get_git_head_revision(GIT_REFSPEC GIT_SHA1)
+
+git_get_exact_tag(GIT_TAG)
+
+
+
+if(GIT_TAG MATCHES ".*NOTFOUND")
+    set(GIT_TAG "unknown")
+endif()
+
+# Let program know if it was built from a clean dir.
+# App can use that to render about info.
+git_local_changes(GIT_CLEAN_RAW)
+if(GIT_CLEAN_RAW MATCHES "CLEAN")
+    set(GIT_CLEAN "1")
+else()
+  set(GIT_CLEAN "0")
+endif()
+
 #add_definitions("-DGIT_SHA1=${GIT_SHA1}")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/about/version.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/version.cpp" @ONLY)
 

--- a/logic/help/about/src/about/version.cpp.in
+++ b/logic/help/about/src/about/version.cpp.in
@@ -3,14 +3,19 @@
 const char GIT_SHA1_tmp[] = GIT_SHA1;
 const char * const about::g_GIT_SHA1(){return GIT_SHA1_tmp;}
 
+#define GIT_TAG "@GIT_TAG@"
+const char GIT_TAG_tmp[] = GIT_TAG;
+const char * const about::g_GIT_TAG(){return GIT_TAG_tmp;}
 // Must supress formatting, or `@` will be separated from name, preventing
 // CMake substitutions.
 // clang-format off
 #define VERSION_MAJOR @Pepp_VERSION_MAJOR@
 #define VERSION_MINOR @Pepp_VERSION_MINOR@
 #define VERSION_PATCH @Pepp_VERSION_PATCH@
+#define CLEAN @GIT_CLEAN@
 // clang-format on
 
 extern const int about::g_MAJOR_VERSION = VERSION_MAJOR;
 extern const int about::g_MINOR_VERSION = VERSION_MINOR;
 extern const int about::g_PATCH_VERSION = VERSION_PATCH;
+extern const bool about::g_GIT_LOCAL_CHANGES = CLEAN;

--- a/logic/help/about/src/about/version.hpp
+++ b/logic/help/about/src/about/version.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include <string>
 namespace about {
 const char* const g_GIT_SHA1();
+const char* const g_GIT_TAG();
 extern const int g_MAJOR_VERSION;
 extern const int g_MINOR_VERSION;
 extern const int g_PATCH_VERSION;
+extern const bool g_GIT_LOCAL_CHANGES;
 } // namespace about


### PR DESCRIPTION
Applications can use this to render versioning information We will need to add a script on release that checks if project verion matches the tag.