### PR TITLE
Add byte converters

### DIFF
--- a/bin/gui/main.qml
+++ b/bin/gui/main.qml
@@ -185,8 +185,13 @@ ApplicationWindow {
                     text: qsTr("⋮")
                     font: menuFont.font
                 }
-                Rectangle {
-                    color: "transparent"
+                ToolSeparator {}
+                Help.Converters {
+                    initialValue: 'a'.charCodeAt(0)
+                    mnemonics: currentProject?.mnemonics ?? null
+                }
+
+                Item {
                     Layout.fillWidth: true
                 }
             }

--- a/ui/help/Converters.qml
+++ b/ui/help/Converters.qml
@@ -1,0 +1,97 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import edu.pepp 1.0
+
+Item {
+    id: wrapper
+    required property int initialValue
+    property alias mnemonics: mnemonic.model
+    property alias font: metrics.font
+    property int value: initialValue
+    function setValue(value) {
+        if (value >= 0 && value <= 255)
+            wrapper.value = value
+    }
+
+    height: childrenRect.height
+
+    FontMetrics {
+        id: metrics
+    }
+
+    Row {
+        TextField {
+            id: dec
+            text: `${wrapper.value}`
+            maximumLength: 4
+            width: metrics.averageCharacterWidth * maximumLength * 1.5
+            font: metrics.font
+            onEditingFinished: {
+                wrapper.setValue(parseInt(dec.text, 10))
+            }
+            validator: RegularExpressionValidator {
+                regularExpression: /(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)/
+            }
+        }
+        TextField {
+            id: hex
+            text: `0x${wrapper.value.toString(16).padStart(2, '0')}`
+            maximumLength: 4
+            width: metrics.averageCharacterWidth * maximumLength * 1.5
+            font: metrics.font
+            onEditingFinished: {
+                wrapper.setValue(parseInt(hex.text, 16))
+            }
+            validator: RegularExpressionValidator {
+                regularExpression: /0x[0-9a-fA-F]{1,2}/
+            }
+        }
+        TextField {
+            id: bin
+            text: `${wrapper.value.toString(2).padStart(8, '0')}`
+            maximumLength: 8
+            width: metrics.averageCharacterWidth * maximumLength * 1.5
+            font: metrics.font
+            onEditingFinished: {
+                wrapper.setValue(parseInt(bin.text, 2))
+            }
+            validator: RegularExpressionValidator {
+                regularExpression: /[01]{1,8}/
+            }
+        }
+        TextField {
+            CharCheck {
+                id: check
+            }
+            id: ascii
+            text: check.isCharSupported(String.fromCharCode(wrapper.value),
+                                        ascii.font) ? String.fromCharCode(
+                                                          wrapper.value) : "�"
+            maximumLength: 1
+            width: metrics.averageCharacterWidth * maximumLength * 4
+            font: check.noMerge(metrics.font)
+            onEditingFinished: {
+                wrapper.setValue(ascii.text.charCodeAt(0) ?? 0)
+            }
+        }
+        ComboBox {
+            id: mnemonic
+            textRole: 'display'
+            // Disable if model is not set.
+            visible: model ?? false
+            // 7=>max mnemonic length, 2=>", ", 3=>max addr mode length
+            width: metrics.averageCharacterWidth * (7 + 2 + 3) * 1.5
+            font: metrics.font
+            currentIndex: model?.indexFromOpcode(wrapper.value) ?? -1
+            // Force mnemonic to re-compute current index by re-setting value.
+            onModelChanged: wrapper.setValue(wrapper.value)
+            // Use on-activated to avoid binding loop from onCurrentIndexChanged.
+            // activated only triggers on user interaction, wherease currentIndexChanged
+            // triggers on any (programatic) update to currentIndex.
+            onActivated: {
+                wrapper.setValue(model.opcodeFromIndex(currentIndex))
+            }
+        }
+    }
+}

