### PR TITLE
Run tests via pepp-term executable

### DIFF
--- a/3rd-party/antlr4/runtime/CMakeLists.txt
+++ b/3rd-party/antlr4/runtime/CMakeLists.txt
@@ -103,6 +103,10 @@ if (TARGET antlr4_shared)
                         PROPERTIES VERSION   ${ANTLR_VERSION}
                                    SOVERSION ${ANTLR_VERSION}
                                    COMPILE_FLAGS "${disabled_compile_warnings} ${extra_share_compile_flags}")
+  install(
+        TARGETS antlr4_shared
+        RUNTIME DESTINATION bin
+  )
 endif()
 
 if (TARGET antlr4_static)

--- a/3rd-party/catch/CMakeLists.txt
+++ b/3rd-party/catch/CMakeLists.txt
@@ -1,3 +1,5 @@
+# Adapted from from Catch2 Commit b817497528877b14d6102869a6df378d029b343b
+# See: https://raw.githubusercontent.com/catchorg/Catch2/b817497528877b14d6102869a6df378d029b343b/extras/CatchShardTests.cmake
 cmake_minimum_required(VERSION 3.23)
 
 # set the project name
@@ -16,3 +18,70 @@ target_include_directories(catch INTERFACE .)
 add_library(catch-main INTERFACE catch_main.cpp)
 target_sources(catch-main INTERFACE ${CMAKE_CURRENT_LIST_DIR}/catch_main.cpp)
 target_link_libraries(catch-main INTERFACE catch)
+
+#########################
+# CatchShardTests.cmake #
+#########################
+
+#              Copyright Catch2 Authors
+# Distributed under the Boost Software License, Version 1.0.
+#   (See accompanying file LICENSE.txt or copy at
+#        https://www.boost.org/LICENSE_1_0.txt)
+
+# SPDX-License-Identifier: BSL-1.0
+
+# Supported optional args:
+#  * SHARD_COUNT - number of shards to split target's tests into
+#  * REPORTER    - reporter spec to use for tests
+#  * TEST_SPEC   - test spec used for filtering tests
+function(catch_add_sharded_tests TARGET ADDTL_ARGS)
+  if (${CMAKE_VERSION} VERSION_LESS "3.10.0")
+    message(FATAL_ERROR "add_sharded_catch_tests only supports CMake versions 3.10.0 and up")
+  endif()
+
+  cmake_parse_arguments(
+    ""
+    ""
+    "SHARD_COUNT;REPORTER;TEST_SPEC"
+    ""
+    ${ARGN}
+  )
+
+  if (NOT DEFINED _SHARD_COUNT)
+    set(_SHARD_COUNT 2)
+  endif()
+
+  # Generate a unique name based on the extra arguments
+  string(SHA1 args_hash "${_TEST_SPEC} ${_EXTRA_ARGS} ${_REPORTER} ${_OUTPUT_DIR} ${_OUTPUT_PREFIX} ${_OUTPUT_SUFFIX} ${_SHARD_COUNT}")
+  string(SUBSTRING ${args_hash} 0 7 args_hash)
+
+  set(ctest_include_file "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}-sharded-tests-include.cmake")
+  set(ctest_tests_file "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}-sharded-tests-impl.cmake")
+
+  file(WRITE "${ctest_include_file}"
+    "if(EXISTS \"${ctest_tests_file}\")\n"
+    "  include(\"${ctest_tests_file}\")\n"
+    "else()\n"
+    "  add_test(${TARGET}_NOT_BUILT ${TARGET}_NOT_BUILT)\n"
+    "endif()\n"
+  )
+
+  set_property(DIRECTORY
+    APPEND PROPERTY TEST_INCLUDE_FILES "${ctest_include_file}"
+  )
+
+  set(shard_impl_script_file "${PROJECT_SOURCE_DIR}/3rd-party/catch/ShardImpl.cmake")
+  message("CTest file: ${ctest_tests_file}")
+  add_custom_command(
+    TARGET ${TARGET} POST_BUILD
+    BYPRODUCTS "${ctest_tests_file}"
+    COMMAND "${CMAKE_COMMAND}"
+            -D "TARGET_NAME=${TARGET}"
+            -D "TEST_BINARY=$<TARGET_FILE:${TARGET}>"
+            -D "CTEST_FILE=${ctest_tests_file}"
+            -D "SHARD_COUNT=${_SHARD_COUNT}"
+            -D "ADDTL_ARGS=${ADDTL_ARGS}"
+            -P "${shard_impl_script_file}"
+    VERBATIM
+  )
+endfunction()

