### PR TITLE
Add CI logic to distinguish events that should be in debug vs release 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
   check_tag:
     name: Check tag
     needs: branch_info
-    if: needs.branch_info.outputs.tag_name
     runs-on: ubuntu-latest
     steps:
     # Conceptually, we only want to run this job iff we are a release.
@@ -104,7 +103,7 @@ jobs:
     concurrency:
       group: ${{ github.sha }}
       # A tag should cancel a branch push, but not vice versa.
-      cancel-in-progress: ${{ needs.branch_info.outputs.do_release || 'false'}}
+      cancel-in-progress: ${{ needs.branch_info.outputs.do_release || false}}
     strategy:
       fail-fast: true
       # If you want to update images, must replace *ALL* images in the matrix manually.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,8 @@ on:
     branches:
   workflow_dispatch:
     inputs:
-      do_release:
-        description: 'Release this build'
-        required: false
+      publish_release:
+        description: 'Publish this release to GitHub. If false, run throught the release pipeline, but upload not artifacts.'
         default: false
       tag_name:
         description: 'Tag to use for release'
@@ -18,20 +17,18 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       branch_name: ${{ steps.branch.outputs.branch }}
-      tag_name:    ${{ steps.branch.outputs.tag_name }}
       not_default: ${{ steps.branch.outputs.not_default }}
-      do_release:  ${{ inputs.do_release }}
+      publish_release: ${{ inputs.publish_release }}
+      tag_name: ${{ inputs.tag_name }}
+      build_release: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       - name: set branch info
         id: branch
         run: |
-          echo "tag_name=${{ inputs.tag_name }}" >> $GITHUB_OUTPUT
           if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
             export BRANCH="${GITHUB_REF##*/}"
           elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             export BRANCH="${$GITHUB_BASE_REF}"
