### PR TITLE
Load object code before execution

### DIFF
--- a/ui/project/aproject.cpp
+++ b/ui/project/aproject.cpp
@@ -221,6 +221,8 @@ bool Pep10_ISA::onLoadObject() {
 }
 
 bool Pep10_ISA::onExecute() {
+  // Ensure latests changes to object code pane are reflected in simulator.
+  onLoadObject();
   _tb->clear();
   _system->init();
   auto pwrOff = _system->output("pwrOff");


### PR DESCRIPTION
Otherwise you will hit an illegal instruction if you forget to load, which is bad UX.