### PR TITLE
Prevent clipping text in ASMB object code pane

### DIFF
--- a/ui/text/editor/ObjTextEditor.qml
+++ b/ui/text/editor/ObjTextEditor.qml
@@ -68,6 +68,7 @@ ScrollView {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.bottom: parent.bottom
+            height: visible ? implicitHeight : 0
             Button {
                 // Buttons must not take focus, or spurious editor.editingFinished will be emitted.
                 focusPolicy: Qt.NoFocus


### PR DESCRIPTION
Buttons were invisible, but still had height.
This caused text area to be smaller than visible area, which looked weird.