### PR TITLE
Switch between project tabs using `Alt+#`

### DIFF
--- a/bin/gui/main.qml
+++ b/bin/gui/main.qml
@@ -116,6 +116,19 @@ ApplicationWindow {
             projectBar.currentIndex = index
     }
 
+    Repeater {
+        model: 10
+        delegate: Item {
+            Shortcut {
+                property int index: modelData
+                //%10 to ensure that Alt+0 maps to index==10
+                sequences: [`Alt+${(index + 1) % 10}`]
+                onActivated: switchToProject(index, true)
+                enabled: index < pm.count
+            }
+        }
+    }
+
     function closeProject(index) {
         console.log(`project: closed ${index}`)
         // TODO: add logic to save project before closing or reject change entirely.


### PR DESCRIPTION
Closes #492.
Prevent selecting a tab that does not exist.