### PR TITLE
Fixes from 11 May '24 meeting 

### DIFF
--- a/logic/isa/pep10.hpp
+++ b/logic/isa/pep10.hpp
@@ -131,7 +131,7 @@ constexpr std::array<Opcode, 256> initOpcodes() {
   };
   auto add_all = [&ret](Instruction i) {
     auto base = static_cast<quint8>(i.mnemon);
-    ret[base] = {.instr = i, .mode = AM::I, .valid = true};
+    ret[base] = {.instr = i, .mode = AM::I, .valid = i.type != T::RAAA_noi};
     ret[base + 1] = {.instr = i, .mode = AM::D, .valid = true};
     ret[base + 2] = {.instr = i, .mode = AM::N, .valid = true};
     ret[base + 3] = {.instr = i, .mode = AM::S, .valid = true};

--- a/ui/cpu/RegisterView.qml
+++ b/ui/cpu/RegisterView.qml
@@ -28,6 +28,12 @@ Rectangle {
     FontMetrics {
         id: metrics
     }
+    TextMetrics {
+        id: tm
+        font: metrics.font
+        text: '0'
+    }
+
     RowLayout {
         id: flagsContainer
         anchors.top: parent.top
@@ -52,27 +58,54 @@ Rectangle {
             }
         }
     }
-
-    // TODO: switch to Row+Repeater
-    TableView {
+    ListView {
         id: registers
         anchors.top: flagsContainer.bottom
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.right: parent.right
-        height: contentHeight
-        interactive: false
-
-        columnWidthProvider: function (column) {
-            return (registers.model.columnCharWidth(
-                        column) + 2) * metrics.averageCharacterWidth
-        }
-        delegate: Component {
-            Text {
-                required property bool readOnly
-                required property string display
-                text: display
-                font: metrics.font
+        clip: true
+        spacing: 1
+        contentWidth: parent.width
+        delegate: RowLayout {
+            id: rowDelegate
+            required property int index
+            width: registers.width
+            Repeater {
+                model: registers.model.columnCount()
+                delegate: Rectangle {
+                    id: columnDelegate
+                    required property int index
+                    property int row: rowDelegate.index
+                    property int column: index
+                    property var mindex: registers.model.index(row, column)
+                    property string display: registers.model.data(mindex)
+                    property bool box: registers.model.data(mindex,
+                                                            registers.model.Box)
+                    property bool rightJustify: registers.model.data(
+                                                    mindex,
+                                                    registers.model.RightJustify)
+                    Layout.minimumWidth: Math.max(35, textField.width)
+                    Layout.minimumHeight: textField.height
+                    Layout.fillWidth: true
+                    TextField {
+                        id: textField
+                        background: Rectangle {
+                            color: "transparent"
+                            border.color: "black"
+                            border.width: box ? 1 : 0
+                            radius: 2
+                        }
+                        font: metrics.font
+                        readOnly: true
+                        maximumLength: registers.model.columnCharWidth(column)
+                        anchors.centerIn: columnDelegate
+                        text: display
+                        horizontalAlignment: rightJustify ? Qt.AlignRight : Qt.AlignHCenter
+                        // '0' is a wide character, and tm contains a single '0' in the current font.
+                        width: tm.width * (maximumLength + 3)
+                    }
+                }
             }
         }
     }

--- a/ui/cpu/RegisterView.qml
+++ b/ui/cpu/RegisterView.qml
@@ -61,6 +61,7 @@ Rectangle {
         anchors.left: parent.left
         anchors.right: parent.right
         height: contentHeight
+        interactive: false
 
         columnWidthProvider: function (column) {
             return (registers.model.columnCharWidth(

--- a/ui/cpu/RegisterView.qml
+++ b/ui/cpu/RegisterView.qml
@@ -41,17 +41,18 @@ Rectangle {
         anchors.right: parent.right
         Repeater {
             id: flags
-            delegate: Column {
+            delegate: Row {
                 required property string display
                 required property bool value
                 Layout.fillWidth: true
                 Layout.fillHeight: true
+                spacing: -5
                 Text {
-                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
                     text: display
                 }
                 CheckBox {
-                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
                     enabled: false
                     checked: value
                 }

--- a/ui/cpu/registermodel.cpp
+++ b/ui/cpu/registermodel.cpp
@@ -22,12 +22,12 @@ QVariant RegisterModel::data(const QModelIndex &index, int role) const
     const auto col = index.column();
     auto item = _data[row][col];
     switch (role) {
-    case static_cast<int>(Roles::ReadOnly):
-      return item->readOnly();
-      break;
+    case static_cast<int>(Roles::Box):
+      return !item->readOnly();
+    case static_cast<int>(Roles::RightJustify):
+      return index.column() == 0;
     case Qt::DisplayRole:
       return item->format();
-      break;
     }
     return {};
 }
@@ -40,15 +40,19 @@ void RegisterModel::appendFormatters(QVector<QSharedPointer<RegisterFormatter>> 
 }
 
 qsizetype RegisterModel::columnCharWidth(int column) const {
+  if (column >= _cols)
+    return 0;
   qsizetype ret = 0;
   for (const auto &row : _data) {
-    ret = std::max(ret, row[column]->length());
+    auto rowMax = row[column]->length();
+    ret = std::max(ret, rowMax);
   }
   return ret;
 }
 
 QHash<int, QByteArray> RegisterModel::roleNames() const {
   static const QHash<int, QByteArray> ret{{Qt::DisplayRole, "display"},
-                                          {static_cast<int>(Roles::ReadOnly), "readOnly"}};
+                                          {static_cast<int>(Roles::Box), "box"},
+                                          {static_cast<int>(Roles::RightJustify), "rightJustify"}};
   return ret;
 }

--- a/ui/cpu/registermodel.hpp
+++ b/ui/cpu/registermodel.hpp
@@ -26,12 +26,11 @@ private:
 //  Read only class for change in Register values
 class CPU_EXPORT RegisterModel : public QAbstractTableModel {
   Q_OBJECT
+  Q_PROPERTY(Roles Box MEMBER _box CONSTANT);
+  Q_PROPERTY(Roles RightJustify MEMBER _justify CONSTANT);
 
 public:
-  // In practice, all are RO, but we use it to add or remove a box outline.
-  enum class Roles {
-    ReadOnly = Qt::UserRole + 1,
-  };
+  enum class Roles { Box = Qt::UserRole + 1, RightJustify };
   Q_ENUM(Roles)
 
   explicit RegisterModel(QObject *parent = nullptr);
@@ -48,6 +47,8 @@ public:
 private:
   uint32_t _cols = 0;
   QVector<QVector<QSharedPointer<RegisterFormatter>>> _data;
+  const Roles _box = Roles::Box;
+  const Roles _justify = Roles::RightJustify;
 
 protected:  //  Role Names must be under protected
   QHash<int, QByteArray> roleNames() const override;

--- a/ui/project/aproject.cpp
+++ b/ui/project/aproject.cpp
@@ -11,7 +11,9 @@ struct Pep10OpcodeInit {
       if (!op.valid)
         continue;
       QString formatted;
-      if (op.mode != isa::Pep10::AddressingMode::NONE) {
+      // instr.unary indicates if the instruction is hardware-unary (i.e., it could be a nonunary trap SCALL).
+      // This is why we test the addressing mode instead, since nonunary traps will have an addressing mode.
+      if (op.mode == isa::Pep10::AddressingMode::NONE) {
         formatted = QString(mnemonicEnum.valueToKey((int)op.instr.mnemon)).toUpper();
       } else {
         formatted = u"%1, %2"_qs.arg(QString(mnemonicEnum.valueToKey((int)op.instr.mnemon)).toUpper(),

--- a/ui/project/aproject.cpp
+++ b/ui/project/aproject.cpp
@@ -11,7 +11,7 @@ struct Pep10OpcodeInit {
       if (!op.valid)
         continue;
       QString formatted;
-      if (op.instr.unary) {
+      if (op.mode != isa::Pep10::AddressingMode::NONE) {
         formatted = QString(mnemonicEnum.valueToKey((int)op.instr.mnemon)).toUpper();
       } else {
         formatted = u"%1, %2"_qs.arg(QString(mnemonicEnum.valueToKey((int)op.instr.mnemon)).toUpper(),

--- a/ui/project/aproject.hpp
+++ b/ui/project/aproject.hpp
@@ -62,7 +62,11 @@ private:
 
 struct UnsignedDecFormatter : public RegisterFormatter {
   explicit UnsignedDecFormatter(std::function<uint64_t()> fn, uint16_t byteCount = 2)
-      : _fn(fn), _bytes(byteCount), _len(std::floor(std::log10(byteCount))), _mask(byteCount) {}
+      : _fn(fn), _bytes(byteCount), _mask(byteCount) {
+    auto maxNum = std::pow(2, 8 * byteCount);
+    auto digits = std::ceil(std::log10(maxNum));
+    _len = digits;
+  }
   ~UnsignedDecFormatter() override = default;
   QString format() const override { return QString::number(_mask & _fn()); }
   bool readOnly() const override { return false; }
@@ -76,7 +80,11 @@ private:
 
 struct SignedDecFormatter : public RegisterFormatter {
   explicit SignedDecFormatter(std::function<int64_t()> fn, uint16_t byteCount = 2)
-      : _fn(fn), _bytes(byteCount), _len(std::floor(std::log10(byteCount))), _mask(mask(byteCount)) {}
+      : _fn(fn), _bytes(byteCount), _mask(mask(byteCount)) {
+    auto maxNum = std::pow(2, 8 * byteCount);
+    auto digits = std::ceil(std::log10(maxNum));
+    _len = digits + 1;
+  }
   ~SignedDecFormatter() override = default;
   QString format() const override {
     if (auto v = _fn(); v < 0)
@@ -85,7 +93,7 @@ struct SignedDecFormatter : public RegisterFormatter {
     return QString::number(_mask & _fn());
   }
   bool readOnly() const override { return false; }
-  qsizetype length() const override { return 1 + _len; }
+  qsizetype length() const override { return _len; }
 
 private:
   uint16_t _bytes = 0, _len = 0;
@@ -110,7 +118,7 @@ struct MnemonicFormatter : public RegisterFormatter {
   explicit MnemonicFormatter(std::function<QString()> fn) : _fn(fn) {}
   ~MnemonicFormatter() override = default;
   QString format() const override { return _fn(); }
-  bool readOnly() const override { return false; }
+  bool readOnly() const override { return true; }
   qsizetype length() const override { return 7 + 2 + 3; }
 
 private:

--- a/ui/utils/opcodemodel.cpp
+++ b/ui/utils/opcodemodel.cpp
@@ -12,24 +12,38 @@ QVariant OpcodeModel::data(const QModelIndex &index, int role) const {
     return QVariant();
   switch (role) {
   case Qt::DisplayRole:
-    return _mnemonics[index.row()].first;
+    return _mnemonics[index.row()].mnemonic_addr;
   }
   return {};
 }
 
 qsizetype OpcodeModel::indexFromOpcode(quint8 opcode) const {
-
   auto result =
-      std::find_if(_mnemonics.begin(), _mnemonics.end(), [&](const auto &pair) { return pair.second == opcode; });
+      std::find_if(_mnemonics.begin(), _mnemonics.end(), [&](const auto &pair) { return pair.opcode == opcode; });
   if (result == _mnemonics.end())
     return 0;
-  return result.key();
+  return result - _mnemonics.begin();
 }
 
 quint8 OpcodeModel::opcodeFromIndex(qsizetype index) const {
-  if (_mnemonics.contains(index))
-    return _mnemonics[index].second;
+  if (index > 0 && index < _mnemonics.size())
+    return _mnemonics[index].opcode;
   return -1;
 }
 
-void OpcodeModel::appendRow(QString mnemonic, quint8 opcode) { _mnemonics[_mnemonics.size()] = {mnemonic, opcode}; }
+void OpcodeModel::appendRow(QString mnemonic, quint8 opcode) {
+  auto indexOfComma = mnemonic.indexOf(',');
+  Opcode toInsert{
+      .opcode = opcode,
+      .mnemonic_addr = mnemonic,
+      .mnemonic_only = indexOfComma == -1 ? QStringView(mnemonic) : QStringView(mnemonic).left(indexOfComma),
+  };
+  // Sort the vector alphabetically on mnemonic, and on opcode for addressing modes.
+  auto index =
+      std::lower_bound(_mnemonics.begin(), _mnemonics.end(), toInsert, [](const auto &pair, const auto &toInsert) {
+        if (pair.mnemonic_only == toInsert.mnemonic_only)
+          return pair.opcode < toInsert.opcode;
+        return pair.mnemonic_only < toInsert.mnemonic_only;
+      });
+  _mnemonics.insert(index, toInsert);
+}

--- a/ui/utils/opcodemodel.cpp
+++ b/ui/utils/opcodemodel.cpp
@@ -21,7 +21,7 @@ qsizetype OpcodeModel::indexFromOpcode(quint8 opcode) const {
   auto result =
       std::find_if(_mnemonics.begin(), _mnemonics.end(), [&](const auto &pair) { return pair.opcode == opcode; });
   if (result == _mnemonics.end())
-    return 0;
+    return -1;
   return result - _mnemonics.begin();
 }
 

--- a/ui/utils/opcodemodel.hpp
+++ b/ui/utils/opcodemodel.hpp
@@ -21,9 +21,16 @@ public:
   void appendRow(QString mnemonic, quint8 opcode);
 
 private:
-  // Store the opcode's mnemonic string and intege value.
-  using T = std::pair<QString, quint8>;
-  // Map index/rows to opcodes.
-  using MapT = QMap<qsizetype, T>;
-  MapT _mnemonics = {};
+  struct Opcode {
+    quint8 opcode;
+    QString mnemonic_addr;
+    QStringView mnemonic_only;
+  };
+  // Map index/rows to opcodes. Store the opcode's mnemonic string and integer value.
+  // Upon each insert, ensure that vector is sorted alphabetically by opcode name, then by opcode value for addressing
+  // modes. The opcode value sorting is required to prevent ADDA,d from occuring before ADDA,i.
+  // NOTE: I don't expect to insert more than 200 items, so the
+  // N^2 performance of repeated insertion should be acceptable. This assumption will likely be broken for RISC-V, but I
+  // will deal with that later.
+  std::vector<Opcode> _mnemonics = {};
 };


### PR DESCRIPTION
Things we discussed during the meeting:
- Alphabetize mnemonics in byte converter.
- SCALL should display addressing modes, even if it is hardware-unary.
- CPU Status bit view should remain as Pep/9 -- labels beside bit rather than above
- CPU Register labels should be right-justified.
- CPU register values should be boxed if integer, and unboxed if not.

The only discussed change that has not been implemented is making the memory dump pane read-only.