### PR TITLE
Prevent builds on main from restore build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,6 @@ jobs:
       compiler_cpp: ${{ matrix.config.compiler_cpp || '' }}
       codeql: ${{ !!matrix.config.codeql }}
       variant: "debug"
-      not_default: ${{ !!needs.branch_info.outputs.not_default }}
+      not_default: ${{ needs.branch_info.outputs.not_default == 'true' }}
       docs_audience: ${{ matrix.config.docs_audience || '' }}
       docs_artifact: ${{ (matrix.config.docs_audience && '') || 'app-docs' }}


### PR DESCRIPTION
not_default was always true, even on main.
This is because github is weird with bool inputs on workflow call. See: https://github.com/actions/runner/issues/1483