### PR TITLE
Fix unsafe bool<=>u16 coercions

### DIFF
--- a/logic/targets/test/isa3-pep10/instr/addr.cpp
+++ b/logic/targets/test/isa3-pep10/instr/addr.cpp
@@ -54,13 +54,13 @@ template <isa::Pep10::Register target_reg, isa::Pep10::Register other_reg> void 
       CHECK(reg(cpu, target_reg) == endRegVal);
       // Check that target status bits match RTL.
       CHECK(csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x8000 ? 1 : 0));
-      CHECK(csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
+      CHECK(!!csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
       auto input_sign_match = ~(init_reg ^ opspec) & 0x8000;
       auto output_sign_match = ~(endRegVal ^ init_reg) & 0x8000;
       // Explicitly check that if input signs do no match, thatV is always
       // false.
       auto signed_overflow = input_sign_match ? input_sign_match != output_sign_match : false;
-      CHECK(csr(cpu, isa::Pep10::CSR::V) == signed_overflow);
+      CHECK(!!csr(cpu, isa::Pep10::CSR::V) == signed_overflow);
       // Don't use bit twiddling here. This validates that my bit twiddles in
       // the CPU are logically equivalent to to carrying into bit 17 of a
       // 32-bit type.

--- a/logic/targets/test/isa3-pep10/instr/andr.cpp
+++ b/logic/targets/test/isa3-pep10/instr/andr.cpp
@@ -54,7 +54,7 @@ template <isa::Pep10::Register target_reg, isa::Pep10::Register other_reg> void 
       CHECK(reg(cpu, target_reg) == endRegVal);
       // Check that target status bits match RTL.
       CHECK(csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x8000 ? 1 : 0));
-      CHECK(csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
+      CHECK(!!csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
       CHECK(csr(cpu, isa::Pep10::CSR::V) == 0);
       CHECK(csr(cpu, isa::Pep10::CSR::C) == 0);
     }

--- a/logic/targets/test/isa3-pep10/instr/aslr.cpp
+++ b/logic/targets/test/isa3-pep10/instr/aslr.cpp
@@ -48,7 +48,7 @@ template <isa::Pep10::Register target_reg> void inner(isa::Pep10::Mnemonic op) {
     // Check that target register had arithmetic performed.
     CHECK(reg(cpu, target_reg) == endRegVal);
     // Check that target status bits match RTL.
-    CHECK(!!csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x8000 ? 1 : 0));
+    CHECK(csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x8000 ? 1 : 0));
     CHECK(!!csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
     auto new_reg = reg(cpu, target_reg);
     // Count the number of 1's in A[0:1].

--- a/logic/targets/test/isa3-pep10/instr/asrr.cpp
+++ b/logic/targets/test/isa3-pep10/instr/asrr.cpp
@@ -48,7 +48,7 @@ template <isa::Pep10::Register target_reg> void inner(isa::Pep10::Mnemonic op) {
     // Check that target register had arithmetic performed.
     CHECK(reg(cpu, target_reg) == endRegVal);
     // Check that target status bits match RTL.
-    CHECK(!!csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x8000 ? 1 : 0));
+    CHECK(csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x8000 ? 1 : 0));
     CHECK(!!csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
     auto new_reg = reg(cpu, target_reg);
     CHECK(csr(cpu, isa::Pep10::CSR::V) == 0);

--- a/logic/targets/test/isa3-pep10/instr/cpbr.cpp
+++ b/logic/targets/test/isa3-pep10/instr/cpbr.cpp
@@ -53,7 +53,7 @@ template <isa::Pep10::Register target_reg> void inner(isa::Pep10::Mnemonic op) {
     // Check that target register did not change.
     CHECK(reg(cpu, target_reg) == init_reg);
     // Check that target status bits match RTL.
-    CHECK(csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
+    CHECK(!!csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
     CHECK(csr(cpu, isa::Pep10::CSR::V) == 0);
     CHECK(csr(cpu, isa::Pep10::CSR::C) == 0);
     CHECK(csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x80 ? 1 : 0));

--- a/logic/targets/test/isa3-pep10/instr/cpwr.cpp
+++ b/logic/targets/test/isa3-pep10/instr/cpwr.cpp
@@ -53,13 +53,13 @@ template <isa::Pep10::Register target_reg> void inner(isa::Pep10::Mnemonic op) {
     // Check that target register did not change.
     CHECK(reg(cpu, target_reg) == init_reg);
     // Check that target status bits match RTL.
-    CHECK(csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
+    CHECK(!!csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
     auto input_sign_match = ~(init_reg ^ (~opspec + 1)) & 0x8000;
     auto output_sign_match = ~(endRegVal ^ init_reg) & 0x8000;
     // Explicitly check that if input signs do no match, thatV is always
     // false.
-    auto signed_overflow = input_sign_match ? input_sign_match != output_sign_match : false;
-    CHECK(csr(cpu, isa::Pep10::CSR::V) == signed_overflow);
+    bool signed_overflow = input_sign_match ? input_sign_match != output_sign_match : false;
+    CHECK(!!csr(cpu, isa::Pep10::CSR::V) == signed_overflow);
     // Don't use bit twiddling here. This validates that my bit twiddles in
     // the CPU are logically equivalent to to carrying into bit 17 of a
     // 32-bit type.

--- a/logic/targets/test/isa3-pep10/instr/ldbr.cpp
+++ b/logic/targets/test/isa3-pep10/instr/ldbr.cpp
@@ -53,7 +53,7 @@ template <isa::Pep10::Register target_reg, isa::Pep10::Register other_reg> void 
     CHECK(reg(cpu, target_reg) == endRegVal);
     // Check that target status bits match RTL.
     CHECK(csr(cpu, isa::Pep10::CSR::N) == 0);
-    CHECK(csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
+    CHECK(!!csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
   }
 }
 } // namespace

--- a/logic/targets/test/isa3-pep10/instr/ldwr.cpp
+++ b/logic/targets/test/isa3-pep10/instr/ldwr.cpp
@@ -53,7 +53,7 @@ template <isa::Pep10::Register target_reg, isa::Pep10::Register other_reg> void 
     // Check that target register had arithmetic performed.
     CHECK(reg(cpu, target_reg) == endRegVal);
     // Check that target status bits match RTL.
-    CHECK(!!csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x8000 ? 1 : 0));
+    CHECK(csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x8000 ? 1 : 0));
     CHECK(!!csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
   }
 }

--- a/logic/targets/test/isa3-pep10/instr/negr.cpp
+++ b/logic/targets/test/isa3-pep10/instr/negr.cpp
@@ -48,9 +48,9 @@ template <isa::Pep10::Register target_reg> void inner(isa::Pep10::Mnemonic op) {
     // Check that target register had arithmetic performed.
     CHECK(reg(cpu, target_reg) == endRegVal);
     // Check that target status bits match RTL.
-    CHECK(!!csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x8000 ? 1 : 0));
+    CHECK(csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x8000 ? 1 : 0));
     CHECK(!!csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
-    CHECK(csr(cpu, isa::Pep10::CSR::V) == (endRegVal == 0x8000));
+    CHECK(!!csr(cpu, isa::Pep10::CSR::V) == (endRegVal == 0x8000));
     // Don't use bit twiddling here. This validates that my bit twiddles in
     // the CPU are logically equivalent to to carrying into bit 17 of a
     // 32-bit type.

--- a/logic/targets/test/isa3-pep10/instr/notr.cpp
+++ b/logic/targets/test/isa3-pep10/instr/notr.cpp
@@ -48,7 +48,7 @@ template <isa::Pep10::Register target_reg> void inner_notr(isa::Pep10::Mnemonic 
     // Check that target register had arithmetic performed.
     CHECK(reg(cpu, target_reg) == endRegVal);
     // Check that target status bits match RTL.
-    CHECK(!!csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x8000 ? 1 : 0));
+    CHECK(csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x8000 ? 1 : 0));
     CHECK(!!csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
   }
 }

--- a/logic/targets/test/isa3-pep10/instr/orr.cpp
+++ b/logic/targets/test/isa3-pep10/instr/orr.cpp
@@ -54,7 +54,7 @@ template <isa::Pep10::Register target_reg, isa::Pep10::Register other_reg> void 
       CHECK(reg(cpu, target_reg) == endRegVal);
       // Check that target status bits match RTL.
       CHECK(csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x8000 ? 1 : 0));
