### PR TITLE
Improve Dark Mode Menus

### DIFF
--- a/bin/gui/menu/Actions.qml
+++ b/bin/gui/menu/Actions.qml
@@ -5,6 +5,7 @@ import edu.pepp 1.0
 QtObject {
     required property var window
     required property var project
+    property bool dark: window.palette.text.hslLightness < 0.5
     readonly property var file: QtObject {
         readonly property var new_: Action {
             property string nativeText: ""
@@ -13,7 +14,7 @@ QtObject {
                                        this.shortcut))
             text: "&New"
             onTriggered: window.onNew()
-            icon.source: "image://icons/file/new.svg"
+            icon.source: `image://icons/file/new${dark ? '' : '_dark'}.svg`
             shortcut: StandardKey.New
         }
         readonly property var open: Action {
@@ -23,7 +24,7 @@ QtObject {
                                        this.shortcut))
             text: "&Open..."
             onTriggered: window.onOpenDialog()
-            icon.source: "image://icons/file/open.svg"
+            icon.source: `image://icons/file/open${dark ? '' : '_dark'}.svg`
             shortcut: StandardKey.Open
         }
         readonly property var save: Action {
@@ -33,7 +34,7 @@ QtObject {
                                        this.shortcut))
             onTriggered: project.onSaveCurrent()
             text: "&Save"
-            icon.source: "image://icons/file/save.svg"
+            icon.source: `image://icons/file/save${dark ? '' : '_dark'}.svg`
             shortcut: StandardKey.Save
         }
         readonly property var print_: Action {
@@ -66,7 +67,7 @@ QtObject {
                                    () => SequenceConverter.toNativeText(
                                        this.shortcut))
             text: "&Undo"
-            icon.source: "image://icons/file/undo.svg"
+            icon.source: `image://icons/file/undo${dark ? '' : '_dark'}.svg`
             shortcut: StandardKey.Undo
         }
         readonly property var redo: Action {
@@ -75,7 +76,7 @@ QtObject {
                                    () => SequenceConverter.toNativeText(
                                        this.shortcut))
             text: "&Redo"
-            icon.source: "image://icons/file/redo.svg"
+            icon.source: `image://icons/file/redo${dark ? '' : '_dark'}.svg`
             shortcut: StandardKey.Redo
         }
         readonly property var copy: Action {
@@ -84,7 +85,7 @@ QtObject {
                                    () => SequenceConverter.toNativeText(
                                        this.shortcut))
             text: "&Copy"
-            icon.source: "image://icons/file/copy.svg"
+            icon.source: `image://icons/file/copy${dark ? '' : '_dark'}.svg`
             shortcut: StandardKey.Copy
         }
         readonly property var cut: Action {
@@ -93,7 +94,7 @@ QtObject {
                                    () => SequenceConverter.toNativeText(
                                        this.shortcut))
             text: "Cu&t"
-            icon.source: "image://icons/file/cut.svg"
+            icon.source: `image://icons/file/cut${dark ? '' : '_dark'}.svg`
             shortcut: StandardKey.Cut
         }
         readonly property var paste: Action {
@@ -102,12 +103,12 @@ QtObject {
                                    () => SequenceConverter.toNativeText(
                                        this.shortcut))
             text: "&Paste"
-            icon.source: "image://icons/file/paste.svg"
+            icon.source: `image://icons/file/paste${dark ? '' : '_dark'}.svg`
             shortcut: StandardKey.Paste
         }
         readonly property var prefs: Action {
             text: "Pr&eferences"
-            icon.source: "image://icons/file/settings.svg"
+            icon.source: `image://icons/file/settings${dark ? '' : '_dark'}.svg`
         }
     }
 
@@ -120,7 +121,7 @@ QtObject {
                                        this.shortcut))
             onTriggered: project.onLoadObject()
             text: "&Load Object Code"
-            icon.source: `image://icons/build/flash${enabled ? '' : '_disabled'}.svg`
+            icon.source: `image://icons/build/flash${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`
             shortcut: "Ctrl+Shift+L"
         }
         readonly property var execute: Action {
@@ -131,7 +132,7 @@ QtObject {
                                        this.shortcut))
             onTriggered: project.onExecute()
             text: "&Execute"
-            icon.source: `image://icons/debug/start_normal${enabled ? '' : '_disabled'}.svg`
+            icon.source: `image://icons/debug/start_normal${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`
             shortcut: "Ctrl+Shift+R"
         }
     }
@@ -145,14 +146,14 @@ QtObject {
                                        this.shortcut))
             onTriggered: project.onDebuggingStart()
             text: "Start &Debugging"
-            icon.source: `image://icons/debug/start_debug${enabled ? '' : '_disabled'}.svg`
+            icon.source: `image://icons/debug/start_debug${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`
             shortcut: "Ctrl+D"
         }
         readonly property var continue_: Action {
             enabled: project?.allowedDebugging & DebugEnableFlags.Continue
             text: "&Continue Debugging"
             onTriggered: project.onDebuggingContinue()
-            icon.source: `image://icons/debug/continue_debug${enabled ? '' : '_disabled'}.svg`
+            icon.source: `image://icons/debug/continue_debug${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`
         }
         readonly property var pause: Action {
             enabled: project?.allowedDebugging & DebugEnableFlags.Pause
@@ -162,14 +163,14 @@ QtObject {
                                        this.shortcut))
             onTriggered: project.onDebuggingPause()
             text: "I&nterrupt Debugging"
