### PR TITLE
Don't overwrite CMAKE_INSTALL_PREFIX

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
           ${{ inputs.docs_audience && format('-D DOC_AUDIENCE={0}', inputs.docs_audience) || '' }}
           ${{inputs.docs_artifact && format('-D DOC_PREBUILT_DIR="{0}"', inputs.docs_artifact) || '' }}
           -D CMAKE_BUILD_TYPE=Debug -D MAC_DEVELOPER_NAME="$MAC_DEVELOPER_NAME"
-          -D CPACK_BUILD_CONFIG=Debug
+          -D CPACK_BUILD_CONFIG=Debug -D CMAKE_INSTALL_PREFIX=./install
         env:
           MAC_DEVELOPER_NAME: ${{ secrets.MAC_DEVELOPER_NAME }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,10 @@ if (ONLY STREQUAL "BUILD")
     set(LANGUAGES "CXX")
 endif ()
 project(Pepp VERSION 0.6.0 LANGUAGES ${LANGUAGES})
-set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/install" CACHE PATH "Installation Directory" FORCE)
-
+# Only overwrite the install prefix if it is the default value.
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/install" CACHE PATH "Installation Directory" FORCE)
+endif ()
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 include(config/cmake/enumerate_targets.cmake)
 


### PR DESCRIPTION
However, if it is defaulted, the build our installers in the build directory.