-          elif [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
-            echo "tag_name=${GITHUB_REF}" >> $GITHUB_OUTPUT
           else
             echo "unknown event"
           fi
@@ -52,27 +49,28 @@ jobs:
     # However, this greatly complicates that matrix build.
     # Instead, exit succes on not release, and run my tag logic on release.
     - name: No-op
-      if:  needs.branch_info.outputs.do_release != true
+      if:  needs.branch_info.outputs.build_release != true
       run: exit 0
     - name: Check that release tag is well-formatted, and extract the version number
-      if: needs.branch_info.outputs.do_release
+      # Need explity == or the step triggers even if false
+      if: needs.branch_info.outputs.build_release == true
       shell: bash
       # Use xargs to trim spaces
       run: |
-        tag=$(echo "${{ needs.branch_info.outputs.tag_name }}" | grep -Eo "/v[0-9]+(\.[0-9]+)*$")
+        tag=$(echo "${{ needs.branch_info.tag_name }}" | grep -Eo "v[0-9]+(\.[0-9]+)*$")
         echo "VERSION_GIT=$(echo "${tag}" | cut -c3- | xargs)" >> $GITHUB_ENV
     - name: Clone sources to extract project version
       uses: actions/checkout@v3
-      if: needs.branch_info.outputs.do_release
+      if: needs.branch_info.outputs.build_release == true
     - uses: lukka/get-cmake@v3.27.7
-      if: needs.branch_info.outputs.do_release
+      if: needs.branch_info.outputs.build_release == true
     - name: Extract the CMake version
-      if: needs.branch_info.outputs.do_release
+      if: needs.branch_info.outputs.build_release == true
       run: |
         cmake -B build -S . -DONLY=VERSION
         echo "VERSION_CMAKE=$(cat version | xargs)" >> $GITHUB_ENV
     - name: CMake project version == Git tag
-      if: needs.branch_info.outputs.do_release
+      if: needs.branch_info.outputs.build_release == true
       shell: bash
       run: |
         if [[ "$VERSION_CMAKE" != "$VERSION_GIT" ]] ; then
@@ -110,7 +108,7 @@ jobs:
         - {name: "Ubuntu 22.04; GCC", cache_name: 'ubuntu-gcc', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/dev:v0.9.0", compiler_launcher: "ccache", compiler_c: "", compiler_cpp: "", cmake_generator: "Ninja"}
         # Do CodeQL in clang run, to prevent needing yet another target.
         - {name: "Ubuntu 22.04; Clang 17.0", cache_name: 'ubuntu-clang', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/dev:v0.9.0", triplet: "x64-linux-clang", compiler_launcher: "", compiler_c: "clang", compiler_cpp: "clang++" , cmake_generator: "Ninja"}
-        - {name: "Ubuntu 22.04; EMSDK 3.1.37", cache_name: 'ubuntu-emsdk', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/dev:v0.9.0-wasm", cmake_toolchain: '$Qt6_DIR/qt.toolchain.cmake', cmake_xargs: '-D QT_HOST_PATH=/qt/6.6.0/gcc_64 -D Boost_INCLUDE_DIR=/usr/local/include', docs_audience: 'WEB'}
+        - {name: "Ubuntu 22.04; EMSDK 3.1.37", cache_name: 'ubuntu-emsdk', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/dev:v0.9.0-wasm", cmake_toolchain: '$Qt6_DIR/qt.toolchain.cmake', cmake_xargs: '-D QT_HOST_PATH=/qt/6.6.0/gcc_64 -D Boost_INCLUDE_DIR=/usr/local/include', docs_audience: 'WEB', release_type: 'MinSizeRel'}
         # See: https://bugreports.qt.io/browse/QTBUG-118086
         - {name: "MacOS-11; Clang 15", cache_name: 'macos-clang', runs-on: "macos-11" , compiler_launcher: "ccache", compiler_c: '$(brew --prefix llvm@15)/bin/clang', compiler_cpp: '$(brew --prefix llvm@15)/bin/clang++', cmake_generator: "Ninja"}
         - {name: "Windows Latest; MSVC", cache_name: 'windows-msvc', runs-on: "windows-latest" , compiler_launcher: "ccache",}
@@ -127,7 +125,7 @@ jobs:
       compiler_c: ${{ matrix.config.compiler_c  || '' }}
       compiler_cpp: ${{ matrix.config.compiler_cpp || '' }}
       codeql: ${{ !!matrix.config.codeql }}
-      variant: ${{ needs.branch_info.outputs.do_release && 'release' || 'debug' }}
+      variant: ${{ needs.branch_info.build_release && (matrix.config.release_type || 'release' ) || 'debug' }}
       not_default: ${{ needs.branch_info.outputs.not_default == 'true' }}
       docs_audience: ${{ matrix.config.docs_audience || '' }}
       docs_artifact: ${{ (matrix.config.docs_audience && '') || 'app-docs' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
       uses: actions/checkout@v3
       if: needs.branch_info.outputs.do_release
     - uses: lukka/get-cmake@v3.27.7
+      if: needs.branch_info.outputs.do_release
     - name: Extract the CMake version
       if: needs.branch_info.outputs.do_release
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
-on: [push, release]
+on:
+  push:
+  release:
+    types: [published]
 jobs:
   branch_info:
     name: Gather branch info
@@ -29,6 +32,35 @@ jobs:
           echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
           echo "Output is:"
           cat $GITHUB_OUTPUT
+  check_tag:
+    name: Check tag
+    needs: branch_info
+    if: needs.branch_info.outputs.tag_name
+    runs-on: ubuntu-latest
+    steps:
+    # Conceptually, we only want to run this job iff we are a release.
+    # However, this greatly complicates that matrix build.
+    # Instead, exit succes on not release, and run my tag logic on release.
+    - name: No-op
+      if:  !needs.branch_info.outputs.tag_name
+    - name: Check that release tag is well-formatted, and extract the version number
+      if: !!needs.branch_info.outputs.tag_name
+      shell: bash
+      # Use xargs to trim spaces
+      run: |
+        tag=$(grep -Eo "/v\d(\.\d)+$" <<< "${{ needs.branch_info.outputs.tag_name }}")
+        echo "VERSION_GIT=$(cut -c3- <<< ${tag} | xargs)" >> $GITHUB_ENV
+    - name: Clone sources to extract project version
+      uses: actions/checkout@v3
+      if: !!needs.branch_info.outputs.tag_name
+    - name: Extract the CMake version
+      if: !!needs.branch_info.outputs.tag_name
+      run: |
+        cmake -B build -S . -DONLY=VERSION
+        echo "VERSION_CMAKE=$(cat version | xargs)" >> $GITHUB_ENV
+    - name: CMake project version == Git tag
+      if: !!needs.branch_info.outputs.tag_name
+      run: [ "${VERSION_CMAKE}" = "cat" ] || (printf "Mismatched project versions.\n Git:${VERSION_GIT}  CMake:${VERSION_CMAKE}" && exit 1)
   build_docs:
     runs-on: ubuntu-latest
     container:
@@ -49,7 +81,7 @@ jobs:
         path: build/docs
         retention-days: 1
   start_matrix:
-    needs: [branch_info, build_docs]
+    needs: [branch_info, build_docs, check_tag]
     uses: ./.github/workflows/build.yml
     concurrency:
       group: ${{ GITHUB_SHA }}
@@ -68,7 +100,6 @@ jobs:
         # See: https://bugreports.qt.io/browse/QTBUG-118086
         - {name: "MacOS-11; Clang 15", cache_name: 'macos-clang', runs-on: "macos-11" , compiler_launcher: "ccache", compiler_c: '$(brew --prefix llvm@15)/bin/clang', compiler_cpp: '$(brew --prefix llvm@15)/bin/clang++', cmake_generator: "Ninja"}
         - {name: "Windows Latest; MSVC", cache_name: 'windows-msvc', runs-on: "windows-latest" , compiler_launcher: "ccache",}
-
     with:
       name: ${{ matrix.config.name }}
       cache_name: ${{ matrix.config.cache_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,20 +3,29 @@ on:
   # Don't build on tags, since thos will be created during a release.
   push:
     branches:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      do_release:
+        description: 'Release this build'
+        required: false
+        default: false
+      tag_name:
+        description: 'Tag to use for release'
+        required: false
 jobs:
   branch_info:
     name: Gather branch info
     runs-on: ubuntu-latest
     outputs:
       branch_name: ${{ steps.branch.outputs.branch }}
-      tag_name:    ${{ steps.branch.outputs.tag }}
+      tag_name:    ${{ steps.branch.outputs.tag_name }}
       not_default: ${{ steps.branch.outputs.not_default }}
+      do_release:  ${{ inputs.do_release }}
     steps:
       - name: set branch info
         id: branch
         run: |
+          echo "tag_name=${{ inputs.tag_name }}" >> $GITHUB_OUTPUT
           if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
             export BRANCH="${GITHUB_REF##*/}"
           elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
@@ -44,25 +53,32 @@ jobs:
     # However, this greatly complicates that matrix build.
     # Instead, exit succes on not release, and run my tag logic on release.
     - name: No-op
-      if:  !needs.branch_info.outputs.tag_name
+      if:  !needs.branch_info.outputs.do_release
+      run: exit 0
     - name: Check that release tag is well-formatted, and extract the version number
-      if: !!needs.branch_info.outputs.tag_name
+      if: needs.branch_info.outputs.do_release
       shell: bash
       # Use xargs to trim spaces
       run: |
-        tag=$(grep -Eo "/v\d(\.\d)+$" <<< "${{ needs.branch_info.outputs.tag_name }}")
-        echo "VERSION_GIT=$(cut -c3- <<< ${tag} | xargs)" >> $GITHUB_ENV
+        tag=$(echo "${{ needs.branch_info.outputs.tag_name }}" | grep -Eo "/v[0-9]+(\.[0-9]+)*$")
+        echo "VERSION_GIT=$(echo "${tag}" | cut -c3- | xargs)" >> $GITHUB_ENV
     - name: Clone sources to extract project version
       uses: actions/checkout@v3
-      if: !!needs.branch_info.outputs.tag_name
+      if: needs.branch_info.outputs.do_release
+    - uses: lukka/get-cmake@v3.27.7
     - name: Extract the CMake version
-      if: !!needs.branch_info.outputs.tag_name
+      if: needs.branch_info.outputs.do_release
       run: |
         cmake -B build -S . -DONLY=VERSION
         echo "VERSION_CMAKE=$(cat version | xargs)" >> $GITHUB_ENV
     - name: CMake project version == Git tag
-      if: !!needs.branch_info.outputs.tag_name
-      run: [ "${VERSION_CMAKE}" = "cat" ] || (printf "Mismatched project versions.\n Git:${VERSION_GIT}  CMake:${VERSION_CMAKE}" && exit 1)
+      if: needs.branch_info.outputs.do_release
+      shell: bash
+      run: |
+        if [[ "$VERSION_CMAKE" != "$VERSION_GIT" ]] ; then
+          printf "Mismatched project versions. Git:$VERSION_GIT  CMake:$VERSION_CMAKE\n"
+          exit 115 # Use a sufficiently rare exit code to make this failure easy to detect
+        fi
   build_docs:
     runs-on: ubuntu-latest
     container:
@@ -115,7 +131,7 @@ jobs:
       compiler_c: ${{ matrix.config.compiler_c  || '' }}
       compiler_cpp: ${{ matrix.config.compiler_cpp || '' }}
       codeql: ${{ !!matrix.config.codeql }}
-      variant: "debug"
+      variant: ${{ needs.branch_info.outputs.do_release && 'release' || 'debug' }}
       not_default: ${{ needs.branch_info.outputs.not_default == 'true' }}
       docs_audience: ${{ matrix.config.docs_audience || '' }}
       docs_artifact: ${{ (matrix.config.docs_audience && '') || 'app-docs' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,9 @@ jobs:
     needs: [branch_info, build_docs, check_tag]
     uses: ./.github/workflows/build.yml
     concurrency:
-      group: ${{ GITHUB_SHA }}
+      group: ${{ github.sha }}
       # A tag should cancel a branch push, but not vice versa.
-      cancel-in-progress: ${{ !!needs.branch_info.outputs.tag_name }}
+      cancel-in-progress: ${{ needs.branch_info.outputs.do_release || 'false'}}
     strategy:
       fail-fast: true
       # If you want to update images, must replace *ALL* images in the matrix manually.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,10 +100,6 @@ jobs:
   start_matrix:
     needs: [branch_info, build_docs, check_tag]
     uses: ./.github/workflows/build.yml
-    concurrency:
-      group: ${{ github.sha }}
-      # A tag should cancel a branch push, but not vice versa.
-      cancel-in-progress: ${{ needs.branch_info.outputs.do_release || false}}
     strategy:
       fail-fast: true
       # If you want to update images, must replace *ALL* images in the matrix manually.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,12 @@
 name: CI
-on: [push]
+on: [push, release]
 jobs:
   branch_info:
     name: Gather branch info
     runs-on: ubuntu-latest
     outputs:
       branch_name: ${{ steps.branch.outputs.branch }}
+      tag_name:    ${{ steps.branch.outputs.tag }}
       not_default: ${{ steps.branch.outputs.not_default }}
     steps:
       - name: set branch info
@@ -15,8 +16,10 @@ jobs:
             export BRANCH="${GITHUB_REF##*/}"
           elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             export BRANCH="${$GITHUB_BASE_REF}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            echo "tag_name=${GITHUB_REF}" >> $GITHUB_OUTPUT
           else
-            echo "unknown event" && exit 1;
+            echo "unknown event"
           fi
           if [ "$BRANCH" = "main" ]; then
             echo "not_default=false" >> $GITHUB_OUTPUT
@@ -48,6 +51,10 @@ jobs:
   start_matrix:
     needs: [branch_info, build_docs]
     uses: ./.github/workflows/build.yml
+    concurrency:
+      group: ${{ GITHUB_SHA }}
+      # A tag should cancel a branch push, but not vice versa.
+      cancel-in-progress: ${{ !!needs.branch_info.outputs.tag_name }}
     strategy:
       fail-fast: true
       # If you want to update images, must replace *ALL* images in the matrix manually.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     # However, this greatly complicates that matrix build.
     # Instead, exit succes on not release, and run my tag logic on release.
     - name: No-op
-      if:  !needs.branch_info.outputs.do_release
+      if:  needs.branch_info.outputs.do_release != true
       run: exit 0
     - name: Check that release tag is well-formatted, and extract the version number
       if: needs.branch_info.outputs.do_release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 on:
+  # Don't build on tags, since thos will be created during a release.
   push:
+    branches:
   release:
     types: [published]
 jobs:


### PR DESCRIPTION
Add logic that requires CMake project version match the provided tag
- This reduces likelihood of re-release due to forgetting version number bump. 

Also add logic to allow manual triggering of release build, since I anticipate needing to debug this in the future.