### PR TITLE
Upgrade Mac CI runner to MacOS 14 from 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         - {name: "Ubuntu 22.04; Clang 17.0", cache_name: 'ubuntu-clang', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/dev:v0.9.0", compiler_launcher: "", compiler_c: "clang", compiler_cpp: "clang++" , cmake_generator: "Ninja"}
         - {name: "Ubuntu 22.04; EMSDK 3.1.37", cache_name: 'ubuntu-emsdk', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/dev:v0.9.0-wasm", cmake_toolchain: '$Qt6_DIR/qt.toolchain.cmake', cmake_xargs: '-D QT_HOST_PATH=/qt/6.6.0/gcc_64', docs_audience: 'WEB', release_type: 'MinSizeRel'}
         # See: https://bugreports.qt.io/browse/QTBUG-118086
-        - {name: "MacOS-11; Clang 15", cache_name: 'macos-clang', runs-on: "macos-11" , compiler_launcher: "ccache", compiler_c: '$(brew --prefix llvm@15)/bin/clang', compiler_cpp: '$(brew --prefix llvm@15)/bin/clang++', cmake_generator: "Ninja"}
+        - {name: "MacOS-14; Clang 15.0.7", cache_name: 'macos-clang', runs-on: "macos-14" , compiler_launcher: "ccache", compiler_c: '$(brew --prefix llvm@15)/bin/clang', compiler_cpp: '$(brew --prefix llvm@15)/bin/clang++', cmake_generator: "Ninja"}
         - {name: "Windows Latest; MSVC", cache_name: 'windows-msvc', runs-on: "windows-latest" , compiler_launcher: "ccache",}
     with:
       name: ${{ matrix.config.name }}


### PR DESCRIPTION
MacOS 11 (Big Sur) no longer receives security updates as of 2023-11-23. Homebrew also has dropped support for this target. This requires building some installed packages from the source, which inflates CI run times.