### PR TITLE
Suppress generation of temporary ELF files

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -120,7 +120,7 @@ else ()
     target_compile_definitions(pepp PRIVATE "DEFAULT_GUI=0")
 endif ()
 
-if (0)
+if (ENABLE_TERM_TESTS)
     configure_file(test/config.hpp.in "${CMAKE_CURRENT_BINARY_DIR}/config.hpp")
     make_target(
             TARGET test-term

--- a/bin/commands/run.cpp
+++ b/bin/commands/run.cpp
@@ -72,15 +72,12 @@ bool RunTask::loadToElf() {
   if (!bytes)
     return false;
   _elf = helper.elf(*bytes);
-  // Need to reload to properly compute segment addresses. Store in temp
-  // directory to prevent clobbering local file contents.
+  // Need to reload to properly compute segment addresses.
   {
-    QTemporaryDir dir;
-    if (!dir.isValid())
-      return false;
-    auto path = dir.filePath("tmp.elf").toStdString();
-    _elf->save(path);
-    _elf->load(path);
+    std::stringstream s;
+    _elf->save(s);
+    s.seekg(0, std::ios::beg);
+    _elf->load(s);
   }
   return true;
 }

--- a/logic/asm/pas/test/e2e/pep10.cpp
+++ b/logic/asm/pas/test/e2e/pep10.cpp
@@ -157,8 +157,12 @@ TEST_CASE("CS6E figure assembly", "[scope:asm][kind:e2e][arch:pep10]") {
         pas::obj::pep10::combineSections(*userRoot);
         pas::obj::pep10::writeUser(*elf, *userRoot);
         // Segments are not layed out correctly until saving.
-        elf->save(u"%1.%2.elf"_qs.arg(chapter, figName).toStdString());
-        elf->load(u"%1.%2.elf"_qs.arg(chapter, figName).toStdString());
+        {
+          std::stringstream s;
+          elf->save(s);
+          s.seekg(0, std::ios::beg);
+          elf->load(s);
+        }
         REQUIRE(result);
 
         // Verify MMIO information.

--- a/logic/targets/test/isa3-pep10/figs.cpp
+++ b/logic/targets/test/isa3-pep10/figs.cpp
@@ -99,14 +99,12 @@ void smoke(QString os, QString userPep, QString userPepo, QString input, QByteAr
   auto elf = pas::obj::pep10::createElf();
   assemble(*elf, os, {.pep = userPep, .pepo = userPepo}, reg);
 
-  // Need to reload to properly compute segment addresses. Store in temp
-  // directory to prevent clobbering local file contents.
+  // Need to reload to properly compute segment addresses.
   {
-    QTemporaryDir dir;
-    REQUIRE(dir.isValid());
-    auto path = dir.filePath("tmp.elf").toStdString();
-    elf->save(path);
-    elf->load(path);
+    std::stringstream s;
+    elf->save(s);
+    s.seekg(0, std::ios::beg);
+    elf->load(s);
   }
   // Skip loading, to save on cycles. However, can't skip dispatch, or
   // main's stack will be wrong.

--- a/ui/project/pep10.cpp
+++ b/ui/project/pep10.cpp
@@ -67,8 +67,7 @@ SystemAssembly make_isa_system() {
     qWarning() << "Default OS assembly failed";
   }
   SystemAssembly ret;
-  // Need to reload to properly compute segment addresses. Store in temp
-  // directory to prevent clobbering local file contents.
+  // Need to reload to properly compute segment addresses.
   ret.elf = helper.elf();
   {
     std::stringstream s;


### PR DESCRIPTION
Our ELF library needs to save to a stream/file to calculate addresses correctly.

I have switched to string streams from files to better work with web assembly.