### PR TITLE
Add arbitrary "scroll to:" controls

### DIFF
--- a/ui/memory/hexdump/memorybytemodel.cpp
+++ b/ui/memory/hexdump/memorybytemodel.cpp
@@ -117,6 +117,8 @@ int MemoryByteModel::columnCount(const QModelIndex &parent) const {
   return column_->Total();
 }
 
+int MemoryByteModel::bytesPerRow() const { return column_->bytesPerLine(); }
+
 QVariant MemoryByteModel::data(const QModelIndex &index, int role) const {
   if (!index.isValid())
     return QVariant();

--- a/ui/memory/hexdump/memorybytemodel.hpp
+++ b/ui/memory/hexdump/memorybytemodel.hpp
@@ -38,9 +38,10 @@ class MEMORY_EXPORT MemoryByteModel : public QAbstractTableModel {
 
   Q_PROPERTY(MemoryColumns *Column READ column CONSTANT)
   Q_PROPERTY(ARawMemory *memory READ memory WRITE setMemory NOTIFY memoryChanged)
-  Q_PROPERTY(int BytesPerRow READ rowCount NOTIFY dimensionsChanged)
-  Q_PROPERTY(int BytesPerColumn READ columnCount NOTIFY dimensionsChanged)
   Q_PROPERTY(OpcodeModel *mnemonics MEMBER mnemonics_ NOTIFY mnemonicsChanged)
+  Q_PROPERTY(int bytesPerRow READ bytesPerRow NOTIFY dimensionsChanged)
+  // Q_PROPERTY(int columns READ columnCount NOTIFY dimensionsChanged)
+  // Q_PROPERTY(int rows READ rowCount NOTIFY dimensionsChanged)
 
 public:
   // Define the role names to be used
@@ -72,15 +73,10 @@ public:
   //  Basic functionality: dimentions of table in QML view
   int rowCount(const QModelIndex &parent = QModelIndex()) const override;
   int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+  int bytesPerRow() const;
 
-  //  Read table data
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-
-  //  Editable:
-  //  Set data through model
   bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
-
-  //  Indicate what operations can occur on a given column or cell
   Qt::ItemFlags flags(const QModelIndex &index) const override;
 
   //  Custom functions available to Qml

--- a/ui/memory/hexdump/memorycolumns.hpp
+++ b/ui/memory/hexdump/memorycolumns.hpp
@@ -33,6 +33,7 @@ public: //  Required by QML
     quint8 CellEnd() const { return cellEnd_; };
     quint8 Ascii() const { return ascii_; };
     quint8 Total() const { return total_; };
+    quint8 bytesPerLine() const { return cellEnd_ - cellStart_ + 1; }
 
     //  If model changes width, adjust column numbers
     void setNumBytesPerLine(const quint8 bytesPerLine)

--- a/ui/project/Pep10ISA.qml
+++ b/ui/project/Pep10ISA.qml
@@ -65,16 +65,31 @@ Item {
         }
         Loader {
             id: loader
-            source: "qrc:/ui/memory/hexdump/MemoryDump.qml"
+            Component.onCompleted: {
+                const props = {
+                    "memory": project.memory,
+                    "mnemonics": project.mnemonics
+                }
+                // Construction sets current address to 0, which propogates back to project.
+                // Must reject changes in current address until component is fully rendered.
+                con.enabled = false
+                setSource("qrc:/ui/memory/hexdump/MemoryDump.qml", props)
+            }
             visible: mode === "debug"
             asynchronous: true
             SplitView.minimumWidth: 340
             onLoaded: {
-                if (item !== null) {
-                    item.memory = project.memory
-                    item.mnemonics = project.mnemonics
-                }
+                loader.item.scrollToAddress(project.currentAddress)
+                con.enabled = true
             }
+        }
+    }
+    Connections {
+        id: con
+        enabled: false
+        target: loader.item
+        function onCurrentAddressChanged() {
+            project.currentAddress = loader.item.currentAddress
         }
     }
 }

--- a/ui/project/aproject.hpp
+++ b/ui/project/aproject.hpp
@@ -125,6 +125,8 @@ class Pep10_ISA final : public QObject {
   Q_PROPERTY(QVariant delegate MEMBER _delegate NOTIFY delegateChanged)
   Q_PROPERTY(QString objectCodeText READ objectCodeText WRITE setObjectCodeText NOTIFY objectCodeTextChanged);
   Q_PROPERTY(ARawMemory *memory READ memory CONSTANT)
+  // Preserve the current address in the memory dump pane on tab-switch.
+  Q_PROPERTY(quint16 currentAddress MEMBER _currentAddress NOTIFY currentAddressChanged)
   Q_PROPERTY(RegisterModel *registers MEMBER _registers CONSTANT)
   Q_PROPERTY(OpcodeModel *mnemonics READ mnemonics CONSTANT)
   Q_PROPERTY(FlagModel *flags MEMBER _flags CONSTANT)
@@ -148,6 +150,7 @@ public:
 signals:
   void objectCodeTextChanged();
   void delegateChanged();
+  void currentAddressChanged();
 
 private:
   QString _objectCodeText = {};
@@ -156,6 +159,7 @@ private:
   ArrayRawMemory *_memory = nullptr;
   RegisterModel *_registers = nullptr;
   FlagModel *_flags = nullptr;
+  qint16 _currentAddress = 0;
 };
 
 // Factory to ensure class invariants of project are maintained.


### PR DESCRIPTION
A text field is linked to the current row of the table.
SP / PC / TextEdit move the view to the indicated row.
PC/SP accessors will need to be provided by the project.

Current address is "remembered" when switching back to a previous tab.

Closes #389.