--- a/ui/help/charcheck.cpp
+++ b/ui/help/charcheck.cpp
@@ -1,0 +1,17 @@
+#include "charcheck.hpp"
+
+#include <QFontMetrics>
+
+CharCheck::CharCheck(QObject *parent) : QObject{parent} {}
+
+bool CharCheck::isCharSupported(const QString &character, const QFont &font) {
+  if (character.isEmpty())
+    return true;
+  return QFontMetrics(font).inFont(character.at(0));
+}
+
+QFont CharCheck::noMerge(const QFont &font) {
+  QFont ret = font;
+  ret.setStyleStrategy(QFont::StyleStrategy::NoFontMerging);
+  return ret;
+}

--- a/ui/help/charcheck.hpp
+++ b/ui/help/charcheck.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <QObject>
+
+class CharCheck : public QObject {
+  Q_OBJECT
+public:
+  explicit CharCheck(QObject *parent = nullptr);
+  Q_INVOKABLE bool isCharSupported(const QString &character, const QFont &font);
+  Q_INVOKABLE QFont noMerge(const QFont &font);
+};

--- a/ui/help/registration.cpp
+++ b/ui/help/registration.cpp
@@ -17,11 +17,13 @@
 #include "registration.hpp"
 #include "book_item_model.hpp"
 #include "bookfiltermodel.hpp"
+#include "charcheck.hpp"
 
 namespace help {
 void registerTypes(const char *uri) {
   // TODO: Missing translations
   qmlRegisterType<builtins::BookModel>(uri, 1, 0, "BookModel");
   qmlRegisterType<builtins::BookFilterModel>(uri, 1, 0, "BookFilterModel");
+  qmlRegisterType<CharCheck>(uri, 1, 0, "CharCheck");
 }
 } // namespace help

--- a/ui/project/CMakeLists.txt
+++ b/ui/project/CMakeLists.txt
@@ -19,4 +19,4 @@ qt_add_qml_module(project
 )
 
 target_compile_definitions(project PRIVATE "PROJECT_LIBRARY")
-target_link_libraries(project PUBLIC Qt6::Core Qt6::Gui Qt6::Quick ui_utils memory cpu)
+target_link_libraries(project PUBLIC Qt6::Core Qt6::Gui Qt6::Quick ui_utils memory cpu isa)

--- a/ui/project/aproject.cpp
+++ b/ui/project/aproject.cpp
@@ -4,7 +4,7 @@
 
 Pep10_ISA::Pep10_ISA(QVariant delegate, QObject *parent)
     : QObject(parent), _delegate(delegate), _memory(new ArrayRawMemory(0x10000, this)),