-      CHECK(csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
+      CHECK(!!csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
     }
   }
 }

--- a/logic/targets/test/isa3-pep10/instr/rolr.cpp
+++ b/logic/targets/test/isa3-pep10/instr/rolr.cpp
@@ -47,8 +47,8 @@ template <isa::Pep10::Register target_reg> void inner(isa::Pep10::Mnemonic op) {
     CHECK(reg(cpu, isa::Pep10::Register::PC) == 0x1);
     CHECK(reg(cpu, isa::Pep10::Register::IS) == (quint8)op);
     CHECK(reg(cpu, isa::Pep10::Register::OS) == 0);
-    CHECK(!!csr(cpu, isa::Pep10::CSR::N) == 0);
-    CHECK(!!csr(cpu, isa::Pep10::CSR::Z) == 0);
+    CHECK(csr(cpu, isa::Pep10::CSR::N) == 0);
+    CHECK(csr(cpu, isa::Pep10::CSR::Z) == 0);
     auto new_reg = reg(cpu, target_reg);
     CHECK(csr(cpu, isa::Pep10::CSR::V) == 0);
     // Carry out if high order bit was non-zero

--- a/logic/targets/test/isa3-pep10/instr/rorr.cpp
+++ b/logic/targets/test/isa3-pep10/instr/rorr.cpp
@@ -50,12 +50,12 @@ template <isa::Pep10::Register target_reg> void inner(isa::Pep10::Mnemonic op) {
     // Check that target register had arithmetic performed.
     CHECK(reg(cpu, target_reg) == endRegVal);
     // Check that target status bits match RTL.
-    CHECK(!!csr(cpu, isa::Pep10::CSR::N) == 0);
-    CHECK(!!csr(cpu, isa::Pep10::CSR::Z) == 0);
+    CHECK(csr(cpu, isa::Pep10::CSR::N) == 0);
+    CHECK(csr(cpu, isa::Pep10::CSR::Z) == 0);
     auto new_reg = reg(cpu, target_reg);
     CHECK(csr(cpu, isa::Pep10::CSR::V) == 0);
     // Carry out if low order bit was non-zero
-    CHECK(csr(cpu, isa::Pep10::CSR::C) == (init_reg & 0x1));
+    CHECK(csr(cpu, isa::Pep10::CSR::C) == quint16(init_reg & 0x1));
   }
 }
 } // namespace

