### PR TITLE
Prevent cmake config error with WASM

### DIFF
--- a/3rd-party/antlr4/runtime/CMakeLists.txt
+++ b/3rd-party/antlr4/runtime/CMakeLists.txt
@@ -96,11 +96,12 @@ if (WIN32)
   endif()
 endif()
 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+
 if (TARGET antlr4_shared)
   set_target_properties(antlr4_shared
                         PROPERTIES VERSION   ${ANTLR_VERSION}
                                    SOVERSION ${ANTLR_VERSION}
-                                   OUTPUT_NAME antlr4-runtime
                                    COMPILE_FLAGS "${disabled_compile_warnings} ${extra_share_compile_flags}")
 endif()
 
@@ -108,7 +109,5 @@ if (TARGET antlr4_static)
   set_target_properties(antlr4_static
                         PROPERTIES VERSION   ${ANTLR_VERSION}
                                    SOVERSION ${ANTLR_VERSION}
-                                   OUTPUT_NAME "antlr4-runtime${static_lib_suffix}"
-                                   COMPILE_PDB_NAME "antlr4-runtime${static_lib_suffix}"
                                    COMPILE_FLAGS "${disabled_compile_warnings} ${extra_static_compile_flags}")
 endif()


### PR DESCRIPTION
Output names on targets generates multiple rules for the same file, but only when I target wasm. With the suggested modification the problem disappears.

See: https://github.com/conan-io/conan-center-index/issues/14004#issuecomment-1302779433