-      _registers(new RegisterModel(this)), _flags(new FlagModel(this)) {
+      _registers(new RegisterModel(this)), _flags(new FlagModel(this)), _mnemonics(new Pep10OpcodeModel(this)) {
   QQmlEngine::setObjectOwnership(_memory, QQmlEngine::CppOwnership);
   QQmlEngine::setObjectOwnership(_registers, QQmlEngine::CppOwnership);
   using RF = QSharedPointer<RegisterFormatter>;

--- a/ui/project/aproject.hpp
+++ b/ui/project/aproject.hpp
@@ -6,6 +6,7 @@
 #include "cpu/registermodel.hpp"
 #include "cpu/statusbitmodel.hpp"
 #include "memory/hexdump/rawmemory.hpp"
+#include "opcodemodel.hpp"
 #include "utils/constants.hpp"
 
 namespace project {
@@ -114,6 +115,7 @@ class Pep10_ISA final : public QObject {
   Q_PROPERTY(QString objectCodeText READ objectCodeText WRITE setObjectCodeText NOTIFY objectCodeTextChanged);
   Q_PROPERTY(ARawMemory *memory READ memory CONSTANT)
   Q_PROPERTY(RegisterModel *registers MEMBER _registers CONSTANT)
+  Q_PROPERTY(Pep10OpcodeModel *mnemonics MEMBER _mnemonics CONSTANT)
   Q_PROPERTY(FlagModel *flags MEMBER _flags CONSTANT)
 public:
   explicit Pep10_ISA(QVariant delegate, QObject *parent = nullptr);
@@ -142,6 +144,7 @@ private:
   ArrayRawMemory *_memory = nullptr;
   RegisterModel *_registers = nullptr;
   FlagModel *_flags = nullptr;
+  Pep10OpcodeModel *_mnemonics = nullptr;
 };
 
 // Factory to ensure class invariants of project are maintained.

--- a/ui/project/opcodemodel.cpp
+++ b/ui/project/opcodemodel.cpp
@@ -1,0 +1,50 @@
+#include "opcodemodel.hpp"
+#include "isa/pep10.hpp"
+Pep10OpcodeModel::Pep10OpcodeModel(QObject *parent) : QAbstractListModel(parent) {
+  static const auto mnemonicEnum = QMetaEnum::fromType<isa::Pep10::Mnemonic>();
+  static const auto addressEnum = QMetaEnum::fromType<isa::Pep10::AddressingMode>();
+  for (int it = 0; it < 256; it++) {
+    auto op = isa::Pep10::opcodeLUT[it];
+    if (!op.valid)
+      continue;
+    QString formatted;
+    if (op.instr.unary) {
+      formatted = QString(mnemonicEnum.valueToKey((int)op.instr.mnemon)).toUpper();
+    } else {
+      formatted = u"%1, %2"_qs.arg(QString(mnemonicEnum.valueToKey((int)op.instr.mnemon)).toUpper(),
+                                   QString(addressEnum.valueToKey((int)op.mode)).toLower());
+    }
+    _mnemonics[_mnemonics.size()] = {formatted, it};
+  }
+}
+
+int Pep10OpcodeModel::rowCount(const QModelIndex &parent) const {
+  if (parent.isValid())
+    return 0;
+  return _mnemonics.size();
+}
+
+QVariant Pep10OpcodeModel::data(const QModelIndex &index, int role) const {
+  if (!index.isValid())
+    return QVariant();
+  switch (role) {
+  case Qt::DisplayRole:
+    return _mnemonics[index.row()].first;
+  }
+  return {};
+}
+
+qsizetype Pep10OpcodeModel::indexFromOpcode(quint8 opcode) const {
+
+  auto result =
+      std::find_if(_mnemonics.begin(), _mnemonics.end(), [&](const auto &pair) { return pair.second == opcode; });
+  if (result == _mnemonics.end())
+    return 0;
+  return result.key();
+}
+
+quint8 Pep10OpcodeModel::opcodeFromIndex(qsizetype index) const {
+  if (_mnemonics.contains(index))
+    return _mnemonics[index].second;
+  return -1;
+}

--- a/ui/project/opcodemodel.hpp
+++ b/ui/project/opcodemodel.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QAbstractListModel>
+
+class Pep10OpcodeModel : public QAbstractListModel {
+  Q_OBJECT
+
+public:
+  explicit Pep10OpcodeModel(QObject *parent = nullptr);
+
+  // Basic functionality:
+  int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+
+  QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+  // Returns a row in the model if it maps to an opcode, or -1 if not.
+  Q_INVOKABLE qsizetype indexFromOpcode(quint8 opcode) const;
+  Q_INVOKABLE quint8 opcodeFromIndex(qsizetype index) const;
+
+private:
+  // Store the opcode's mnemonic string and intege value.
+  using T = std::pair<QString, quint8>;
+  // Map index/rows to opcodes.
+  using MapT = QMap<qsizetype, T>;
+  MapT _mnemonics = {};
+};

--- a/ui/project/registration.cpp
+++ b/ui/project/registration.cpp
@@ -1,10 +1,12 @@
 #include "registration.hpp"
 #include <qqml.h>
 #include "./aproject.hpp"
+#include "opcodemodel.hpp"
 #include "utils/strings.hpp"
 
 static const char *error_only_project = "Can only be created through Project::";
 void project::registerTypes(const char *uri) {
   qmlRegisterUncreatableType<Pep10_ISA>(uri, 1, 0, "Pep10ISA", error_only_project);
   qmlRegisterType<ProjectModel>(uri, 1, 0, "ProjectModel");
+  qmlRegisterType<Pep10OpcodeModel>(uri, 1, 0, "Pep10OpcodeModel");
 }


### PR DESCRIPTION
These linked byte converters replicate existing functionality from all Pep/9 applications.

It includes a selectable opcode converter, which is an improvement over the static opcode text of Pep/9.
Additionally, it will use a placeholder glyph for unprintable characters.

Closes #286.
Provides opcode decoder for #389.  