-            icon.source: `image://icons/debug/pause${enabled ? '' : '_disabled'}.svg`
+            icon.source: `image://icons/debug/pause${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`
             shortcut: "Ctrl+."
         }
         readonly property var stop: Action {
             enabled: project?.allowedDebugging & DebugEnableFlags.Stop
             text: "S&top Debugging"
             onTriggered: project.onDebuggingStop()
-            icon.source: `image://icons/debug/stop_debug${enabled ? '' : '_disabled'}.svg`
+            icon.source: `image://icons/debug/stop_debug${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`
         }
         readonly property var step: Action {
             enabled: project?.allowedSteps & StepEnableFlags.Step
@@ -179,26 +180,26 @@ QtObject {
                                        this.shortcut))
             onTriggered: project.onISAStep()
             text: "&Step"
-            icon.source: `image://icons/debug/step_normal${enabled ? '' : '_disabled'}.svg`
+            icon.source: `image://icons/debug/step_normal${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`
             shortcut: "Ctrl+Return"
         }
         readonly property var stepOver: Action {
             enabled: project?.allowedSteps & StepEnableFlags.StepOver
             text: "Step O&ver"
             onTriggered: project.onISAStepOver()
-            icon.source: `image://icons/debug/step_over${enabled ? '' : '_disabled'}.svg`
+            icon.source: `image://icons/debug/step_over${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`
         }
         readonly property var stepInto: Action {
             enabled: project?.allowedSteps & StepEnableFlags.StepInto
             text: "Step &Into"
             onTriggered: project.onISAStepInto()
-            icon.source: `image://icons/debug/step_into${enabled ? '' : '_disabled'}.svg`
+            icon.source: `image://icons/debug/step_into${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`
         }
         readonly property var stepOut: Action {
             enabled: project?.allowedSteps & StepEnableFlags.StepOut
             text: "Step &Out"
             onTriggered: project.onISAStepOut()
-            icon.source: `image://icons/debug/step_out${enabled ? '' : '_disabled'}.svg`
+            icon.source: `image://icons/debug/step_out${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`
         }
         readonly property var removeAllBreakpoints: Action {
             onTriggered: project.onISARemoveAllBreakpoints()

--- a/bin/gui/menu/MainMenu.qml
+++ b/bin/gui/menu/MainMenu.qml
@@ -29,6 +29,8 @@ MenuBar {
         // Color to pick if enabled == disabled, and that color is #000000, on which lighter does not work.
         const backup = en.hslLightness < 0.5 ? ens.lighter(4.0) : en.darker()
         const selected = item.enabled ? en : (en === dis ? backup : dis)
+        if (item.color)
+            item.color = Qt.binding(() => selected)
         item.contentItem.color = selected
     }
     TextMetrics {
@@ -150,12 +152,15 @@ MenuBar {
         MenuSeparator {}
         ShortcutMenuItem {
             action: actions.edit.cut
+            onPaletteChanged: fixTextColors(this)
         }
         ShortcutMenuItem {
             action: actions.edit.copy
+            onPaletteChanged: fixTextColors(this)
         }
         ShortcutMenuItem {
             action: actions.edit.paste
+            onPaletteChanged: fixTextColors(this)
         }
         // Formatting magic!
         MenuSeparator {}

--- a/bin/gui/menu/MainMenu.qml
+++ b/bin/gui/menu/MainMenu.qml
@@ -20,16 +20,14 @@ MenuBar {
         }
         return menu.count
     }
-    function isDark(c) {
-        return (0.299 * c.r + 0.587 * c.g + 0.114 * c.g) < 0.5
-    }
     function fixTextColors(item) {
         const p = item.palette
         const en = p.text, dis = p.disabled.text
         // TODO: Remove when themes work properly
         // TODO: fix icon colors
-        const en_shifted = Qt.rgba(en.r + 0.1, en.g + 0.1, en.b + 0.1, en.a)
-        const backup = isDark(en) ? en_shifted.lighter(4.0) : en.darker()
+        const ens = Qt.rgba(en.r + 0.1, en.g + 0.1, en.b + 0.1, en.a)
+        // Color to pick if enabled == disabled, and that color is #000000, on which lighter does not work.
+        const backup = en.hslLightness < 0.5 ? ens.lighter(4.0) : en.darker()
         const selected = item.enabled ? en : (en === dis ? backup : dis)
         item.contentItem.color = selected
     }

--- a/bin/gui/menu/ShortcutMenuItem.qml
+++ b/bin/gui/menu/ShortcutMenuItem.qml
@@ -5,13 +5,14 @@ import edu.pepp 1.0
 
 MenuItem {
     id: wrapper
+    property var color: palette.text
     Label {
-        enabled: wrapper.action?.enabled
         anchors.verticalCenter: parent.verticalCenter
         anchors.right: parent.right
         text: wrapper.action.nativeText
         width: tm.width * 20 // 40 spaces wide
         horizontalAlignment: Text.AlignLeft
         rightPadding: tm.width
+        color: wrapper.color
     }
 }


### PR DESCRIPTION
- Icons should use the same color as `QPalette::Text`
- Shortcuts should use the same color as `QPalette::Text`

Workaround are currently inserted to handle `palette.disabled` not having unique values.