### PR TITLE
Rename C++ dependency model in "About" pane

### DIFF
--- a/bin/gui/about/AboutDialog.qml
+++ b/bin/gui/about/AboutDialog.qml
@@ -134,14 +134,14 @@ Dialog {
 
                 Layout.fillWidth: true
                 id: projectCombo
-                model: Projects
+                model: Dependencies
                 currentIndex: 0
                 textRole: "name"
 
                 onCurrentIndexChanged: {
                     let index = model.index(currentIndex, 0)
-                    projectLicense.text = model.data(index, ProjectRoles.LicenseText)
-                    let url = model.data(index, ProjectRoles.URL)
+                    projectLicense.text = model.data(index, DependencyRoles.LicenseText)
+                    let url = model.data(index, DependencyRoles.URL)
                     projectUrl.text = "<a href=\"" + url + "\">" + url + "</a>"
                 }
             }

--- a/bin/gui/about/dependencies.cpp
+++ b/bin/gui/about/dependencies.cpp
@@ -14,19 +14,19 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "projects.hpp"
+#include "dependencies.hpp"
 
-ProjectRoles *ProjectRoles::instance() {
-  static ProjectRoles *_instance = new ProjectRoles;
+DependencyRoles *DependencyRoles::instance() {
+  static DependencyRoles *_instance = new DependencyRoles;
   return _instance;
 }
 
-Projects::Projects(QObject *parent) : QAbstractListModel(parent), _deps(about::dependencies()) {}
+Dependencies::Dependencies(QObject *parent) : QAbstractListModel(parent), _deps(about::dependencies()) {}
 
-int Projects::rowCount(const QModelIndex &parent) const { return _deps.size(); }
+int Dependencies::rowCount(const QModelIndex &parent) const { return _deps.size(); }
 
-QVariant Projects::data(const QModelIndex &index, int role) const {
-  using enum ProjectRoles::RoleNames;
+QVariant Dependencies::data(const QModelIndex &index, int role) const {
+  using enum DependencyRoles::RoleNames;
   int row = index.row();
   if (!index.isValid() || row < 0 || row >= _deps.size())
     return QVariant();
@@ -49,8 +49,8 @@ QVariant Projects::data(const QModelIndex &index, int role) const {
   }
 }
 
-QHash<int, QByteArray> Projects::roleNames() const {
-  using enum ProjectRoles::RoleNames;
+QHash<int, QByteArray> Dependencies::roleNames() const {
+  using enum DependencyRoles::RoleNames;
   QHash<int, QByteArray> roles = {
       {Name, "name"},
       {URL, "url"},

--- a/bin/gui/about/dependencies.hpp
+++ b/bin/gui/about/dependencies.hpp
@@ -19,7 +19,7 @@
 #include <QtCore>
 #include "help/about/dependencies.hpp"
 
-class ProjectRoles : public QObject {
+class DependencyRoles : public QObject {
   Q_OBJECT
 public:
   enum RoleNames {
@@ -31,20 +31,20 @@ public:
     DevDependency = Qt::UserRole + 5
   };
   Q_ENUM(RoleNames)
-  static ProjectRoles *instance();
+  static DependencyRoles *instance();
   // Prevent copying and assignment
-  ProjectRoles(const ProjectRoles &) = delete;
-  ProjectRoles &operator=(const ProjectRoles &) = delete;
+  DependencyRoles(const DependencyRoles &) = delete;
+  DependencyRoles &operator=(const DependencyRoles &) = delete;
 
 private:
-  ProjectRoles() : QObject(nullptr) {}
+  DependencyRoles() : QObject(nullptr) {}
 };
 
-class Projects : public QAbstractListModel {
+class Dependencies : public QAbstractListModel {
   Q_OBJECT
 public:
-  explicit Projects(QObject *parent = nullptr);
-  ~Projects() override = default;
+  explicit Dependencies(QObject *parent = nullptr);
+  ~Dependencies() override = default;
   int rowCount(const QModelIndex &parent) const override;
   QVariant data(const QModelIndex &index, int role) const override;
   QHash<int, QByteArray> roleNames() const override;

--- a/bin/gui/about/registration.cpp
+++ b/bin/gui/about/registration.cpp
@@ -16,9 +16,9 @@
 
 #include "registration.hpp"
 #include "contributors.hpp"
+#include "dependencies.hpp"
 #include "help/about/pepp.hpp"
 #include "help/about/version.hpp"
-#include "projects.hpp"
 #include "version.hpp"
 
 namespace about {
@@ -39,8 +39,8 @@ void registerTypes(QQmlApplicationEngine &engine) {
   });
   qmlRegisterSingletonType<Contributors>("edu.pepp", 1, 0, "Contributors",
                                          [](QQmlEngine *, QJSEngine *) { return new Contributors(); });
-  qmlRegisterUncreatableType<ProjectRoles>("edu.pepp", 1, 0, "ProjectRoles", "Error: only enums");
-  qmlRegisterSingletonType<Projects>("edu.pepp", 1, 0, "Projects",
-                                     [](QQmlEngine *, QJSEngine *) { return new Projects(); });
+  qmlRegisterUncreatableType<DependencyRoles>("edu.pepp", 1, 0, "DependencyRoles", "Error: only enums");
+  qmlRegisterSingletonType<Dependencies>("edu.pepp", 1, 0, "Dependencies",
+                                     [](QQmlEngine *, QJSEngine *) { return new Dependencies(); });
 }
 } // namespace about


### PR DESCRIPTION
"Projects" is an overloaded term that usually refers to the active document in our application. "Dependency" remove this ambiguity.