### PR TITLE
Create installers / app bundles in CI

### DIFF
--- a/.github/actions/install-qt-cmake/action.yml
+++ b/.github/actions/install-qt-cmake/action.yml
@@ -17,3 +17,4 @@ runs:
       version: ${{ inputs.qt_version }}
       cache: true
       extra: "--base https://mirrors.ocf.berkeley.edu/qt"
+      tools: "tools_ifw"

--- a/.github/actions/install-qt-cmake/action.yml
+++ b/.github/actions/install-qt-cmake/action.yml
@@ -17,4 +17,5 @@ runs:
       version: ${{ inputs.qt_version }}
       cache: true
       extra: "--base https://mirrors.ocf.berkeley.edu/qt"
-      tools: "tools_ifw"
+      tools: 'tools_ifw,qt.tools.ifw.46'
+      add-tools-to-path: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,11 +53,14 @@ jobs:
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
           echo "$MAC_BUILD_CERTIFICATE_BASE64"
           echo -n "$MAC_BUILD_CERTIFICATE_BASE64" | base64 --decode > $CERTIFICATE_PATH
-          ls -lah $RUNNER_TEMP
           security create-keychain -p "$MAC_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
           security unlock-keychain -p "$MAC_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security import $CERTIFICATE_PATH -P "$MAC_P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security show-keychain-info $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+          security find-identity -v -p codesigning $KEYCHAIN_PATH
+          security find-certificate -a -p -c $CERTIFICATE_PATH $KEYCHAIN_PATH
         env:
           MAC_BUILD_CERTIFICATE_BASE64: ${{ secrets.MAC_BUILD_CERTIFICATE_BASE64 }}
           MAC_KEYCHAIN_PASSWORD: ${{ secrets.MAC_KEYCHAIN_PASSWORD }}
@@ -130,7 +133,7 @@ jobs:
         shell: bash
         if: ${{ !contains(inputs.name, 'EMSDK') }}
         working-directory: build
-        run: ls -lah && cpack
+        run: cpack
 
       # Run tests, sign outputs, and upload artifacts
       - name: Run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,12 @@ jobs:
       - name: Run build
         run: cmake --build build -j6
 
+      - name: Run cpack
+        shell: bash
+        if: ${{ !contains(inputs.name, 'EMSDK') }}
+        working-directory: build
+        run: ls -lah && cpack
+
       # Run tests, sign outputs, and upload artifacts
       - name: Run tests
         if: inputs.ctest_launcher

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,25 @@ jobs:
       - if: env.ACT
         name: Install Node if running locally using `nektos/act`
         uses: ./.github/actions/install-node
+      # Must do a bunch of work to enable signing on MacOS.
+      # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
+      # WARNING: If we switch to self-hosted runners, must clean up the certs ourselves.
+      - name: Import Apple Certificate
+        if: ${{ contains(inputs.name, 'MacOS') }}
+        run: |
+          CERTIFICATE_PATH=$RUNNER_TEMP/cert.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          echo "$MAC_BUILD_CERTIFICATE_BASE64"
+          echo -n "$MAC_BUILD_CERTIFICATE_BASE64" | base64 --decode > $CERTIFICATE_PATH
+          ls -lah $RUNNER_TEMP
+          security create-keychain -p "$MAC_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$MAC_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security import $CERTIFICATE_PATH -P "$MAC_P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+        env:
+          MAC_BUILD_CERTIFICATE_BASE64: ${{ secrets.MAC_BUILD_CERTIFICATE_BASE64 }}
+          MAC_KEYCHAIN_PASSWORD: ${{ secrets.MAC_KEYCHAIN_PASSWORD }}
+          MAC_P12_PASSWORD: ${{ secrets.MAC_P12_PASSWORD }}
 
       # Install dependencies based on enabled features
       - name: Install Qt+CMake in non-containerized builds
@@ -100,7 +119,9 @@ jobs:
           ${{ inputs.cmake_xargs }}
           ${{ inputs.docs_audience && format('-D DOC_AUDIENCE={0}', inputs.docs_audience) || '' }}
           ${{inputs.docs_artifact && format('-D DOC_PREBUILT_DIR="{0}"', inputs.docs_artifact) || '' }}