--- a/logic/targets/test/isa3-pep10/instr/subr.cpp
+++ b/logic/targets/test/isa3-pep10/instr/subr.cpp
@@ -54,13 +54,13 @@ template <isa::Pep10::Register target_reg, isa::Pep10::Register other_reg> void 
       CHECK(reg(cpu, target_reg) == endRegVal);
       // Check that target status bits match RTL.
       CHECK(csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x8000 ? 1 : 0));
-      CHECK(csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
+      CHECK(!!csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
       auto input_sign_match = ~(init_reg ^ (~opspec + 1)) & 0x8000;
       auto output_sign_match = ~(endRegVal ^ init_reg) & 0x8000;
       // Explicitly check that if input signs do no match, thatV is always
       // false.
-      auto signed_overflow = input_sign_match ? input_sign_match != output_sign_match : false;
-      CHECK(csr(cpu, isa::Pep10::CSR::V) == signed_overflow);
+      bool signed_overflow = input_sign_match ? input_sign_match != output_sign_match : false;
+      CHECK(!!csr(cpu, isa::Pep10::CSR::V) == signed_overflow);
       // Don't use bit twiddling here. This validates that my bit twiddles in
       // the CPU are logically equivalent to to carrying into bit 17 of a
       // 32-bit type.

--- a/logic/targets/test/isa3-pep10/instr/xorr.cpp
+++ b/logic/targets/test/isa3-pep10/instr/xorr.cpp
@@ -54,7 +54,7 @@ template <isa::Pep10::Register target_reg, isa::Pep10::Register other_reg> void 
       CHECK(reg(cpu, target_reg) == endRegVal);
       // Check that target status bits match RTL.
       CHECK(csr(cpu, isa::Pep10::CSR::N) == (endRegVal & 0x8000 ? 1 : 0));
-      CHECK(csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
+      CHECK(!!csr(cpu, isa::Pep10::CSR::Z) == (endRegVal == 0));
     }
   }
 }


### PR DESCRIPTION
MSVC should emit far fewer compiler warnings now.

Can't auto-merge, because I want to check my handiwork on a clean Windows build.