--- a/3rd-party/catch/ShardImpl.cmake
+++ b/3rd-party/catch/ShardImpl.cmake
@@ -1,0 +1,54 @@
+# Adapted from from Catch2 Commit b817497528877b14d6102869a6df378d029b343b
+# See: https://raw.githubusercontent.com/catchorg/Catch2/b817497528877b14d6102869a6df378d029b343b/extras/CatchShardTestsImpl.cmake
+#############################
+# CatchShardTestsImpl.cmake #
+#############################
+
+#              Copyright Catch2 Authors
+# Distributed under the Boost Software License, Version 1.0.
+#   (See accompanying file LICENSE.txt or copy at
+#        https://www.boost.org/LICENSE_1_0.txt)
+
+# SPDX-License-Identifier: BSL-1.0
+
+# Indirection for CatchShardTests that allows us to delay the script
+# file generation until build time.
+
+# Expected args:
+#  * TEST_BINARY - full path to the test binary to run sharded
+#  * CTEST_FILE  - full path to ctest script file to write to
+#  * TARGET_NAME - name of the target to shard (used for test names)
+#  * SHARD_COUNT - number of shards to split the binary into
+#  * ADDTL_ARGS  - Any additional args before the catch ones
+# Optional args:
+#  * REPORTER_SPEC - reporter specs to be passed down to the binary
+#  * TEST_SPEC     - test spec to pass down to the test binary
+
+if(NOT EXISTS "${TEST_BINARY}")
+  message(FATAL_ERROR
+    "Specified test binary '${TEST_BINARY}' does not exist"
+  )
+endif()
+
+set(other_args "")
+if (TEST_SPEC)
+  set(other_args "${other_args} ${TEST_SPEC}")
+endif()
+if (REPORTER_SPEC)
+  set(other_args "${other_args} --reporter ${REPORTER_SPEC}")
+endif()
+
+# foreach RANGE in cmake is inclusive of the end, so we have to adjust it
+math(EXPR adjusted_shard_count "${SHARD_COUNT} - 1")
+
+# Must use ctest syntax, not cmake syntax.
+# This limits us to add_test(<name> <executable> <args...>)
+file(WRITE "${CTEST_FILE}"
+"string(RANDOM LENGTH 8 ALPHABET \"0123456789abcdef\" rng_seed)
+foreach(shard_idx RANGE ${adjusted_shard_count})
+  add_test(\"${TARGET_NAME}-shard-$" "{shard_idx}/${adjusted_shard_count}\"
+    ${TEST_BINARY} ${ADDTL_ARGS} --shard-index  $" "{shard_idx} --shard-count ${SHARD_COUNT} \
+    --rng-seed  0x$" "{rng_seed} --order rand ${other_args}
+  )
+endforeach()"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ if (ONLY STREQUAL "BUILD")
     set(LANGUAGES "CXX")
 endif ()
 project(Pepp VERSION 0.6.0 LANGUAGES ${LANGUAGES})
+set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/install" CACHE PATH "Installation Directory" FORCE)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 include(config/cmake/enumerate_targets.cmake)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -24,12 +24,12 @@ make_target(
         Qt::Widgets test-lib-all memory highlight
 )
 
+target_compile_definitions(pepp PRIVATE "INCLUDE_GUI=1")
+set(TEST_TARGET "pepp")
 # Files with QML definitions must always be includeable without a prefix.
 # See: https://bugreports.qt.io/browse/QTBUG-101146.
 target_include_directories(pepp PRIVATE ${CMAKE_CURRENT_LIST_DIR}/demo/fig-view)
 
-
-target_compile_definitions(pepp PRIVATE "INCLUDE_GUI=1")
 # On Windows, applications may either be GUI or terminal, not both.
 # So, we (hackishly) recompile the target above, but this time we will not set WIN32_EXECUTABLE.
 if (WIN32)
