### PR TITLE
Add library for shared constants

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -35,7 +35,7 @@ make_target(
         DEPENDS
         TextFlow cli about macro pas builtins isa targets sim
         Qt6::Core Qt6::Gui Qt::Qml Qt::Quick Qt::QuickControls2
-        Qt::Widgets test-lib-all memory text
+        Qt::Widgets test-lib-all constants memory text
 )
 
 target_compile_definitions(pepp PRIVATE "INCLUDE_GUI=1")

--- a/bin/commands/gui.cpp
+++ b/bin/commands/gui.cpp
@@ -30,6 +30,7 @@
 #include "../gui/cpu/statusbitmodel.h"
 #include "../gui/helpview/registration.hpp"
 #include "../gui/object/registration.hpp"
+#include "constants/registration.hpp"
 #include "help/about/version.hpp"
 #include "memory/hexdump/memorybytemodel.h"
 #include "text/plugin.hpp"
@@ -44,6 +45,7 @@ struct default_data : public gui_globals {
 };
 
 QSharedPointer<gui_globals> default_init(QQmlApplicationEngine &engine) {
+  constants::registerTypes("edu.pepp");
   text::registerTypes("edu.pepp");
   helpview::registerTypes(engine);
   object::registerTypes(engine);

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -1,7 +1,8 @@
+add_subdirectory(constants)
 add_subdirectory(text)
 add_subdirectory(memory)
 
-set(ui_targets "memory;text")
+set(ui_targets "constants;memory;text")
 
 
 if (APPLE)

--- a/ui/constants/CMakeLists.txt
+++ b/ui/constants/CMakeLists.txt
@@ -1,0 +1,27 @@
+file(GLOB_RECURSE sources_and_tests CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/*.cpp" "${CMAKE_CURRENT_LIST_DIR}/*.hpp")
+file(GLOB_RECURSE tests CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/test/*.cpp" "${CMAKE_CURRENT_LIST_DIR}/test/*.hpp")
+file(GLOB_RECURSE old_sources CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/__old/*.cpp")
+list(APPEND sources ${sources_and_tests})
+list(REMOVE_ITEM sources ${tests})
+list(REMOVE_ITEM sources ${old_sources})
+
+# GLOB_RECURSE uses abs paths, QML_FILES expects relative paths. This blob converts from abs to rel.
+file(GLOB_RECURSE abs_qml_sources CONFIGURE_DEPENDS "main.qml" "*.qml")
+SET(rel_qml_sources, "")
+foreach (f_abs IN LISTS abs_qml_sources)
+    file(RELATIVE_PATH f_rel "${CMAKE_CURRENT_LIST_DIR}" ${f_abs})
+    list(APPEND rel_qml_sources "${f_rel}")
+endforeach ()
+
+qt_add_qml_module(constants
+        URI "constants"
+        VERSION 0.1
+        QML_FILES
+        ${rel_qml_sources}
+        RESOURCE_PREFIX /ui
+        SOURCES
+        ${sources}
+)
+
+target_compile_definitions(constants PRIVATE "CONSTANTS_LIBRARY")
+target_link_libraries(constants PUBLIC Qt6::Core Qt6::Gui Qt6::Quick)

--- a/ui/constants/constants_global.hpp
+++ b/ui/constants/constants_global.hpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023-2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QtCore/QtGlobal>
+
+#if defined(CONSTANTS_LIBRARY)
+#define CONSTANTS_EXPORT Q_DECL_EXPORT
+#else
+#define CONSTANTS_EXPORT Q_DECL_IMPORT
+#endif

--- a/ui/constants/registration.cpp
+++ b/ui/constants/registration.cpp
@@ -1,0 +1,8 @@
+#include "registration.hpp"
+#include <qqml.h>
+#include "./utils.hpp"
+
+void constants::registerTypes(const char *uri) {
+  qmlRegisterUncreatableType<constants::Abstraction>(uri, 1, 0, "Abstraction", error_only_enums);
+  qmlRegisterUncreatableType<constants::Architecture>(uri, 1, 0, "Architecture", error_only_enums);
+}

--- a/ui/constants/registration.hpp
+++ b/ui/constants/registration.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include <QObject>
+namespace constants {
+
+class Abstraction : public QObject {
+  Q_GADGET
+public:
+  Abstraction(QObject *parent = nullptr) : QObject(parent) {}
+  enum Value {
+    // LG1 = 1,
+    MC2 = 2,
+    ISA3 = 3,
+    OS4 = 4,
+    ASMB5 = 5,
+    // HOL6 = 6,
+    // APP7 = 7,
+  };
+  Q_ENUM(Value);
+};
+
+class Architecture : public QObject {
+  Q_GADGET
+public:
+  Architecture(QObject *parent = nullptr) : QObject(parent) {}
+  enum Value {
+    // Pep8 = 8,
+    // Pep9 = 9,
+    Pep10 = 10,
+    RISCV32I = 128,
+  };
+  Q_ENUM(Value);
+};
+
+void registerTypes(const char *uri);
+}; // namespace constants

--- a/ui/constants/utils.hpp
+++ b/ui/constants/utils.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#define SHARED_CONSTANT(type, name, value)                                                                             \
+  static inline const type name = value;                                                                               \
+  Q_PROPERTY(type name MEMBER name CONSTANT)
+
+namespace constants {
+static const char *error_only_enums = "Only contains enums";
+}


### PR DESCRIPTION
Examples of shared constants are supported architectures and levels of abstraction.

Needed for #395 to communicate selected level of abstraction.