### PR TITLE
Store icons in LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 * text=auto
+# Generic image files
+*.png filter=lfs diff=lfs merge=lfs -text
+# Icon files
+*.ico filter=lfs diff=lfs merge=lfs -text
+*.icns filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: 'true'
+          # LFS defaults to disabled, but accidental LFS bandwidth would be bad.
+          lfs: 'false'
       # Local github runner doesn't have node installed.
       - if: env.ACT
         name: Install Node if running locally using `nektos/act`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Clone sources to extract project version
         uses: actions/checkout@v4
         if: needs.branch_info.outputs.build_release == true
+        # LFS defaults to disabled, but accidental LFS bandwidth would be bad.
+        with:
+          lfs: 'false'
       - uses: lukka/get-cmake@v3.27.9
         if: needs.branch_info.outputs.build_release == true
       - name: Extract the CMake version
@@ -85,6 +88,9 @@ jobs:
     steps:
       # Must exectute before any repo-local actions
       - uses: actions/checkout@v4
+        # LFS defaults to disabled, but accidental LFS bandwidth would be bad.
+        with:
+          lfs: 'false'
       # Install dependencies based on enabled features
       - if: env.ACT
         uses: ./.github/actions/install-node
@@ -102,6 +108,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        # LFS defaults to disabled, but accidental LFS bandwidth would be bad.
+        with:
+          lfs: 'false'
       - name: Setup ImageMagick libicns (for ICNS conversion)
         run: sudo apt update && sudo apt install imagemagick icnsutils
       - name: Convert SVG to PNG

--- a/.github/workflows/cleancache.yml
+++ b/.github/workflows/cleancache.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
     - name: Checkout source code (shallow)
       uses: actions/checkout@v4
+      # LFS defaults to disabled, but accidental LFS bandwidth would be bad.
+      with:
+        lfs: 'false'
     - name: Show caches (debug)
       run: gh cache list
     - name: Get caches

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 # Build from Sources
 
 When cloning this project, please use `--recurse-submodules`.
+Please install [git lfs](https://git-lfs.com), which we use to manage binary assets like images and icons.
 
 It is recommended to build the application from within Qt Creator.
 

--- a/data/icons/.gitignore
+++ b/data/icons/.gitignore
@@ -2,3 +2,7 @@
 !*.svg
 !.gitignore
 !*.rc
+# No longer need to ignore icons because we will use LFS.
+!*.png
+!*.ico
+!*.icns

--- a/data/icons/icon.icns
+++ b/data/icons/icon.icns
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca4f9935fbd879ff1b3d8417c827c410a60919b9f2f5c786bec172d83419b37e
+size 10439

--- a/data/icons/icon.ico
+++ b/data/icons/icon.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d39c78b43704cf9d478a882b6eca8dcde16371ec388c03078d7515874bb8f50b
+size 19721

--- a/data/icons/icon.png
+++ b/data/icons/icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ac40565d40ffde63d8d214c8ab16ea27f6a5b74b4fb094c43cbe81f031ea599
+size 20372


### PR DESCRIPTION
This prevents developers from need tools locally to convert `SVG=>ICO/ICNS`. However, we do need to limit LFS bandwidth because this could cost money.

One bandwidth reduction is to ensure CI disables LFS. We can continue to use the icon generation targets in CI. The checkout action documentation indicates that LFS is default-disabled. However, I have explicitly disabled it in all of my CI scripts as a precaution.