-          -D CMAKE_BUILD_TYPE=Debug
+          -D CMAKE_BUILD_TYPE=Debug -D MAC_DEVELOPER_NAME="$MAC_DEVELOPER_NAME"
+        env:
+          MAC_DEVELOPER_NAME: ${{ secrets.MAC_DEVELOPER_NAME }}
 
       - name: Run build
         run: cmake --build build -j6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,11 @@ jobs:
         with:
           cache-key-prefix: install-qt-${{ inputs.runs-on }}
 
+      - name: Add QTIFW to path
+        if: inputs.runs-on == 'windows-latest'
+        shell: bash
+        run: echo "$RUNNER_WORKSPACE/Qt/Tools/QtInstallerFramework/4.6/bin" >>$GITHUB_PATH
+
       # Prevent clang from using ccache, because it is profiling build times
       - name: Enable caching object files between builds
         # Disable ccache when running locally
@@ -135,6 +140,7 @@ jobs:
           ${{ inputs.docs_audience && format('-D DOC_AUDIENCE={0}', inputs.docs_audience) || '' }}
           ${{inputs.docs_artifact && format('-D DOC_PREBUILT_DIR="{0}"', inputs.docs_artifact) || '' }}
           -D CMAKE_BUILD_TYPE=Debug -D MAC_DEVELOPER_NAME="$MAC_DEVELOPER_NAME"
+          -D CPACK_BUILD_CONFIG=Debug
         env:
           MAC_DEVELOPER_NAME: ${{ secrets.MAC_DEVELOPER_NAME }}
 
@@ -145,7 +151,7 @@ jobs:
         shell: bash
         if: ${{ !contains(inputs.name, 'EMSDK') }}
         working-directory: build
-        run: cpack
+        run: ls -lah && cpack -c Debug
 
       # Run tests, sign outputs, and upload artifacts
       - name: Run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,19 @@ on:
       docs_artifact: { type: string }
       images_artifact: { type: string }
       docs_audience: { type: string }
+    secrets:
+      MAC_BUILD_CERTIFICATE_BASE64:
+        description: 'Contains an apple developer cert.'
+        required: false
+      MAC_KEYCHAIN_PASSWORD:
+        description: 'Password for keychain in which developer cert will be stored..'
+        required: false
+      MAC_P12_PASSWORD:
+        description: 'Password for build certificate.'
+        required: false
+      MAC_DEVELOPER_NAME:
+        description: 'Developer name for build certificate.'
+        required: false
 
 jobs:
   matrix_build:
@@ -51,7 +64,6 @@ jobs:
         run: |
           CERTIFICATE_PATH=$RUNNER_TEMP/cert.p12
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          echo "$MAC_BUILD_CERTIFICATE_BASE64"
           echo -n "$MAC_BUILD_CERTIFICATE_BASE64" | base64 --decode > $CERTIFICATE_PATH
           security create-keychain -p "$MAC_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security set-keychain-settings -lut 21600 $KEYCHAIN_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,3 +151,8 @@ jobs:
       docs_audience: ${{ matrix.config.docs_audience || '' }}
       docs_artifact: ${{ (matrix.config.docs_audience && '') || 'app-docs' }}
       images_artifact: 'icons'
