### PR TITLE
Update contributors, licenses on "About" pane

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,3 +7,5 @@ IncludeCategories:
     CaseSensitive: false
   - Regex: '.*'
     Priority: 2
+IndentWidth: 2
+TabWidth: 2

--- a/bin/commands/gui.cpp
+++ b/bin/commands/gui.cpp
@@ -14,7 +14,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "gui.hpp"
+
 #if INCLUDE_GUI
+
 #include <QApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
@@ -23,13 +25,16 @@
 #include <QDirIterator>
 #include <QTimer>
 
+#include "../gui/about/registration.hpp"
 #include "../gui/cpu/registermodel.h"
 #include "../gui/cpu/statusbitmodel.h"
 #include "../gui/helpview/registration.hpp"
 #include "memory/hexdump/memorybytemodel.h"
 #include "text/plugin.hpp"
+
 struct default_data : public gui_globals {
   ~default_data() override = default;
+
   StatusBitModel sbm;
   RegisterModel rm;
   MemoryByteModel mbm;
@@ -39,6 +44,7 @@ struct default_data : public gui_globals {
 QSharedPointer<gui_globals> default_init(QQmlApplicationEngine &engine) {
   text::registerTypes("edu.pepp");
   helpview::registerTypes(engine);
+  about::registerTypes(engine);
   //  Note, these models are instantiated in C++ and passed to QML. QML
   //  cannot instantiate these models directly
   qmlRegisterUncreatableType<MemoryByteModel>("edu.pepperdine", 1, 0, "MemByteRoles", "Error: only enums");

--- a/bin/commands/gui.hpp
+++ b/bin/commands/gui.hpp
@@ -19,7 +19,9 @@
 #include "../task.hpp"
 
 #if INCLUDE_GUI
+
 QSharedPointer<gui_globals> default_init(QQmlApplicationEngine &engine);
+
 #endif
 
 struct gui_args {
@@ -31,6 +33,7 @@ struct gui_args {
 };
 
 int gui_main(const gui_args &);
+
 void registerGUI(auto &app, task_factory_t &task, detail::SharedFlags &flags, gui_args &gui_args) {
   static auto gui = app.add_subcommand("gui", "Start Pepp GUI");
   gui->prefix_command(true);

--- a/bin/gui/about/AboutDialog.qml
+++ b/bin/gui/about/AboutDialog.qml
@@ -1,101 +1,136 @@
+/*
+ * Copyright (c) 2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
 import QtQuick.Window
+import edu.pepp 1.0
 
 Dialog {
-  id: aboutDialog
-  title: qsTr("About Pep/10")
-  modal: true
-  dim: false
-  focus: true
+    id: aboutDialog
+    title: qsTr("About Pep/10")
+    modal: true
+    dim: false
+    focus: true
 
-  implicitWidth: 500
-  implicitHeight: 800
+    implicitWidth: 500
+    implicitHeight: 800
 
-  standardButtons: Dialog.Ok
-  width: Math.min(implicitWidth * 1.1, parent.width * .5)
-  height: Math.min(implicitHeight, parent.height * .75)
-  anchors.centerIn: parent
-
-  //  Figure contents
-  ScrollView {
-    anchors.fill: parent
-
-    Column {
-      spacing: 10
-
-      Text {
-        text: qsTr("<html><h2>Pep/10 version %1</h2> <a href=\"https://www.pepperdine.edu//\">Check for updates</a><br></html>").arg(Qt.application.version)
-        onLinkActivated: Qt.openUrlExternally(link)
-        MouseArea {
-          anchors.fill: parent
-          acceptedButtons: Qt.NoButton // Don't eat the mouse clicks
-          cursorShape: Qt.PointingHandCursor
-        }
-      }
-
-      Label {
-        text: qsTr("Programmed By:")
-        font.bold: true
-        font.pixelSize: Qt.application.font.pixelSize
-      }
-
-      Label {
-        text: qsTr("Matthew McRaven (Matthew.McRaven@pepperdine.edu)\nJ. Stanley Warford (Stan.Warford@pepperdine.edu)\n")
-        font.pixelSize: Qt.application.font.pixelSize
-      }
-
-      Label {
-        text: qsTr("Previous Contributions By:")
-        font.bold: true
-      }
-
-      Label {
-        width: parent.width
-        wrapMode: Text.WordWrap
-        text: qsTr("David McRaven, Emily Dimpfl, Tip Aroonvatanaporn, Deacon Bradley, Jeff Cook, Nathan Counts, Stuartt Fox, Dave Grue, Justin Haight, Paul Harvey, Hermi Heimgartner, Matt Highfield, Trent Kyono, Malcolm Lipscomb, Brady Lockhart, Adrian Lomas, Ryan Okelberry, Thomas Rampelberg, Mike Spandrio, Jack Thomason, Daniel Walton, Di Wang, Peter Warford, and Matt Wells.\n")
-      }
-
-      Label {
-        text: qsTr("License:")
-        font.bold: true
-        wrapMode: Text.WordWrap
-      }
-
-      Label {
-        text: qsTr("Copyright © 2016 - 2023, J. Stanley Warford, Pepperdine University\n")
-      }
-
-      Label {
-        width: parent.width
-        wrapMode: Text.WordWrap
-        text: qsTr("This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.\n\n")
-      }
-
-      Text {
-        text: qsTr("<html>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.\n\nYou should have received a copy of the GNU General Public License along with this program. If not, see <a href=\"https://www.gnu.org/licenses/.\">https://www.gnu.org/licenses/</a><br/></html>")
-
-        width: parent.width
-        wrapMode: Text.WordWrap
-        onLinkActivated: Qt.openUrlExternally(link)
-        MouseArea {
-          anchors.fill: parent
-          acceptedButtons: Qt.NoButton // Don't eat the mouse clicks
-          cursorShape: Qt.PointingHandCursor
-        }
-      }
-
-      Text {
-        text: qsTr("Pep/10 is programmed using QT. Learn more at <html><a href=\"https://www.qt.io/\">Qt Group</a></html>")
-        wrapMode: Text.WordWrap
-        onLinkActivated: Qt.openUrlExternally(link)
-        MouseArea {
-          anchors.fill: parent
-          acceptedButtons: Qt.NoButton // Don't eat the mouse clicks
-          cursorShape: Qt.PointingHandCursor
-        }
-      }
+    standardButtons: Dialog.Ok
+    width: Math.min(implicitWidth * 1.1, parent.width * .5)
+    height: Math.min(implicitHeight, parent.height * .75)
+    anchors.centerIn: parent
+    FontMetrics {
+        id: fontMetrics
     }
-  } //  ScrollView
+    //  Figure contents
+    ScrollView {
+        anchors.fill: parent
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        contentWidth: parent.width
+        ColumnLayout {
+            anchors.fill: parent
+            Text {
+                Layout.fillWidth: true
+                text: qsTr("<html><h2>Pepp version %1</h2> <a href=\"https://github.com/Matthew-McRaven/Pepp/releases\">Check for updates</a><br></html>").arg(Version.version_str_full)
+                onLinkActivated: Qt.openUrlExternally(link)
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.NoButton // Don't eat the mouse clicks
+                    cursorShape: Qt.PointingHandCursor
+                }
+            }
+            Label {
+                Layout.fillWidth: true
+                text: qsTr("Programmed By:")
+                font.bold: true
+                font.pixelSize: Qt.application.font.pixelSize
+            }
+            Column {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Repeater {
+                    model: Maintainers
+                    Text {
+                        width:parent.width
+                        height: fontMetrics.height
+                        required property string name;
+                        required property string email;
+                        text: name + "  <" + email + ">";
+                    }
+                    height: Maintainers.rowCount * fontMetrics.height
+                }
+            }
+            Label {
+                Layout.fillWidth: true
+                text: qsTr("Previous Contributions By:")
+                font.bold: true
+            }
+
+            Label {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                text: qsTr("David McRaven, Emily Dimpfl, Tip Aroonvatanaporn, Deacon Bradley, Jeff Cook, Nathan Counts, Stuartt Fox, Dave Grue, Justin Haight, Paul Harvey, Hermi Heimgartner, Matt Highfield, Trent Kyono, Malcolm Lipscomb, Brady Lockhart, Adrian Lomas, Ryan Okelberry, Thomas Rampelberg, Mike Spandrio, Jack Thomason, Daniel Walton, Di Wang, Peter Warford, and Matt Wells.\n")
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: qsTr("License:")
+                font.bold: true
+                wrapMode: Text.WordWrap
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: qsTr("Copyright © 2016 - 2024, J. Stanley Warford, Matthew McRaven, Pepperdine University\n")
+            }
+
+            Label {
+                Layout.fillWidth: true
+                width: parent.width
+                wrapMode: Text.WordWrap
+                text: qsTr("This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.\n\n")
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: qsTr("<html>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.\n\nYou should have received a copy of the GNU General Public License along with this program. If not, see <a href=\"https://www.gnu.org/licenses/.\">https://www.gnu.org/licenses/</a><br/></html>")
+
+                width: parent.width
+                wrapMode: Text.WordWrap
+                onLinkActivated: Qt.openUrlExternally(link)
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.NoButton // Don't eat the mouse clicks
+                    cursorShape: Qt.PointingHandCursor
+                }
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: qsTr("Pep/10 is programmed using QT. Learn more at <html><a href=\"https://www.qt.io/\">Qt Group</a></html>")
+                wrapMode: Text.WordWrap
+                onLinkActivated: Qt.openUrlExternally(link)
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.NoButton // Don't eat the mouse clicks
+                    cursorShape: Qt.PointingHandCursor
+                }
+            }
+        }
+    } //  ScrollView
 }

--- a/bin/gui/about/AboutDialog.qml
+++ b/bin/gui/about/AboutDialog.qml
@@ -135,13 +135,14 @@ Dialog {
                 onCurrentIndexChanged: {
                     let index = model.index(currentIndex, 0)
                     projectLicense.text = model.data(index, ProjectRoles.LicenseText)
-                    let url = model.data(index, ProjectRoles.Url)
+                    let url = model.data(index, ProjectRoles.URL)
                     projectUrl.text = "<a href=\"" + url + "\">" + url + "</a>"
                 }
             }
-            Label {
+            Text {
                 Layout.fillWidth: true
                 id: projectUrl
+                onLinkActivated: Qt.openUrlExternally(link)
             }
             TextArea {
                 Layout.fillWidth: true

--- a/bin/gui/about/AboutDialog.qml
+++ b/bin/gui/about/AboutDialog.qml
@@ -84,7 +84,7 @@ Dialog {
             Label {
                 Layout.fillWidth: true
                 wrapMode: Text.WordWrap
-                text: qsTr("David McRaven, Emily Dimpfl, Tip Aroonvatanaporn, Deacon Bradley, Jeff Cook, Nathan Counts, Stuartt Fox, Dave Grue, Justin Haight, Paul Harvey, Hermi Heimgartner, Matt Highfield, Trent Kyono, Malcolm Lipscomb, Brady Lockhart, Adrian Lomas, Ryan Okelberry, Thomas Rampelberg, Mike Spandrio, Jack Thomason, Daniel Walton, Di Wang, Peter Warford, and Matt Wells.\n")
+                text: Contributors.text
             }
 
             Label {

--- a/bin/gui/about/AboutDialog.qml
+++ b/bin/gui/about/AboutDialog.qml
@@ -45,9 +45,18 @@ Dialog {
         ColumnLayout {
             anchors.fill: parent
             Text {
-                Layout.fillWidth: true
-                text: qsTr("<html><h2>Pepp version %1</h2> <a href=\"https://github.com/Matthew-McRaven/Pepp/releases\">Check for updates</a><br></html>").arg(Version.version_str_full)
+
+                id: title
                 onLinkActivated: (link) => {Qt.openUrlExternally(link)}
+                // Too much text to assign in binding, so build it inline instead.
+                Component.onCompleted: {
+                    let line0 = "<h2>Pepp version %1</h2> <a href=\"https://github.com/Matthew-McRaven/Pepp/releases\">Check for updates</a>.  ".arg(Version.version_str_full)
+                    let url = "https://github.com/Matthew-McRaven/Pepp/commit/"+Version.git_sha
+                    let line1 = "Based on <a href=\"" + url + "\">"
+                    line1 += Version.git_tag !== "unknown"? Version.git_tag : Version.git_sha.substring(0, 7)
+                    line1 += "</a>."
+                    text = line0+line1
+                }
             }
             Label {
                 Layout.fillWidth: true

--- a/bin/gui/about/AboutDialog.qml
+++ b/bin/gui/about/AboutDialog.qml
@@ -47,12 +47,7 @@ Dialog {
             Text {
                 Layout.fillWidth: true
                 text: qsTr("<html><h2>Pepp version %1</h2> <a href=\"https://github.com/Matthew-McRaven/Pepp/releases\">Check for updates</a><br></html>").arg(Version.version_str_full)
-                onLinkActivated: Qt.openUrlExternally(link)
-                MouseArea {
-                    anchors.fill: parent
-                    acceptedButtons: Qt.NoButton // Don't eat the mouse clicks
-                    cursorShape: Qt.PointingHandCursor
-                }
+                onLinkActivated: (link) => {Qt.openUrlExternally(link)}
             }
             Label {
                 Layout.fillWidth: true
@@ -142,7 +137,7 @@ Dialog {
             Text {
                 Layout.fillWidth: true
                 id: projectUrl
-                onLinkActivated: Qt.openUrlExternally(link)
+                onLinkActivated: (link) => {Qt.openUrlExternally(link)}
             }
             TextArea {
                 Layout.fillWidth: true

--- a/bin/gui/about/AboutDialog.qml
+++ b/bin/gui/about/AboutDialog.qml
@@ -66,7 +66,7 @@ Dialog {
                 Repeater {
                     model: Maintainers
                     Text {
-                        width:parent.width
+                        width: parent.width
                         height: fontMetrics.height
                         required property string name;
                         required property string email;
@@ -89,16 +89,14 @@ Dialog {
 
             Label {
                 Layout.fillWidth: true
-                text: qsTr("License:")
+                text: qsTr("Legal:")
                 font.bold: true
                 wrapMode: Text.WordWrap
             }
-
             Label {
                 Layout.fillWidth: true
                 text: qsTr("Copyright © 2016 - 2024, J. Stanley Warford, Matthew McRaven, Pepperdine University\n")
             }
-
             Label {
                 Layout.fillWidth: true
                 width: parent.width
@@ -119,17 +117,36 @@ Dialog {
                     cursorShape: Qt.PointingHandCursor
                 }
             }
-
-            Text {
+            Label {
                 Layout.fillWidth: true
-                text: qsTr("Pep/10 is programmed using QT. Learn more at <html><a href=\"https://www.qt.io/\">Qt Group</a></html>")
+                text: qsTr("Dependencies:")
+                font.bold: true
                 wrapMode: Text.WordWrap
-                onLinkActivated: Qt.openUrlExternally(link)
-                MouseArea {
-                    anchors.fill: parent
-                    acceptedButtons: Qt.NoButton // Don't eat the mouse clicks
-                    cursorShape: Qt.PointingHandCursor
+            }
+            ComboBox {
+                Component.onCompleted: {onCurrentIndexChanged()}
+
+                Layout.fillWidth: true
+                id: projectCombo
+                model: Projects
+                currentIndex: 0
+                textRole: "name"
+
+                onCurrentIndexChanged: {
+                    let index = model.index(currentIndex, 0)
+                    projectLicense.text = model.data(index, ProjectRoles.LicenseText)
+                    let url = model.data(index, ProjectRoles.Url)
+                    projectUrl.text = "<a href=\"" + url + "\">" + url + "</a>"
                 }
+            }
+            Label {
+                Layout.fillWidth: true
+                id: projectUrl
+            }
+            TextArea {
+                Layout.fillWidth: true
+                id: projectLicense
+                readOnly: true
             }
         }
     } //  ScrollView

--- a/bin/gui/about/AboutDialog.qml
+++ b/bin/gui/about/AboutDialog.qml
@@ -47,15 +47,17 @@ Dialog {
             Text {
 
                 id: title
-                onLinkActivated: (link) => {Qt.openUrlExternally(link)}
+                onLinkActivated: (link) => {
+                    Qt.openUrlExternally(link)
+                }
                 // Too much text to assign in binding, so build it inline instead.
                 Component.onCompleted: {
                     let line0 = "<h2>Pepp version %1</h2> <a href=\"https://github.com/Matthew-McRaven/Pepp/releases\">Check for updates</a>.  ".arg(Version.version_str_full)
-                    let url = "https://github.com/Matthew-McRaven/Pepp/commit/"+Version.git_sha
+                    let url = "https://github.com/Matthew-McRaven/Pepp/commit/" + Version.git_sha
                     let line1 = "Based on <a href=\"" + url + "\">"
-                    line1 += Version.git_tag !== "unknown"? Version.git_tag : Version.git_sha.substring(0, 7)
+                    line1 += Version.git_tag !== "unknown" ? Version.git_tag : Version.git_sha.substring(0, 7)
                     line1 += "</a>."
-                    text = line0+line1
+                    text = line0 + line1
                 }
             }
             Label {
@@ -146,7 +148,9 @@ Dialog {
             Text {
                 Layout.fillWidth: true
                 id: projectUrl
-                onLinkActivated: (link) => {Qt.openUrlExternally(link)}
+                onLinkActivated: (link) => {
+                    Qt.openUrlExternally(link)
+                }
             }
             TextArea {
                 Layout.fillWidth: true

--- a/bin/gui/about/contributors.cpp
+++ b/bin/gui/about/contributors.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "contributors.hpp"
+#include "help/about/pepp.hpp"
+
+Maintainer::Maintainer(QString name, QString email, QObject *parent) : QObject(parent), _name(name), _email(email) {}
+QString Maintainer::name() { return _name; }
+QString Maintainer::email() { return _email; }
+
+MaintainerList::MaintainerList(QList<Maintainer *> list, QObject *parent) : QAbstractListModel(parent), _list(list) {
+  // Must re-parent to avoid memory leaks.
+  for (auto *item : list)
+    item->setParent(this);
+}
+
+int MaintainerList::rowCount(const QModelIndex &parent) const { return _list.size(); }
+
+QVariant MaintainerList::data(const QModelIndex &index, int role) const {
+  int row = index.row();
+  if (!index.isValid() || row < 0 || row >= _list.size())
+    return QVariant();
+  auto *item = _list.at(row);
+  switch (role) {
+  case NAME:
+    return item->name();
+  case EMAIL:
+    return item->email();
+  default:
+    return QVariant();
+  }
+}
+
+QHash<int, QByteArray> MaintainerList::roleNames() const {
+  QHash<int, QByteArray> roles;
+  roles[NAME] = "name";
+  roles[EMAIL] = "email";
+  return roles;
+}
+
+Contributors::Contributors(QObject *parent) : QObject(parent) {}
+
+QString Contributors::text() {
+  static QString text = about::contributors().join(", ");
+  return text;
+}

--- a/bin/gui/about/contributors.hpp
+++ b/bin/gui/about/contributors.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <QtCore>
+
+class Maintainer : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(QString name READ name CONSTANT)
+  Q_PROPERTY(QString email READ email CONSTANT)
+public:
+  Maintainer(QString name, QString email, QObject *parent = nullptr);
+  ~Maintainer() override = default;
+  QString name();
+  QString email();
+
+private:
+  QString _name = {}, _email = {};
+};
+class MaintainerList : public QAbstractListModel {
+public:
+  enum { NAME = Qt::UserRole, EMAIL = Qt::UserRole + 1 };
+  explicit MaintainerList(QList<Maintainer *> list, QObject *parent = nullptr);
+  ~MaintainerList() override = default;
+  int rowCount(const QModelIndex &parent) const override;
+  QVariant data(const QModelIndex &index, int role) const override;
+  QHash<int, QByteArray> roleNames() const override;
+
+private:
+  QList<Maintainer *> _list;
+};
+
+class Contributors : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(QString text READ text CONSTANT)
+public:
+  explicit Contributors(QObject *parent = nullptr);
+  ~Contributors() override = default;
+  static QString text();
+};

--- a/bin/gui/about/projects.cpp
+++ b/bin/gui/about/projects.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "projects.hpp"
+
+ProjectRoles *ProjectRoles::instance() {
+  static ProjectRoles *_instance = new ProjectRoles;
+  return _instance;
+}
+
+Projects::Projects(QObject *parent) : QAbstractListModel(parent), _deps(about::dependencies()) {}
+
+int Projects::rowCount(const QModelIndex &parent) const { return _deps.size(); }
+
+QVariant Projects::data(const QModelIndex &index, int role) const {
+  using enum ProjectRoles::RoleNames;
+  int row = index.row();
+  if (!index.isValid() || row < 0 || row >= _deps.size())
+    return QVariant();
+  auto &item = _deps.at(row);
+  switch (role) {
+  case Name:
+    return item.name;
+  case URL:
+    return item.url;
+  case LicenseName:
+    return item.licenseName;
+  case LicenseSPDXID:
+    return item.licenseSPDXID;
+  case LicenseText:
+    return item.licenseText;
+  case DevDependency:
+    return item.devDependency;
+  default:
+    return QVariant();
+  }
+}
+
+QHash<int, QByteArray> Projects::roleNames() const {
+  using enum ProjectRoles::RoleNames;
+  QHash<int, QByteArray> roles = {
+      {Name, "name"},
+      {URL, "url"},
+      {LicenseName, "licenseName"},
+      {LicenseSPDXID, "licenseSPDXID"},
+      {LicenseText, "licenseText"},
+      {DevDependency, "devDependency"},
+  };
+  return roles;
+}

--- a/bin/gui/about/projects.hpp
+++ b/bin/gui/about/projects.hpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QtCore>
+#include "help/about/dependencies.hpp"
+
+class ProjectRoles : public QObject {
+  Q_OBJECT
+public:
+  enum RoleNames {
+    Name = Qt::UserRole,
+    URL = Qt::UserRole + 1,
+    LicenseName = Qt::UserRole + 2,
+    LicenseSPDXID = Qt::UserRole + 3,
+    LicenseText = Qt::UserRole + 4,
+    DevDependency = Qt::UserRole + 5
+  };
+  Q_ENUM(RoleNames)
+  static ProjectRoles *instance();
+  // Prevent copying and assignment
+  ProjectRoles(const ProjectRoles &) = delete;
+  ProjectRoles &operator=(const ProjectRoles &) = delete;
+
+private:
+  ProjectRoles() : QObject(nullptr) {}
+};
+
+class Projects : public QAbstractListModel {
+  Q_OBJECT
+public:
+  explicit Projects(QObject *parent = nullptr);
+  ~Projects() override = default;
+  int rowCount(const QModelIndex &parent) const override;
+  QVariant data(const QModelIndex &index, int role) const override;
+  QHash<int, QByteArray> roleNames() const override;
+
+private:
+  QList<about::Dependency> _deps;
+};

--- a/bin/gui/about/registration.cpp
+++ b/bin/gui/about/registration.cpp
@@ -70,6 +70,52 @@ QString Contributors::text() {
   return text;
 }
 
+ProjectRoles *ProjectRoles::instance() {
+  static ProjectRoles *_instance = new ProjectRoles;
+  return _instance;
+}
+
+Projects::Projects(QObject *parent) : QAbstractListModel(parent), _deps(about::dependencies()) {}
+
+int Projects::rowCount(const QModelIndex &parent) const { return _deps.size(); }
+
+QVariant Projects::data(const QModelIndex &index, int role) const {
+  using enum ProjectRoles::RoleNames;
+  int row = index.row();
+  if (!index.isValid() || row < 0 || row >= _deps.size())
+    return QVariant();
+  auto &item = _deps.at(row);
+  switch (role) {
+  case Name:
+    return item.name;
+  case URL:
+    return item.url;
+  case LicenseName:
+    return item.licenseName;
+  case LicenseSPDXID:
+    return item.licenseSPDXID;
+  case LicenseText:
+    return item.licenseText;
+  case DevDependency:
+    return item.devDependency;
+  default:
+    return QVariant();
+  }
+}
+
+QHash<int, QByteArray> Projects::roleNames() const {
+  using enum ProjectRoles::RoleNames;
+  QHash<int, QByteArray> roles = {
+      {Name, "name"},
+      {URL, "url"},
+      {LicenseName, "licenseName"},
+      {LicenseSPDXID, "licenseSPDXID"},
+      {LicenseText, "licenseText"},
+      {DevDependency, "devDependency"},
+  };
+  return roles;
+}
+
 namespace about {
 void registerTypes(QQmlApplicationEngine &engine) {
   qmlRegisterSingletonType<Version>("edu.pepp", 1, 0, "Version",
@@ -88,5 +134,8 @@ void registerTypes(QQmlApplicationEngine &engine) {
   });
   qmlRegisterSingletonType<Contributors>("edu.pepp", 1, 0, "Contributors",
                                          [](QQmlEngine *, QJSEngine *) { return new Contributors(); });
+  qmlRegisterUncreatableType<ProjectRoles>("edu.pepp", 1, 0, "ProjectRoles", "Error: only enums");
+  qmlRegisterSingletonType<Projects>("edu.pepp", 1, 0, "Projects",
+                                     [](QQmlEngine *, QJSEngine *) { return new Projects(); });
 }
 } // namespace about

--- a/bin/gui/about/registration.cpp
+++ b/bin/gui/about/registration.cpp
@@ -15,9 +15,68 @@
  */
 
 #include "registration.hpp"
-#include "book_item_model.hpp"
+#include "help/about/pepp.hpp"
+#include "help/about/version.hpp"
+
+Version::Version(QObject *parent) : QObject(parent) {}
+QString Version::git_sha() { return about::g_GIT_SHA1(); }
+QString Version::git_tag() { return about::g_GIT_TAG(); }
+bool Version::git_dirty() { return about::g_GIT_LOCAL_CHANGES(); }
+int Version::version_major() { return about::g_MAJOR_VERSION(); }
+int Version::version_minor() { return about::g_MINOR_VERSION(); }
+int Version::version_patch() { return about::g_PATCH_VERSION(); }
+QString Version::version_str_full() {
+  return u"%1.%2.%3"_qs.arg(version_major()).arg(version_minor()).arg(version_patch());
+}
+
+Maintainer::Maintainer(QString name, QString email, QObject *parent) : QObject(parent), _name(name), _email(email) {}
+QString Maintainer::name() { return _name; }
+QString Maintainer::email() { return _email; }
 
 namespace about {
-    void registerTypes(QQmlApplicationEngine &engine) {
+void registerTypes(QQmlApplicationEngine &engine) {
+  qmlRegisterSingletonType<Version>("edu.pepp", 1, 0, "Version",
+                                    [](QQmlEngine *, QJSEngine *) { return new Version(); });
+  qmlRegisterUncreatableType<Maintainer>("edu.pepp", 1, 0, "Maintainer", "Must be created from C++");
+  qmlRegisterSingletonType<QList<Maintainer *>>("edu.pepp", 1, 0, "Maintainers", [](QQmlEngine *, QJSEngine *) {
+    // Need global scope ::, or it picks up about::Maintainer
+    QList<::Maintainer *> maintainers{};
+    for (const auto &maintainer : about::maintainers()) {
+      auto *item = new ::Maintainer(maintainer.name, maintainer.email, nullptr);
+      maintainers.push_back(item);
     }
+    // Class assumes ownership of objects via modifying parent pointer.
+    auto owning = new MaintainerList(maintainers);
+    return owning;
+  });
+}
 } // namespace about
+MaintainerList::MaintainerList(QList<Maintainer *> list, QObject *parent) : QAbstractListModel(parent), _list(list) {
+  // Must re-parent to avoid memory leaks.
+  for (auto *item : list)
+    item->setParent(this);
+}
+
+int MaintainerList::rowCount(const QModelIndex &parent) const { return _list.size(); }
+
+QVariant MaintainerList::data(const QModelIndex &index, int role) const {
+  int row = index.row();
+  if (!index.isValid() || row < 0 || row >= _list.size())
+    return QVariant();
+  auto *item = _list.at(row);
+  switch (role) {
+  case NAME:
+    return item->name();
+  case EMAIL:
+    return item->email();
+  default:
+    return QVariant();
+  }
+}
+
+QHash<int, QByteArray> MaintainerList::roleNames() const {
+  QHash<int, QByteArray> roles;
+  roles[NAME] = "name";
+  roles[EMAIL] = "email";
+  return roles;
+}

--- a/bin/gui/about/registration.cpp
+++ b/bin/gui/about/registration.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023-2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "registration.hpp"
+#include "book_item_model.hpp"
+
+namespace about {
+    void registerTypes(QQmlApplicationEngine &engine) {
+    }
+} // namespace about

--- a/bin/gui/about/registration.cpp
+++ b/bin/gui/about/registration.cpp
@@ -15,106 +15,11 @@
  */
 
 #include "registration.hpp"
+#include "contributors.hpp"
 #include "help/about/pepp.hpp"
 #include "help/about/version.hpp"
-
-Version::Version(QObject *parent) : QObject(parent) {}
-QString Version::git_sha() { return about::g_GIT_SHA1(); }
-QString Version::git_tag() { return about::g_GIT_TAG(); }
-bool Version::git_dirty() { return about::g_GIT_LOCAL_CHANGES(); }
-int Version::version_major() { return about::g_MAJOR_VERSION(); }
-int Version::version_minor() { return about::g_MINOR_VERSION(); }
-int Version::version_patch() { return about::g_PATCH_VERSION(); }
-QString Version::version_str_full() {
-  return u"%1.%2.%3"_qs.arg(version_major()).arg(version_minor()).arg(version_patch());
-}
-
-Maintainer::Maintainer(QString name, QString email, QObject *parent) : QObject(parent), _name(name), _email(email) {}
-QString Maintainer::name() { return _name; }
-QString Maintainer::email() { return _email; }
-
-MaintainerList::MaintainerList(QList<Maintainer *> list, QObject *parent) : QAbstractListModel(parent), _list(list) {
-  // Must re-parent to avoid memory leaks.
-  for (auto *item : list)
-    item->setParent(this);
-}
-
-int MaintainerList::rowCount(const QModelIndex &parent) const { return _list.size(); }
-
-QVariant MaintainerList::data(const QModelIndex &index, int role) const {
-  int row = index.row();
-  if (!index.isValid() || row < 0 || row >= _list.size())
-    return QVariant();
-  auto *item = _list.at(row);
-  switch (role) {
-  case NAME:
-    return item->name();
-  case EMAIL:
-    return item->email();
-  default:
-    return QVariant();
-  }
-}
-
-QHash<int, QByteArray> MaintainerList::roleNames() const {
-  QHash<int, QByteArray> roles;
-  roles[NAME] = "name";
-  roles[EMAIL] = "email";
-  return roles;
-}
-
-Contributors::Contributors(QObject *parent) : QObject(parent) {}
-
-QString Contributors::text() {
-  static QString text = about::contributors().join(", ");
-  return text;
-}
-
-ProjectRoles *ProjectRoles::instance() {
-  static ProjectRoles *_instance = new ProjectRoles;
-  return _instance;
-}
-
-Projects::Projects(QObject *parent) : QAbstractListModel(parent), _deps(about::dependencies()) {}
-
-int Projects::rowCount(const QModelIndex &parent) const { return _deps.size(); }
-
-QVariant Projects::data(const QModelIndex &index, int role) const {
-  using enum ProjectRoles::RoleNames;
-  int row = index.row();
-  if (!index.isValid() || row < 0 || row >= _deps.size())
-    return QVariant();
-  auto &item = _deps.at(row);
-  switch (role) {
-  case Name:
-    return item.name;
-  case URL:
-    return item.url;
-  case LicenseName:
-    return item.licenseName;
-  case LicenseSPDXID:
-    return item.licenseSPDXID;
-  case LicenseText:
-    return item.licenseText;
-  case DevDependency:
-    return item.devDependency;
-  default:
-    return QVariant();
-  }
-}
-
-QHash<int, QByteArray> Projects::roleNames() const {
-  using enum ProjectRoles::RoleNames;
-  QHash<int, QByteArray> roles = {
-      {Name, "name"},
-      {URL, "url"},
-      {LicenseName, "licenseName"},
-      {LicenseSPDXID, "licenseSPDXID"},
-      {LicenseText, "licenseText"},
-      {DevDependency, "devDependency"},
-  };
-  return roles;
-}
+#include "projects.hpp"
+#include "version.hpp"
 
 namespace about {
 void registerTypes(QQmlApplicationEngine &engine) {

--- a/bin/gui/about/registration.hpp
+++ b/bin/gui/about/registration.hpp
@@ -19,6 +19,52 @@
 #include <QtCore>
 #include "commands/gui.hpp"
 
+class Version : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(QString git_sha READ git_sha CONSTANT)
+  Q_PROPERTY(QString git_tag READ git_tag CONSTANT)
+  Q_PROPERTY(bool git_dirty READ git_dirty CONSTANT)
+  Q_PROPERTY(int version_major READ version_major CONSTANT)
+  Q_PROPERTY(int version_minor READ version_minor CONSTANT)
+  Q_PROPERTY(int version_patch READ version_patch CONSTANT)
+  Q_PROPERTY(QString version_str_full READ version_str_full CONSTANT)
+public:
+  explicit Version(QObject *parent = nullptr);
+  ~Version() override = default;
+  static QString git_sha();
+  static QString git_tag();
+  static bool git_dirty();
+  static int version_major();
+  static int version_minor();
+  static int version_patch();
+  static QString version_str_full();
+};
+class Maintainer : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(QString name READ name CONSTANT)
+  Q_PROPERTY(QString email READ email CONSTANT)
+public:
+  Maintainer(QString name, QString email, QObject *parent = nullptr);
+  ~Maintainer() override = default;
+  QString name();
+  QString email();
+
+private:
+  QString _name = {}, _email = {};
+};
+class MaintainerList : public QAbstractListModel {
+public:
+  enum { NAME = Qt::UserRole, EMAIL = Qt::UserRole + 1 };
+  explicit MaintainerList(QList<Maintainer *> list, QObject *parent = nullptr);
+  ~MaintainerList() override = default;
+  int rowCount(const QModelIndex &parent) const override;
+  QVariant data(const QModelIndex &index, int role) const override;
+  QHash<int, QByteArray> roleNames() const override;
+
+private:
+  QList<Maintainer *> _list;
+};
+
 namespace about {
-    void registerTypes(QQmlApplicationEngine &engine);
+void registerTypes(QQmlApplicationEngine &engine);
 }

--- a/bin/gui/about/registration.hpp
+++ b/bin/gui/about/registration.hpp
@@ -64,6 +64,14 @@ public:
 private:
   QList<Maintainer *> _list;
 };
+class Contributors : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(QString text READ text CONSTANT)
+public:
+  explicit Contributors(QObject *parent = nullptr);
+  ~Contributors() override = default;
+  static QString text();
+};
 
 namespace about {
 void registerTypes(QQmlApplicationEngine &engine);

--- a/bin/gui/about/registration.hpp
+++ b/bin/gui/about/registration.hpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <QQmlApplicationEngine>
+#include <QtCore>
+#include "commands/gui.hpp"
+
+namespace about {
+    void registerTypes(QQmlApplicationEngine &engine);
+}

--- a/bin/gui/about/registration.hpp
+++ b/bin/gui/about/registration.hpp
@@ -18,6 +18,7 @@
 #include <QQmlApplicationEngine>
 #include <QtCore>
 #include "commands/gui.hpp"
+#include "help/about/dependencies.hpp"
 
 class Version : public QObject {
   Q_OBJECT
@@ -64,6 +65,7 @@ public:
 private:
   QList<Maintainer *> _list;
 };
+
 class Contributors : public QObject {
   Q_OBJECT
   Q_PROPERTY(QString text READ text CONSTANT)
@@ -71,6 +73,40 @@ public:
   explicit Contributors(QObject *parent = nullptr);
   ~Contributors() override = default;
   static QString text();
+};
+
+class ProjectRoles : public QObject {
+  Q_OBJECT
+public:
+  enum RoleNames {
+    Name = Qt::UserRole,
+    URL = Qt::UserRole + 1,
+    LicenseName = Qt::UserRole + 2,
+    LicenseSPDXID = Qt::UserRole + 3,
+    LicenseText = Qt::UserRole + 4,
+    DevDependency = Qt::UserRole + 5
+  };
+  Q_ENUM(RoleNames)
+  static ProjectRoles *instance();
+  // Prevent copying and assignment
+  ProjectRoles(const ProjectRoles &) = delete;
+  ProjectRoles &operator=(const ProjectRoles &) = delete;
+
+private:
+  ProjectRoles() : QObject(nullptr) {}
+};
+
+class Projects : public QAbstractListModel {
+  Q_OBJECT
+public:
+  explicit Projects(QObject *parent = nullptr);
+  ~Projects() override = default;
+  int rowCount(const QModelIndex &parent) const override;
+  QVariant data(const QModelIndex &index, int role) const override;
+  QHash<int, QByteArray> roleNames() const override;
+
+private:
+  QList<about::Dependency> _deps;
 };
 
 namespace about {

--- a/bin/gui/about/version.cpp
+++ b/bin/gui/about/version.cpp
@@ -13,11 +13,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#pragma once
 
-#include <QQmlApplicationEngine>
-#include <QtCore>
+#include "version.hpp"
+#include "help/about/version.hpp"
 
-namespace about {
-void registerTypes(QQmlApplicationEngine &engine);
+Version::Version(QObject *parent) : QObject(parent) {}
+QString Version::git_sha() { return about::g_GIT_SHA1(); }
+QString Version::git_tag() { return about::g_GIT_TAG(); }
+bool Version::git_dirty() { return about::g_GIT_LOCAL_CHANGES(); }
+int Version::version_major() { return about::g_MAJOR_VERSION(); }
+int Version::version_minor() { return about::g_MINOR_VERSION(); }
+int Version::version_patch() { return about::g_PATCH_VERSION(); }
+QString Version::version_str_full() {
+  return u"%1.%2.%3"_qs.arg(version_major()).arg(version_minor()).arg(version_patch());
 }

--- a/bin/gui/about/version.hpp
+++ b/bin/gui/about/version.hpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <QtCore>
+
+class Version : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(QString git_sha READ git_sha CONSTANT)
+  Q_PROPERTY(QString git_tag READ git_tag CONSTANT)
+  Q_PROPERTY(bool git_dirty READ git_dirty CONSTANT)
+  Q_PROPERTY(int version_major READ version_major CONSTANT)
+  Q_PROPERTY(int version_minor READ version_minor CONSTANT)
+  Q_PROPERTY(int version_patch READ version_patch CONSTANT)
+  Q_PROPERTY(QString version_str_full READ version_str_full CONSTANT)
+public:
+  explicit Version(QObject *parent = nullptr);
+  ~Version() override = default;
+  static QString git_sha();
+  static QString git_tag();
+  static bool git_dirty();
+  static int version_major();
+  static int version_minor();
+  static int version_patch();
+  static QString version_str_full();
+};

--- a/logic/help/about/pepp.cpp
+++ b/logic/help/about/pepp.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include "pepp.hpp"
 #include "help/about/version.hpp"
 #include "read.hpp"
@@ -53,5 +69,5 @@ QString about::licenseNotice() {
 }
 
 QString about::versionString() {
-  return u"%1.%2.%3"_qs.arg(about::g_MAJOR_VERSION).arg(about::g_MINOR_VERSION).arg(about::g_PATCH_VERSION);
+  return u"%1.%2.%3"_qs.arg(about::g_MAJOR_VERSION()).arg(about::g_MINOR_VERSION()).arg(about::g_PATCH_VERSION());
 }

--- a/logic/help/about/version.cpp.in
+++ b/logic/help/about/version.cpp.in
@@ -1,12 +1,28 @@
+/*
+ * Copyright (c) 2023-2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include "help/about/version.hpp"
 #define GIT_SHA1 "@GIT_SHA1@"
 const char GIT_SHA1_tmp[] = GIT_SHA1;
-const char * const about::g_GIT_SHA1(){return GIT_SHA1_tmp;}
+const char *const about::g_GIT_SHA1() { return GIT_SHA1_tmp; }
 
 #define GIT_TAG "@GIT_TAG@"
 const char GIT_TAG_tmp[] = GIT_TAG;
-const char * const about::g_GIT_TAG(){return GIT_TAG_tmp;}
-// Must supress formatting, or `@` will be separated from name, preventing
+const char *const about::g_GIT_TAG() { return GIT_TAG_tmp; }
+// Must suppress formatting, or `@` will be separated from name, preventing
 // CMake substitutions.
 // clang-format off
 #define VERSION_MAJOR @Pepp_VERSION_MAJOR@
@@ -15,7 +31,7 @@ const char * const about::g_GIT_TAG(){return GIT_TAG_tmp;}
 #define CLEAN @GIT_CLEAN@
 // clang-format on
 
-extern const int about::g_MAJOR_VERSION = VERSION_MAJOR;
-extern const int about::g_MINOR_VERSION = VERSION_MINOR;
-extern const int about::g_PATCH_VERSION = VERSION_PATCH;
-extern const bool about::g_GIT_LOCAL_CHANGES = CLEAN;
+int about::g_MAJOR_VERSION() { return VERSION_MAJOR; }
+int about::g_MINOR_VERSION() { return VERSION_MINOR; }
+int about::g_PATCH_VERSION() { return VERSION_PATCH; }
+bool about::g_GIT_LOCAL_CHANGES() { return CLEAN; }

--- a/logic/help/about/version.hpp
+++ b/logic/help/about/version.hpp
@@ -1,9 +1,25 @@
+/*
+ * Copyright (c) 2023-2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 namespace about {
-const char* const g_GIT_SHA1();
-const char* const g_GIT_TAG();
-extern const int g_MAJOR_VERSION;
-extern const int g_MINOR_VERSION;
-extern const int g_PATCH_VERSION;
-extern const bool g_GIT_LOCAL_CHANGES;
+const char *const g_GIT_SHA1();
+const char *const g_GIT_TAG();
+int g_MAJOR_VERSION();
+int g_MINOR_VERSION();
+int g_PATCH_VERSION();
+bool g_GIT_LOCAL_CHANGES();
 } // namespace about


### PR DESCRIPTION
Replaces the current placeholder "about" screen.
The new pane contains the following:
- Project version (taken from CMake)
- SHA from which the project was built
- Developer list
- Assorted past contributors
- A list of all dependencies and their licenses

Future improvements:
- Build date
- Build toolset