### PR TITLE
Enable code folding on comments & macros

### DIFF
--- a/logic/asm/pas/operations/generic/include_macros.cpp
+++ b/logic/asm/pas/operations/generic/include_macros.cpp
@@ -108,8 +108,10 @@ void pas::ops::generic::IncludeMacros::addExtraChildren(ast::Node &node) {
 
   // Must generate start comment before removing symbol declaration.
   auto start = QSharedPointer<ast::Node>::create(commentType);
-  start->set(ast::generic::CommentIndent{.value = ast::generic::CommentIndent::Level::Instruction});
-  start->set(ast::generic::Comment{.value = detail::formatMacro(node, {})});
+  start->set(ast::generic::CommentIndent{.value = ast::generic::CommentIndent::Level::Left});
+  // Align the macro commen as if it were an instruction.
+  auto formattedMacro = detail::formatMacro(node, {}).mid(3);
+  start->set(ast::generic::Comment{.value = formattedMacro});
 
   // Use an empty .BLOCK to avoid having to complex line manipulations.
   if (node.has<ast::generic::SymbolDeclaration>()) {

--- a/logic/helpers/asmb.cpp
+++ b/logic/helpers/asmb.cpp
@@ -118,7 +118,7 @@ QSharedPointer<ELFIO::elfio> helpers::AsmHelper::elf(std::optional<QList<quint8>
 QStringList helpers::AsmHelper::listing(bool os) {
   try {
     if (os && !_osRoot.isNull()) return pas::ops::pepp::formatListing<isa::Pep10>(*_osRoot);
-    if (!os && !_userRoot.isNull()) return pas::ops::pepp::formatListing<isa::Pep10>(*_userRoot);
+    else if (!os && !_userRoot.isNull()) return pas::ops::pepp::formatListing<isa::Pep10>(*_userRoot);
   } catch (std::exception &e) {
   }
   return {};

--- a/ui/text/editor/scintillaasmeditbase.hpp
+++ b/ui/text/editor/scintillaasmeditbase.hpp
@@ -16,7 +16,6 @@ public slots:
   void clearAllEOLAnnotations();
   void setEOLAnnotationsVisibile(int style);
   void addEOLAnnotation(int line, const QString &annotation);
-  // For breakpoints
   void onMarginClicked(Scintilla::Position position, Scintilla::KeyMod modifiers, int margin);
 signals:
   void lexerLanguageChanged();


### PR DESCRIPTION
Collapse multi-line comments with a margin click.
Expanded macros in listing should fold too.