+    secrets:
+      MAC_BUILD_CERTIFICATE_BASE64: ${{ secrets.MAC_BUILD_CERTIFICATE_BASE64 }}
+      MAC_KEYCHAIN_PASSWORD: ${{ secrets.MAC_KEYCHAIN_PASSWORD }}
+      MAC_P12_PASSWORD: ${{ secrets.MAC_P12_PASSWORD }}
+      MAC_DEVELOPER_NAME: ${{ secrets.MAC_DEVELOPER_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
           path: data
           retention-days: 1
   start_matrix:
+    name: Trigger build for ${{ matrix.name }}
     needs: [ branch_info, build_docs, check_tag, create_icons ]
     uses: ./.github/workflows/build.yml
     strategy:

--- a/.github/workflows/cleancache.yml
+++ b/.github/workflows/cleancache.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   remove_ccache:
+    name: Remove orphan caches
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,7 @@ jobs:
           cat $GITHUB_OUTPUT
 
   start_codeql:
+    name: Run CodeQL
     needs: branch_info
     uses: ./.github/workflows/build.yml
     permissions:

--- a/3rd-party/antlr4/CMakeLists.txt
+++ b/3rd-party/antlr4/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required (VERSION 3.15)
 # 3.14 needed because of FetchContent
 # 3.15 needed to avid spew of warnings related to overriding cl command line flags
 
-set(CMAKE_MACOSX_RPATH OFF)
+set(CMAKE_MACOSX_RPATH ON)
 
 # Detect build type, fallback to release and throw a warning if use didn't specify any
 if(NOT CMAKE_BUILD_TYPE)
@@ -111,7 +111,3 @@ endif()
 
 
 add_subdirectory(runtime)
-
-set(CPACK_PACKAGE_CONTACT "antlr-discussion@googlegroups.com")
-set(CPACK_PACKAGE_VERSION ${ANTLR_VERSION})
-include(CPack)

--- a/3rd-party/antlr4/runtime/CMakeLists.txt
+++ b/3rd-party/antlr4/runtime/CMakeLists.txt
@@ -101,17 +101,11 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 if (TARGET antlr4_shared)
   set_target_properties(antlr4_shared
                         PROPERTIES VERSION   ${ANTLR_VERSION}
-                                   SOVERSION ${ANTLR_VERSION}
                                    COMPILE_FLAGS "${disabled_compile_warnings} ${extra_share_compile_flags}")
-  install(
-        TARGETS antlr4_shared
-        RUNTIME DESTINATION bin
-  )
 endif()
 
 if (TARGET antlr4_static)
   set_target_properties(antlr4_static
                         PROPERTIES VERSION   ${ANTLR_VERSION}
-                                   SOVERSION ${ANTLR_VERSION}
                                    COMPILE_FLAGS "${disabled_compile_warnings} ${extra_static_compile_flags}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,14 +263,13 @@ if (ONLY STREQUAL "BUILD")
         set(CPACK_GENERATOR "Bundle") # for a macOS .dmg
         set(CPACK_BUNDLE_NAME "Pepp")
         set(CPACK_BUNDLE_PLIST "${PROJECT_SOURCE_DIR}/bin/Info.plist")
-        set(CPACK_BUNDLE_ICON "${PROJECT__DIR}/icons/icon.icns")
+        set(CPACK_BUNDLE_ICON "${PROJECT_DATA_DIR}/icons/icon.icns")
 
         # Allow developer name to be passed via environment or -D
         set(MAC_DEVELOPER_NAME "" CACHE STRING "A variable passed in via -D")
         if(NOT MAC_DEVELOPER_NAME)
             set(MAC_DEVELOPER_NAME $ENV{MAC_DEVELOPER_NAME})
         endif()
-        message("Dev Name is ${MAC_DEVELOPER_NAME}")
         set(CPACK_BUNDLE_APPLE_CERT_APP "${MAC_DEVELOPER_NAME}")
         set(CPACK_BUNDLE_APPLE_ENTITLEMENTS "${PROJECT_SOURCE_DIR}/bin/entitlements.plist")
         set(CPACK_BUNDLE_APPLE_CODESIGN_PARAMETERS "--deep --timestamp -f")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,12 +234,30 @@ if (ONLY STREQUAL "BUILD")
     # Configure CPack installer generation.
     set(CPACK_PACKAGE_NAME "Pepp")
     set(CPACK_PACKAGE_VENDOR "Pepperdine University")
-    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A GUI for the Pep/10 virtual machine at various levels of abstraction")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Pepp IDE")
     set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
     set(CPACK_PACKAGE_INSTALL_DIRECTORY "Pepp")
     # Assuming you're targeting multiple platforms, you might want to conditionally set the generator
     if (WIN32)
         set(CPACK_GENERATOR "IFW") # or "ZIP" for a simple zip archive
+        set(CPACK_IFW_PRODUCT_URL "https://github.com/Matthew-McRaven/Pepp/")
+        if (EXISTS "${PROJECT_DATA_DIR}/icons/icon.ico")
+            set(CPACK_IFW_PACKAGE_ICON "${PROJECT_DATA_DIR}/icons/icon.ico")
+        endif ()
+        if (EXISTS "${PROJECT_DATA_DIR}/icons/icon.png")
+            set(CPACK_IFW_PACKAGE_WINDOW_ICON "${PROJECT_DATA_DIR}/icons/icon.png")
+        endif ()
+        include(CPackIFW)
+        cpack_add_component(Pepp
+                DISPLAY_NAME Pepp
+                REQUIRED
+        )
+        cpack_ifw_configure_component(Pepp
+                FORCED_INSTALLATION
+                REQUIRES_ADMIN_RIGHTS
+                NAME "Pepp"
+                LICENSES "GPL-3.0" "${PROJECT_SOURCE_DIR}/LICENSE"
+        )
     elseif (APPLE)
         set(CPACK_GENERATOR "DragNDrop") # for a macOS .dmg
     else ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,7 @@ if (ONLY STREQUAL "BUILD")
     # Assuming you're targeting multiple platforms, you might want to conditionally set the generator
     if (WIN32)
         set(CPACK_GENERATOR "IFW") # or "ZIP" for a simple zip archive
+        set(CPACK_IFW_ROOT "${Qt6_DIR}/../../../../Tools/QtInstallerFramework/4.6")
         set(CPACK_IFW_PRODUCT_URL "https://github.com/Matthew-McRaven/Pepp/")
         if (EXISTS "${PROJECT_DATA_DIR}/icons/icon.ico")
             set(CPACK_IFW_PACKAGE_ICON "${PROJECT_DATA_DIR}/icons/icon.ico")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,8 +262,8 @@ if (ONLY STREQUAL "BUILD")
     elseif (APPLE)
         set(CPACK_GENERATOR "Bundle") # for a macOS .dmg
         set(CPACK_BUNDLE_NAME "Pepp")
-        set(CPACK_BUNDLE_PLIST "${PROJECT_DATA_DIR}/Info.plist")
-        set(CPACK_BUNDLE_ICON "${PROJECT_DATA_DIR}/icons/icon.icns")
+        set(CPACK_BUNDLE_PLIST "${PROJECT_SOURCE_DIR}/bin/Info.plist")
+        set(CPACK_BUNDLE_ICON "${PROJECT__DIR}/icons/icon.icns")
 
         # Allow developer name to be passed via environment or -D
         set(MAC_DEVELOPER_NAME "" CACHE STRING "A variable passed in via -D")
@@ -272,7 +272,7 @@ if (ONLY STREQUAL "BUILD")
         endif()
         message("Dev Name is ${MAC_DEVELOPER_NAME}")
         set(CPACK_BUNDLE_APPLE_CERT_APP "${MAC_DEVELOPER_NAME}")
-        set(CPACK_BUNDLE_APPLE_ENTITLEMENTS "${PROJECT_DATA_DIR}/entitlements.plist")
+        set(CPACK_BUNDLE_APPLE_ENTITLEMENTS "${PROJECT_SOURCE_DIR}/bin/entitlements.plist")
         set(CPACK_BUNDLE_APPLE_CODESIGN_PARAMETERS "--deep --timestamp -f")
         # Will still need to notarize & staple the DMG in CI.
     else ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,21 @@ if (ONLY STREQUAL "BUILD")
                 LICENSES "GPL-3.0" "${PROJECT_SOURCE_DIR}/LICENSE"
         )
     elseif (APPLE)
-        set(CPACK_GENERATOR "DragNDrop") # for a macOS .dmg
+        set(CPACK_GENERATOR "Bundle") # for a macOS .dmg
+        set(CPACK_BUNDLE_NAME "Pepp")
+        set(CPACK_BUNDLE_PLIST "${PROJECT_DATA_DIR}/Info.plist")
+        set(CPACK_BUNDLE_ICON "${PROJECT_DATA_DIR}/icons/icon.icns")
+
+        # Allow developer name to be passed via environment or -D
+        set(MAC_DEVELOPER_NAME "" CACHE STRING "A variable passed in via -D")
+        if(NOT MAC_DEVELOPER_NAME)
+            set(MAC_DEVELOPER_NAME $ENV{MAC_DEVELOPER_NAME})
+        endif()
+        message("Dev Name is ${MAC_DEVELOPER_NAME}")
+        set(CPACK_BUNDLE_APPLE_CERT_APP "${MAC_DEVELOPER_NAME}")
+        set(CPACK_BUNDLE_APPLE_ENTITLEMENTS "${PROJECT_DATA_DIR}/entitlements.plist")
+        set(CPACK_BUNDLE_APPLE_CODESIGN_PARAMETERS "--deep --timestamp -f")
+        # Will still need to notarize & staple the DMG in CI.
     else ()
         set(CPACK_GENERATOR "TGZ") # for Linux, multiple generators can be specified
     endif ()

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -51,13 +51,13 @@ set_target_properties(pepp PROPERTIES
         FOLDER "qtc_runnable"
 )
 
-install(TARGETS pepp DESTINATION bin)
+install(TARGETS pepp DESTINATION bin COMPONENT Pepp)
 qt_generate_deploy_qml_app_script(
         TARGET pepp
         OUTPUT_SCRIPT deploy_script
         NO_UNSUPPORTED_PLATFORM_ERROR
 )
-install(SCRIPT ${deploy_script})
+install(SCRIPT ${deploy_script} COMPONENT Pepp)
 
 set(TEST_TARGET "pepp")
 # Files with QML definitions must always be includeable without a prefix.
@@ -73,7 +73,7 @@ if (WIN32)
             SOURCES ${sources}
             DEPENDS TextFlow cli about macro pas builtins isa targets sim Qt6::Core catch test-lib-all
     )
