### PR TITLE
feat!: replace `MOVASP` with `SWAPSPA`

### DIFF
--- a/logic/asm/pas/test/e2e/pep10.cpp
+++ b/logic/asm/pas/test/e2e/pep10.cpp
@@ -202,7 +202,7 @@ TEST_CASE("CS6E figure assembly", "[scope:asm][kind:e2e][arch:pep10]") {
         auto systemBootFlg = sys->getBootFlagAddress();
         CHECK(bootFlg.has_value() == systemBootFlg.has_value());
         if (bootFlg) {
-          CHECK(*bootFlg == 0xFA36);
+          CHECK(*bootFlg == 0xFA37);
           CHECK(*systemBootFlg == *bootFlg);
           CHECK(sys->getBootFlags() == 3);
         }

--- a/logic/help/builtins/books/cs6e/os/full/pep10os.pep
+++ b/logic/help/builtins/books/cs6e/os/full/pep10os.pep
@@ -49,10 +49,9 @@ hang:    BR      hang
          .BLOCK  64          ;Padding for possible future modification
 ;
 retVal:  .EQUATE 0           ;Main return value #2d
-execMain:MOVSPA              ;Preserve system stack pointer
-         STWA    initSp,d
-         LDWA    osRAM,i     ;Load address of user stack
-         MOVASP              ;Switch to user stack
+execMain:LDWA    osRAM,i     ;Load address of user stack
+         SWAPSPA             ;Switch to user stack
+         STWA    initSp,d    ;Preserve system stack pointer
          SUBSP   2,i         ;Allocate @param #retVal
          LDWA    0,i         ;Initialize user main return
          STWA    0,s         ;  value to zero
@@ -62,8 +61,8 @@ execMain:MOVSPA              ;Preserve system stack pointer
 mainCln: LDWA    0,s         ;Load return value
          BRNE    mainErr     ;If retval is not zero, report error
          ADDSP   2,i         ;Deallocate @param #retVal
-         LDWA    initSp,d  ;Restore system stack pointer
-         MOVASP              ;OS Stack might be clobbered during by syscalls
+         LDWA    initSp,d    ;Restore system stack pointer
+         SWAPSPA             ;OS Stack might be clobbered during by syscalls
          BR      shutdown    ;  So branch instead of call
 ;
 mainErr: LDWA    execErr,i   ;Load the address of the loader error address.

--- a/logic/isa/pep10.hpp
+++ b/logic/isa/pep10.hpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2023 J. Stanley Warford, Matthew McRaven
- *
+ * Copyright (c) 2023-2024 J. Stanley Warford, Matthew McRaven
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -24,10 +23,10 @@ Q_NAMESPACE_EXPORT(ISA_EXPORT)
 enum class Mnemonic {
   RET = 0x1,
   SRET = 0x2,
-  MOVSPA = 0x3,
-  MOVASP = 0x4,
-  MOVFLGA = 0x5,
-  MOVAFLG = 0x6,
+  MOVFLGA = 0x3,
+  MOVAFLG = 0x4,
+  MOVSPA = 0x5,
+  SWAPSPA = 0x6,
   NOP = 0x7,
 
   // FAULTS
@@ -142,94 +141,35 @@ constexpr std::array<Opcode, 256> initOpcodes() {
     ret[base + 7] = {.instr = i, .mode = AM::SFX, .valid = true};
   };
 
-  ret[0x00] = {
-      .instr = {.mnemon = M::INVALID, .type = T::U_none, .unary = true},
-      .mode = AM::NONE,
-      .valid = false};
-  ret[(quint8)M::RET] = {
-      .instr = {.mnemon = M::RET, .type = T::U_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
-  ret[(quint8)M::SRET] = {
-      .instr = {.mnemon = M::SRET, .type = T::U_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
-  ret[(quint8)M::MOVSPA] = {
-      .instr = {.mnemon = M::MOVSPA, .type = T::U_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
-  ret[(quint8)M::MOVASP] = {
-      .instr = {.mnemon = M::MOVASP, .type = T::U_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
+  ret[0x00] = {.instr = {.mnemon = M::INVALID, .type = T::U_none, .unary = true}, .mode = AM::NONE, .valid = false};
+  ret[(quint8)M::RET] = {.instr = {.mnemon = M::RET, .type = T::U_none, .unary = 1}, .mode = AM::NONE, .valid = true};
+  ret[(quint8)M::SRET] = {.instr = {.mnemon = M::SRET, .type = T::U_none, .unary = 1}, .mode = AM::NONE, .valid = true};
   ret[(quint8)M::MOVFLGA] = {
-      .instr = {.mnemon = M::MOVFLGA, .type = T::U_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
+      .instr = {.mnemon = M::MOVFLGA, .type = T::U_none, .unary = 1}, .mode = AM::NONE, .valid = true};
   ret[(quint8)M::MOVAFLG] = {
-      .instr = {.mnemon = M::MOVAFLG, .type = T::U_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
-  ret[(quint8)M::NOP] = {
-      .instr = {.mnemon = M::NOP, .type = T::U_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
+      .instr = {.mnemon = M::MOVAFLG, .type = T::U_none, .unary = 1}, .mode = AM::NONE, .valid = true};
+  ret[(quint8)M::MOVSPA] = {
+      .instr = {.mnemon = M::MOVSPA, .type = T::U_none, .unary = 1}, .mode = AM::NONE, .valid = true};
+  ret[(quint8)M::SWAPSPA] = {
+      .instr = {.mnemon = M::SWAPSPA, .type = T::U_none, .unary = 1}, .mode = AM::NONE, .valid = true};
+  ret[(quint8)M::NOP] = {.instr = {.mnemon = M::NOP, .type = T::U_none, .unary = 1}, .mode = AM::NONE, .valid = true};
 
   // Gap
   for (int it = (int)M::NOP + 1; it < (int)M::NOTA; it++)
-    ret[it] = {
-        .instr = {.mnemon = M::INVALID, .type = T::U_none, .unary = true},
-        .mode = AM::NONE,
-        .valid = false};
+    ret[it] = {.instr = {.mnemon = M::INVALID, .type = T::U_none, .unary = true}, .mode = AM::NONE, .valid = false};
 
-  ret[(quint8)M::NOTA] = {
-      .instr = {.mnemon = M::NOTA, .type = T::R_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
-  ret[(quint8)M::NOTX] = {
-      .instr = {.mnemon = M::NOTX, .type = T::R_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
-  ret[(quint8)M::NEGA] = {
-      .instr = {.mnemon = M::NEGA, .type = T::R_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
-  ret[(quint8)M::NEGX] = {
-      .instr = {.mnemon = M::NEGX, .type = T::R_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
-  ret[(quint8)M::ASLA] = {
-      .instr = {.mnemon = M::ASLA, .type = T::R_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
-  ret[(quint8)M::ASLX] = {
-      .instr = {.mnemon = M::ASLX, .type = T::R_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
-  ret[(quint8)M::ASRA] = {
-      .instr = {.mnemon = M::ASRA, .type = T::R_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
-  ret[(quint8)M::ASRX] = {
-      .instr = {.mnemon = M::ASRX, .type = T::R_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
-  ret[(quint8)M::ROLA] = {
-      .instr = {.mnemon = M::ROLA, .type = T::R_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
-  ret[(quint8)M::ROLX] = {
-      .instr = {.mnemon = M::ROLX, .type = T::R_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
-  ret[(quint8)M::RORA] = {
-      .instr = {.mnemon = M::RORA, .type = T::R_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
-  ret[(quint8)M::RORX] = {
-      .instr = {.mnemon = M::RORX, .type = T::R_none, .unary = 1},
-      .mode = AM::NONE,
-      .valid = true};
+  ret[(quint8)M::NOTA] = {.instr = {.mnemon = M::NOTA, .type = T::R_none, .unary = 1}, .mode = AM::NONE, .valid = true};
+  ret[(quint8)M::NOTX] = {.instr = {.mnemon = M::NOTX, .type = T::R_none, .unary = 1}, .mode = AM::NONE, .valid = true};
+  ret[(quint8)M::NEGA] = {.instr = {.mnemon = M::NEGA, .type = T::R_none, .unary = 1}, .mode = AM::NONE, .valid = true};
+  ret[(quint8)M::NEGX] = {.instr = {.mnemon = M::NEGX, .type = T::R_none, .unary = 1}, .mode = AM::NONE, .valid = true};
+  ret[(quint8)M::ASLA] = {.instr = {.mnemon = M::ASLA, .type = T::R_none, .unary = 1}, .mode = AM::NONE, .valid = true};
+  ret[(quint8)M::ASLX] = {.instr = {.mnemon = M::ASLX, .type = T::R_none, .unary = 1}, .mode = AM::NONE, .valid = true};
+  ret[(quint8)M::ASRA] = {.instr = {.mnemon = M::ASRA, .type = T::R_none, .unary = 1}, .mode = AM::NONE, .valid = true};
+  ret[(quint8)M::ASRX] = {.instr = {.mnemon = M::ASRX, .type = T::R_none, .unary = 1}, .mode = AM::NONE, .valid = true};
+  ret[(quint8)M::ROLA] = {.instr = {.mnemon = M::ROLA, .type = T::R_none, .unary = 1}, .mode = AM::NONE, .valid = true};
+  ret[(quint8)M::ROLX] = {.instr = {.mnemon = M::ROLX, .type = T::R_none, .unary = 1}, .mode = AM::NONE, .valid = true};
+  ret[(quint8)M::RORA] = {.instr = {.mnemon = M::RORA, .type = T::R_none, .unary = 1}, .mode = AM::NONE, .valid = true};
+  ret[(quint8)M::RORX] = {.instr = {.mnemon = M::RORX, .type = T::R_none, .unary = 1}, .mode = AM::NONE, .valid = true};
 
   add_ix({.mnemon = M::BR, .type = T::A_ix, .unary = 0});
   add_ix({.mnemon = M::BRLE, .type = T::A_ix, .unary = 0});
@@ -328,20 +268,16 @@ struct ISA_EXPORT Pep10 {
   static bool isUType(Mnemonic mnemonic);
   static bool isRType(Mnemonic mnemonic);
   static bool isAType(Mnemonic mnemonic);
-  static bool isValidATypeAddressingMode(Mnemonic mnemonic,
-                                         AddressingMode addr);
+  static bool isValidATypeAddressingMode(Mnemonic mnemonic, AddressingMode addr);
   static bool isAAAType(Mnemonic mnemonic);
-  static bool isValidAAATypeAddressingMode(Mnemonic mnemonic,
-                                           AddressingMode addr);
+  static bool isValidAAATypeAddressingMode(Mnemonic mnemonic, AddressingMode addr);
   static bool isRAAAType(Mnemonic mnemonic);
-  static bool isValidRAAATypeAddressingMode(Mnemonic mnemonic,
-                                            AddressingMode addr);
+  static bool isValidRAAATypeAddressingMode(Mnemonic mnemonic, AddressingMode addr);
   static bool isValidAddressingMode(Mnemonic mnemonic, AddressingMode addr);
 
   static bool requiresAddressingMode(Mnemonic mnemonic);
   static bool canElideAddressingMode(Mnemonic mnemonic, AddressingMode addr);
-  constexpr static std::array<Opcode, 256> opcodeLUT =
-      detail::pep10::initOpcodes();
+  constexpr static std::array<Opcode, 256> opcodeLUT = detail::pep10::initOpcodes();
   static QSet<QString> legalDirectives();
   static bool isLegalDirective(QString directive);
 };


### PR DESCRIPTION
Moving `A` to `SP` without first saving `SP` is almost universally a mistake. The value in `A` can usually be re-created in a handful of instructions. The value of `SP` tracks the entire run of a program. Failure to first preserve `SP` will make it nearly impossible to re-enter the OS after main returns.

I drew some inspiration from `C++17` for changing a `MOV` to a `SWAP`. In `C++17` a `[[nodiscard]]` attribute was added.
It warns the user if they don't explicit capture the return value in variable. This can be used to help prevent leaking raw pointers across returns. The programmer may choose to explicitly (void) the return value, but they are required to do *something* with it.

In a similar way, we could swap `A` and `SP` rather than copying from `A` to `SP`. The programmer will be required to do *something* with the old SP value.

It saves ~1 byte in the OS.
The most important benefit is in the instruction set not providing you an unnecessary tool to crash your OS with.

Previous SP/A movement mnemonics:
- `MOVASP`
- `MOVSPA`

Proposed mnemonics:
- `MOVSPA`
- `SWAPSPA`

Mnemonic names not chosen:
- `XCHG*`, `EX*` style mnemonics not used because the X in the name may be confusing
- `SWPSPA` not used because we have 7 chars for mnemonics, and `SWAPSPA` sounds nicer.
- `SWAPASP` not used to keep parity with `MOVSPA`.

This commit re-arranges the opcode space so that all `MOV*` instructions are before `SWAPSPA`. 
It also fixes unit tests that depend on boot flags position. 
Closes #444.