### PR TITLE
Enable operand decoding in CPU pane

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,3 +9,5 @@ IncludeCategories:
     Priority: 2
 IndentWidth: 2
 TabWidth: 2
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: true

--- a/logic/isa/pep10.cpp
+++ b/logic/isa/pep10.cpp
@@ -84,6 +84,19 @@ bool isa::Pep10::isStore(quint8 opcode) {
   return isStore(opcodeLUT[opcode].instr.mnemon);
 }
 
+quint8 isa::Pep10::operandBytes(Mnemonic mnemonic) {
+  if (isMnemonicUnary(mnemonic)) return 0;
+  switch (mnemonic) {
+  case Mnemonic::LDBA: [[fallthrough]];
+  case Mnemonic::LDBX: [[fallthrough]];
+  case Mnemonic::CPBA: [[fallthrough]];
+  case Mnemonic::CPBX: return 1;
+  default: return 2;
+  }
+}
+
+quint8 isa::Pep10::operandBytes(quint8 opcode) { return operandBytes(opcodeLUT[opcode].instr.mnemon); }
+
 bool isa::Pep10::isUType(Mnemonic mnemonic) {
   using T = InstructionType;
   auto type = opcodeLUT[opcode(mnemonic)].instr.type;

--- a/logic/isa/pep10.cpp
+++ b/logic/isa/pep10.cpp
@@ -28,9 +28,9 @@ isa::Pep10::AddressingMode isa::Pep10::defaultAddressingMode() {
 isa::Pep10::AddressingMode
 isa::Pep10::defaultAddressingMode(Mnemonic mnemonic) {
     if (isAType(mnemonic))
-        return AddressingMode::I;
+      return AddressingMode::I;
     else
-        return defaultAddressingMode();
+      return defaultAddressingMode();
 }
 
 quint8 isa::Pep10::opcode(Mnemonic mnemonic) {
@@ -124,13 +124,11 @@ bool isa::Pep10::isRAAAType(Mnemonic mnemonic) {
   return type == T::RAAA_all || type == T::RAAA_noi;
 }
 
-bool isa::Pep10::isValidRAAATypeAddressingMode(Mnemonic mnemonic,
-                                               AddressingMode addr) {
+bool isa::Pep10::isValidRAAATypeAddressingMode(Mnemonic mnemonic, AddressingMode addr) {
   using T = InstructionType;
   using AM = AddressingMode;
   auto type = opcodeLUT[opcode(mnemonic)].instr.type;
-  return !(addr == AM::ALL || addr == AM::INVALID || addr == AM::NONE ||
-           (type == T::RAAA_noi && addr == AM::I));
+  return !(addr == AM::ALL || addr == AM::INVALID || addr == AM::NONE || (type == T::RAAA_noi && addr == AM::I));
 }
 
 bool isa::Pep10::isValidAddressingMode(Mnemonic mnemonic, AddressingMode addr) {
@@ -138,43 +136,30 @@ bool isa::Pep10::isValidAddressingMode(Mnemonic mnemonic, AddressingMode addr) {
   using AM = AddressingMode;
   auto type = opcodeLUT[opcode(mnemonic)].instr.type;
   switch (type) {
-  case detail::pep10::InstructionType::Invalid:
-    [[fallthrough]];
-  case detail::pep10::InstructionType::U_none:
-    [[fallthrough]];
-  case detail::pep10::InstructionType::R_none:
-    return false;
-  case detail::pep10::InstructionType::A_ix:
-    return addr == AM::X || addr == AM::I;
-  case detail::pep10::InstructionType::AAA_i:
-    return addr == AM::I;
-  case detail::pep10::InstructionType::AAA_all:
-  case detail::pep10::InstructionType::RAAA_all:
-    return !(addr == AM::ALL || addr == AM::INVALID || addr == AM::NONE);
+  case detail::pep10::InstructionType::Invalid: [[fallthrough]];
+  case detail::pep10::InstructionType::U_none: [[fallthrough]];
+  case detail::pep10::InstructionType::R_none: return false;
+  case detail::pep10::InstructionType::A_ix: return addr == AM::X || addr == AM::I;
+  case detail::pep10::InstructionType::AAA_i: return addr == AM::I;
+  case detail::pep10::InstructionType::AAA_all: [[fallthrough]];
+  case detail::pep10::InstructionType::RAAA_all: return !(addr == AM::ALL || addr == AM::INVALID || addr == AM::NONE);
   case detail::pep10::InstructionType::RAAA_noi:
-    return !(addr == AM::ALL || addr == AM::INVALID || addr == AM::NONE ||
-             addr == AM::I);
+    return !(addr == AM::ALL || addr == AM::INVALID || addr == AM::NONE || addr == AM::I);
   }
   return false;
 }
 
-bool isa::Pep10::requiresAddressingMode(Mnemonic mnemonic) {
-  return isAAAType(mnemonic) | isRAAAType(mnemonic);
-}
+bool isa::Pep10::requiresAddressingMode(Mnemonic mnemonic) { return isAAAType(mnemonic) | isRAAAType(mnemonic); }
 
-bool isa::Pep10::canElideAddressingMode(Mnemonic mnemonic,
-                                        AddressingMode addr) {
-    return isAType(mnemonic) && addr == AddressingMode::I;
+bool isa::Pep10::canElideAddressingMode(Mnemonic mnemonic, AddressingMode addr) {
+  return isAType(mnemonic) && addr == AddressingMode::I;
 }
 
 QSet<QString> isa::Pep10::legalDirectives()
 {
-    static const auto valid = QSet<QString>{
-                                            "ALIGN", "ASCII",  "BLOCK", "BYTE",  "EQUATE",  "EXPORT", "IMPORT",
-                                            "INPUT", "OUTPUT", "ORG",   "SCALL", "SECTION", "USCALL", "WORD"};
-    return valid;
+  static const auto valid = QSet<QString>{"ALIGN", "ASCII",  "BLOCK", "BYTE",  "EQUATE",  "EXPORT", "IMPORT",
+                                          "INPUT", "OUTPUT", "ORG",   "SCALL", "SECTION", "USCALL", "WORD"};
+  return valid;
 }
 
-bool isa::Pep10::isLegalDirective(QString directive) {
-    return legalDirectives().contains(directive.toUpper());
-}
+bool isa::Pep10::isLegalDirective(QString directive) { return legalDirectives().contains(directive.toUpper()); }

--- a/logic/isa/pep10.hpp
+++ b/logic/isa/pep10.hpp
@@ -264,6 +264,8 @@ struct ISA_EXPORT Pep10 {
   static bool isOpcodeUnary(quint8 opcode);
   static bool isStore(Mnemonic mnemonic);
   static bool isStore(quint8 opcode);
+  static quint8 operandBytes(Mnemonic mnemonic);
+  static quint8 operandBytes(quint8 opcode);
 
   static bool isUType(Mnemonic mnemonic);
   static bool isRType(Mnemonic mnemonic);

--- a/logic/targets/pep10/isa3/cpu.hpp
+++ b/logic/targets/pep10/isa3/cpu.hpp
@@ -41,8 +41,11 @@ public:
   };
 
   Status status() const;
+  // Helper to convert OS to an operand value.
+  // It will use Application access, and will not trigger MMIO.
+  std::optional<quint16> currentOperand();
 
-  // Recipient interface
+  // Target interface
   const sim::api2::tick::Source *getSource() override;
   void setSource(sim::api2::tick::Source *) override;
   sim::api2::tick::Result clock(sim::api2::tick::Type currentTick) override;
@@ -57,7 +60,6 @@ public:
 
   // Initiator interface
   void setTarget(sim::api2::memory::Target<quint16> *target, void* port) override;
-
 private:
   Status _status = Status::Ok;
   sim::api2::device::Descriptor _device;
@@ -76,9 +78,7 @@ private:
 
   sim::api2::tick::Result unaryDispatch(quint8 is);
   sim::api2::tick::Result nonunaryDispatch(quint8 is, quint16 os, quint16 pc);
-  void decodeStoreOperand(quint8 is, quint16 os,
-                                              quint16 &decoded);
-  void decodeLoadOperand(quint8 is, quint16 os,
-                                             quint16 &decoded);
+  void decodeStoreOperand(quint8 is, quint16 os, quint16 &decoded, bool traced = true);
+  void decodeLoadOperand(quint8 is, quint16 os, quint16 &decoded, bool traced = true);
 };
 } // namespace targets::pep10::isa

--- a/logic/targets/pep10/isa3/helpers.hpp
+++ b/logic/targets/pep10/isa3/helpers.hpp
@@ -16,58 +16,45 @@
  */
 
 #pragma once
+#include <QtCore>
 #include "bits/operations/swap.hpp"
 #include "bits/order.hpp"
 #include "isa/pep10.hpp"
 #include "sim/api2.hpp"
-#include <QtCore>
 namespace targets::pep10::isa {
 template <typename Address>
-sim::api2::memory::Result readRegister(sim::api2::memory::Target<Address> *target,
-                                      ::isa::Pep10::Register reg,
-                                      quint16 &value,
-                                      sim::api2::memory::Operation op) {
-  auto ret = target->read(static_cast<quint8>(reg) * 2,
-                          {reinterpret_cast<quint8 *>(&value), 2}, op);
-  if (bits::hostOrder() != bits::Order::BigEndian)
-    value = bits::byteswap(value);
+sim::api2::memory::Result readRegister(sim::api2::memory::Target<Address> *target, ::isa::Pep10::Register reg,
+                                       quint16 &value, sim::api2::memory::Operation op) {
+  auto ret = target->read(static_cast<quint8>(reg) * 2, {reinterpret_cast<quint8 *>(&value), 2}, op);
+  if (bits::hostOrder() != bits::Order::BigEndian) value = bits::byteswap(value);
   return ret;
 }
 
 template <typename Address>
-sim::api2::memory::Result
-writeRegister(sim::api2::memory::Target<Address> *target,
-              ::isa::Pep10::Register reg, quint16 value,
-              sim::api2::memory::Operation op) {
-  if (bits::hostOrder() != bits::Order::BigEndian)
-    value = bits::byteswap(value);
-  return target->write(static_cast<quint8>(reg) * 2,
-                       {reinterpret_cast<quint8 *>(&value), 2}, op);
+sim::api2::memory::Result writeRegister(sim::api2::memory::Target<Address> *target, ::isa::Pep10::Register reg,
+                                        quint16 value, sim::api2::memory::Operation op) {
+  if (bits::hostOrder() != bits::Order::BigEndian) value = bits::byteswap(value);
+  return target->write(static_cast<quint8>(reg) * 2, {reinterpret_cast<quint8 *>(&value), 2}, op);
 }
 
 template <typename Address>
-sim::api2::memory::Result readCSR(sim::api2::memory::Target<Address> *target,
-                                 ::isa::Pep10::CSR csr, bool &value,
-                                 sim::api2::memory::Operation op) {
-  return target->read(static_cast<quint8>(csr),
-                      {reinterpret_cast<quint8 *>(&value), 1}, op);
-}
-
-template <typename Address>
-sim::api2::memory::Result writeCSR(sim::api2::memory::Target<Address> *target,
-                                  ::isa::Pep10::CSR csr, bool value,
+sim::api2::memory::Result readCSR(sim::api2::memory::Target<Address> *target, ::isa::Pep10::CSR csr, bool &value,
                                   sim::api2::memory::Operation op) {
-  return target->write(static_cast<quint8>(csr),
-                       {reinterpret_cast<quint8 *>(&value), 1}, op);
+  return target->read(static_cast<quint8>(csr), {reinterpret_cast<quint8 *>(&value), 1}, op);
+}
+
+template <typename Address>
+sim::api2::memory::Result writeCSR(sim::api2::memory::Target<Address> *target, ::isa::Pep10::CSR csr, bool value,
+                                   sim::api2::memory::Operation op) {
+  return target->write(static_cast<quint8>(csr), {reinterpret_cast<quint8 *>(&value), 1}, op);
 }
 
 quint8 packCSR(bool n, bool z, bool v, bool c);
 std::tuple<bool, bool, bool, bool> unpackCSR(quint8 value);
 
 template <typename Address>
-sim::api2::memory::Result
-readPackedCSR(sim::api2::memory::Target<Address> *target, quint8 &value,
-              sim::api2::memory::Operation op) {
+sim::api2::memory::Result readPackedCSR(sim::api2::memory::Target<Address> *target, quint8 &value,
+                                        sim::api2::memory::Operation op) {
   quint8 ctx[4];
   auto ret = target->read(0, {ctx}, op);
   value = packCSR(ctx[0], ctx[1], ctx[2], ctx[3]);
@@ -75,9 +62,8 @@ readPackedCSR(sim::api2::memory::Target<Address> *target, quint8 &value,
 }
 
 template <typename Address>
-sim::api2::memory::Result
-writePackedCSR(sim::api2::memory::Target<Address> *target, quint8 value,
-               sim::api2::memory::Operation op) {
+sim::api2::memory::Result writePackedCSR(sim::api2::memory::Target<Address> *target, quint8 value,
+                                         sim::api2::memory::Operation op) {
   auto [n, z, v, c] = unpackCSR(value);
   quint8 ctx[4] = {n, z, v, c};
   return target->write(0, {ctx}, op);

--- a/ui/cpu/registermodel.hpp
+++ b/ui/cpu/registermodel.hpp
@@ -8,16 +8,20 @@
 struct CPU_EXPORT RegisterFormatter {
   virtual ~RegisterFormatter() = default;
   virtual QString format() const = 0;
+  virtual QString format(quint8 byteCount) const = 0;
   virtual bool readOnly() const = 0;
   virtual qsizetype length() const = 0;
+  virtual qsizetype length(quint8 byteCount) const = 0;
 };
 
 struct CPU_EXPORT TextFormatter : public RegisterFormatter {
   explicit TextFormatter(QString value) : _value(value) {}
   ~TextFormatter() override = default;
   QString format() const override { return _value; }
+  QString format(quint8 byteCount) const override { return _value; }
   bool readOnly() const override { return true; }
   qsizetype length() const override { return _value.length(); }
+  qsizetype length(quint8 byteCount) const override { return _value.length(); }
 
 private:
   QString _value;


### PR DESCRIPTION
The decoded operand will be 0, 1, or 2 bytes depending on which mnemonic is current.
The number of bytes is assigned as such: unary => 0, LDBr && CPBr => 1, all other => 2.