-    install(TARGETS pepp-term DESTINATION bin)
+    install(TARGETS pepp-term DESTINATION bin COMPONENT Pepp)
     set_target_properties(pepp-term PROPERTIES FOLDER "qtc_runnable")
     target_compile_definitions(pepp-term PRIVATE "INCLUDE_GUI=0")
     target_compile_definitions(pepp-term PRIVATE "DEFAULT_GUI=0")

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -51,7 +51,16 @@ set_target_properties(pepp PROPERTIES
         FOLDER "qtc_runnable"
 )
 
-install(TARGETS pepp DESTINATION bin COMPONENT Pepp)
+# Must specify antlr, because we can't easily install 3rd-party deps.
+install(TARGETS pepp antlr4_shared
+    COMPONENT Pepp
+    RUNTIME DESTINATION bin
+    BUNDLE DESTINATION .
+)
+if(APPLE)
+    install(TARGETS antlr4_shared LIBRARY DESTINATION pepp.app/Contents/Frameworks)
+endif()
+
 qt_generate_deploy_qml_app_script(
         TARGET pepp
         OUTPUT_SCRIPT deploy_script

--- a/bin/Entitlements.plist
+++ b/bin/Entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+</dict>
+</plist>

--- a/bin/Info.plist
+++ b/bin/Info.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<string>True</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>pep</string>
+			</array>
+			<key>CFBundleTypeMIMETypes</key>
+			<array>
+				<string>text/plain</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Pep Assembly Source File</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSTypeIsPackage</key>
+			<true/>
+			<key>NSPersistentStoreTypeKey</key>
+			<string>Binary</string>
+		</dict>
+	</array>
+	<key>CFBundleShortVersionString</key>
+	<string>0.6.0</string>
+	<key>CFBundleIconFile</key>
+	<string>icon.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>edu.pepperdine.cslab.pepp</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleVersion</key>
+	<string>0.6.0</string>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.plain-text</string>
+				<string>public.text</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Pepp Assembly Document</string>
+			<key>UTTypeIdentifier</key>
+			<string>edu.pepperdine.cslab.pepp</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>com.apple.ostype</key>
+				<string>TEXT</string>
+				<key>public.filename-extension</key>
+				<array>
+					<string>pep</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/config/cmake/create_targets.cmake
+++ b/config/cmake/create_targets.cmake
@@ -140,6 +140,9 @@ function(make_target)
             BUNDLE DESTINATION .
             RUNTIME DESTINATION bin
     )
+    if(APPLE)
+        install(TARGETS ${MK_TARGET} LIBRARY DESTINATION pepp.app/Contents/Frameworks)
+    endif()
 endfunction()
 
 # Helper to make a PUBLIC library with cpp sources.

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -1,7 +1,13 @@
 add_subdirectory(highlight)
 add_subdirectory(memory)
 
+set(ui_targets "memory;highlight")
 install(
-        TARGETS memory highlight
+        TARGETS ${ui_targets}
         RUNTIME DESTINATION bin
+        LIBRARY DESTINATION pepp.app/Contents/Frameworks
 )
+
+if(APPLE)
+    install(TARGETS ${ui_targets} LIBRARY DESTINATION pepp.app/Contents/Frameworks)
+endif()


### PR DESCRIPTION
I want to automatically build installers or bundles for all platforms in our CI environment.
This will make authoring releases easy to automate.

So far, I have Windows & Mac OS working, with Linux mostly working.
I codesign Mac OS bundles, but do not yet notarize them.

Future work will include:
- Linux deployment via AppImage
- Moving CI install dir out of build dir (to reduce size of files saved with ccache)
- Notarize Mac OS applications
- Determine if I need to build apps in release mode