@@ -43,8 +43,10 @@ if (WIN32)
     target_compile_definitions(pepp-term PRIVATE "INCLUDE_GUI=0")
     target_compile_definitions(pepp-term PRIVATE "DEFAULT_GUI=0")
     target_compile_definitions(pepp PRIVATE "DEFAULT_GUI=1")
+    set(TEST_TARGET "pepp-term")
 else ()
     target_compile_definitions(pepp PRIVATE "DEFAULT_GUI=0")
+    add_executable(pepp-term ALIAS pepp)
 endif ()
 
 # GLOB_RECURSE uses abs paths, QML_FILES expects relative paths. This blob converts from abs to rel.
@@ -56,6 +58,7 @@ set_target_properties(pepp PROPERTIES
         WIN32_EXECUTABLE TRUE
 )
 
+set_target_properties(pepp PROPERTIES FOLDER "qtc_runnable")
 # Non-DLL platforms have empty generator expressin, so use more generator magic to only copy DLLs if the exist.
 add_custom_command(TARGET pepp POST_BUILD
         COMMAND ${CMAKE_COMMAND}
@@ -65,9 +68,7 @@ add_custom_command(TARGET pepp POST_BUILD
 )
 
 
-set_target_properties(pepp PROPERTIES FOLDER "qtc_runnable")
-
-if (NOT EMSCRIPTEN)
+if (0)
     configure_file(test/config.hpp.in "${CMAKE_CURRENT_BINARY_DIR}/config.hpp")
     make_target(
             TARGET test-term
@@ -114,3 +115,11 @@ qt6_add_resources(pepp "pepp"
         FILES
         ${pep10_resource_files}
 )
+
+# Set pepp/pepp-term as a test target.
+if (NOT EMSCRIPTEN)
+    set(count 2)
+    catch_test_count(count)
+    message("Creating ${count} test shards")
+    catch_add_sharded_tests(${TEST_TARGET} "selftest" SHARD_COUNT ${count})
+endif ()

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -23,6 +23,13 @@ make_target(
         Qt6::Core Qt6::Gui Qt::Qml Qt::Quick Qt::QuickControls2
         Qt::Widgets test-lib-all memory highlight
 )
+install(TARGETS pepp DESTINATION bin)
+qt_generate_deploy_qml_app_script(
+        TARGET pepp
+        OUTPUT_SCRIPT deploy_script
+        NO_UNSUPPORTED_PLATFORM_ERROR
+)
+install(SCRIPT ${deploy_script})
 
 target_compile_definitions(pepp PRIVATE "INCLUDE_GUI=1")
 set(TEST_TARGET "pepp")
@@ -39,6 +46,7 @@ if (WIN32)
             SOURCES ${sources}
             DEPENDS TextFlow cli about macro pas builtins isa targets sim Qt6::Core catch test-lib-all
     )
+    install(TARGETS pepp-term DESTINATION bin)
     set_target_properties(pepp-term PROPERTIES FOLDER "qtc_runnable")
     target_compile_definitions(pepp-term PRIVATE "INCLUDE_GUI=0")
     target_compile_definitions(pepp-term PRIVATE "DEFAULT_GUI=0")
@@ -59,7 +67,7 @@ set_target_properties(pepp PROPERTIES
 )
 
 set_target_properties(pepp PROPERTIES FOLDER "qtc_runnable")
-# Non-DLL platforms have empty generator expressin, so use more generator magic to only copy DLLs if the exist.
+# Non-DLL platforms have empty generator expression, so use more generator magic to only copy DLLs if the exist.
 add_custom_command(TARGET pepp POST_BUILD
         COMMAND ${CMAKE_COMMAND}
         ARGS

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -23,6 +23,15 @@ make_target(
         Qt6::Core Qt6::Gui Qt::Qml Qt::Quick Qt::QuickControls2
         Qt::Widgets test-lib-all memory highlight
 )
+# GLOB_RECURSE uses abs paths, QML_FILES expects relative paths. This blob converts from abs to rel.
+set_target_properties(pepp PROPERTIES
+        MACOSX_BUNDLE_GUI_IDENTIFIER edu.pepperdine.cslab.pepp
+        MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
+        MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+        MACOSX_BUNDLE TRUE
+        WIN32_EXECUTABLE TRUE
+)
+
 install(TARGETS pepp DESTINATION bin)
 qt_generate_deploy_qml_app_script(
         TARGET pepp
@@ -57,14 +66,6 @@ else ()
     add_executable(pepp-term ALIAS pepp)
 endif ()
 
-# GLOB_RECURSE uses abs paths, QML_FILES expects relative paths. This blob converts from abs to rel.
-set_target_properties(pepp PROPERTIES
-        MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com
-        MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
-        MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
-        MACOSX_BUNDLE TRUE
-        WIN32_EXECUTABLE TRUE
-)
 
 set_target_properties(pepp PROPERTIES FOLDER "qtc_runnable")
 # Non-DLL platforms have empty generator expression, so use more generator magic to only copy DLLs if the exist.

--- a/bin/commands/selftest.hpp
+++ b/bin/commands/selftest.hpp
@@ -36,6 +36,7 @@ void registerSelfTest(auto &app, task_factory_t &task, const detail::SharedFlags
   test->callback([&]() {
     task = [&](QObject *parent) {
       auto remainingArgs = test->remaining_for_passthrough();
+      std::reverse(remainingArgs.begin(), remainingArgs.end());
       // Must push executable name to argv[0], or catch arg parsing CTDs.
       auto realArgs = QCoreApplication::arguments();
       remainingArgs.insert(remainingArgs.begin(), u"%1 selftest"_qs.arg(realArgs[0]).toStdString());

--- a/config/cmake/create_targets.cmake
+++ b/config/cmake/create_targets.cmake
@@ -130,10 +130,16 @@ function(make_target)
     else ()
         qt6_add_library(${MK_TARGET} ${MK_TYPE} ${MK_SOURCES})
     endif ()
+
     # Only add dependencies if present
     if (MK_DEPENDS)
         target_link_libraries(${MK_TARGET} PUBLIC ${MK_DEPENDS})
     endif ()
+
+    install(TARGETS ${MK_TARGET}
+            BUNDLE DESTINATION .
+            RUNTIME DESTINATION bin
+    )
 endfunction()
 
 # Helper to make a PUBLIC library with cpp sources.

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -1,2 +1,7 @@
 add_subdirectory(highlight)
 add_subdirectory(memory)
+
+install(
+        TARGETS memory highlight
+        RUNTIME DESTINATION bin
+)

--- a/ui/memory/CMakeLists.txt
+++ b/ui/memory/CMakeLists.txt
@@ -6,21 +6,22 @@ list(REMOVE_ITEM sources ${tests})
 list(REMOVE_ITEM sources ${old_sources})
 
 # GLOB_RECURSE uses abs paths, QML_FILES expects relative paths. This blob converts from abs to rel.
-file(GLOB_RECURSE abs_qml_sources CONFIGURE_DEPENDS  "main.qml" "*.qml")
+file(GLOB_RECURSE abs_qml_sources CONFIGURE_DEPENDS "main.qml" "*.qml")
 SET(rel_qml_sources, "")
-foreach(f_abs IN LISTS abs_qml_sources)
+foreach (f_abs IN LISTS abs_qml_sources)
     file(RELATIVE_PATH f_rel "${CMAKE_CURRENT_LIST_DIR}" ${f_abs})
     list(APPEND rel_qml_sources "${f_rel}")
-endforeach()
+endforeach ()
 
 qt_add_qml_module(memory
-    URI "memory"
-    VERSION 0.1
-    QML_FILES
+        URI "memory"
+        VERSION 0.1
+        QML_FILES
         ${rel_qml_sources}
-    RESOURCE_PREFIX /ui
-    SOURCES
+        RESOURCE_PREFIX /ui
+        SOURCES
         ${sources}
 )
+
 target_compile_definitions(memory PRIVATE "MEMORY_LIBRARY")
 target_link_libraries(memory PUBLIC Qt6::Core Qt6::Gui Qt6::Quick)


### PR DESCRIPTION
This reduces the number of executables that need to be produced.
On Windows, this reduces the amount of DLLs copied by 100s of MBs.