### PR TITLE
Optimize assembler performance in debug

### DIFF
--- a/logic/asm/pas/ast/generic/attr_address.hpp
+++ b/logic/asm/pas/ast/generic/attr_address.hpp
@@ -27,6 +27,7 @@ struct PAS_EXPORT Address {
   };
 
   static const inline QString attributeName = u"generic:address"_qs;
+  static const inline uint8_t attribute = 2;
   Span value = {};
   bool operator==(const Address &other) const = default;
 };

--- a/logic/asm/pas/ast/generic/attr_argument.hpp
+++ b/logic/asm/pas/ast/generic/attr_argument.hpp
@@ -25,12 +25,14 @@ class Base;
 namespace pas::ast::generic {
 struct PAS_EXPORT Argument {
   static const inline QString attributeName = u"generic:arg"_qs;
+  static const inline uint8_t attribute = 3;
   QSharedPointer<value::Base> value = {};
   bool operator==(const Argument &other) const = default;
 };
 
 struct PAS_EXPORT ArgumentList {
   static const inline QString attributeName = u"generic:arg_list"_qs;
+  static const inline uint8_t attribute = 4;
   QList<QSharedPointer<value::Base>> value = {};
   bool operator==(const ArgumentList &other) const = default;
 };

--- a/logic/asm/pas/ast/generic/attr_children.hpp
+++ b/logic/asm/pas/ast/generic/attr_children.hpp
@@ -25,6 +25,7 @@ class Node;
 namespace pas::ast::generic {
 struct PAS_EXPORT Children {
   static const inline QString attributeName = u"generic:children"_qs;
+  static const inline uint8_t attribute = 5;
   QList<QSharedPointer<pas::ast::Node>> value = {}; // All direct children of the owning node
   // TODO: replace with element-wise value comparison.
   bool operator==(const Children &other) const = default;

--- a/logic/asm/pas/ast/generic/attr_comment.hpp
+++ b/logic/asm/pas/ast/generic/attr_comment.hpp
@@ -22,6 +22,7 @@
 namespace pas::ast::generic {
 struct PAS_EXPORT Comment {
   static const inline QString attributeName = u"generic:comment"_qs;
+  static const inline uint8_t attribute = 6;
   QString value = {};
   bool operator==(const Comment &other) const = default;
 };

--- a/logic/asm/pas/ast/generic/attr_comment_indent.hpp
+++ b/logic/asm/pas/ast/generic/attr_comment_indent.hpp
@@ -23,6 +23,7 @@ namespace pas::ast::generic {
 struct PAS_EXPORT CommentIndent {
   enum class Level { Left, Instruction };
   static const inline QString attributeName = u"generic:comment_indent"_qs;
+  static const inline uint8_t attribute = 7;
   Level value = Level::Left;
   bool operator==(const CommentIndent &other) const = default;
 };

--- a/logic/asm/pas/ast/generic/attr_directive.hpp
+++ b/logic/asm/pas/ast/generic/attr_directive.hpp
@@ -22,6 +22,7 @@
 namespace pas::ast::generic {
 struct PAS_EXPORT Directive {
   static const inline QString attributeName = u"generic:directive"_qs;
+  static const inline uint8_t attribute = 8;
   QString value = {};
   bool operator==(const Directive &other) const = default;
 };

--- a/logic/asm/pas/ast/generic/attr_error.hpp
+++ b/logic/asm/pas/ast/generic/attr_error.hpp
@@ -33,6 +33,7 @@ struct PAS_EXPORT Message {
 
 struct PAS_EXPORT Error {
   static const inline QString attributeName = u"generic:error"_qs;
+  static const inline uint8_t attribute = 9;
   QList<Message> value = {};
   bool operator==(const Error &other) const = default;
 };

--- a/logic/asm/pas/ast/generic/attr_hide.hpp
+++ b/logic/asm/pas/ast/generic/attr_hide.hpp
@@ -22,6 +22,7 @@
 namespace pas::ast::generic {
 struct PAS_EXPORT Hide {
   static const inline QString attributeName = u"generic:hide"_qs;
+  static const inline uint8_t attribute = 10;
   struct In {
     bool source = false;
     bool listing = false;

--- a/logic/asm/pas/ast/generic/attr_location.hpp
+++ b/logic/asm/pas/ast/generic/attr_location.hpp
@@ -28,6 +28,7 @@ struct PAS_EXPORT Location {
 
 struct PAS_EXPORT SourceLocation {
   static const inline QString attributeName = u"generic:source_loc"_qs;
+  static const inline uint8_t attribute = 11;
   Location value = {}; // The location (line) line in the source file on which
                        // the node starts.
   bool operator==(const SourceLocation &other) const = default;

--- a/logic/asm/pas/ast/generic/attr_macro.hpp
+++ b/logic/asm/pas/ast/generic/attr_macro.hpp
@@ -22,6 +22,7 @@
 namespace pas::ast::generic {
 struct PAS_EXPORT Macro {
   static const inline QString attributeName = u"generic:macro"_qs;
+  static const inline uint8_t attribute = 12;
   QString value = {};
   bool operator==(const Macro &other) const = default;
 };

--- a/logic/asm/pas/ast/generic/attr_parent.hpp
+++ b/logic/asm/pas/ast/generic/attr_parent.hpp
@@ -25,6 +25,7 @@ class Node;
 namespace pas::ast::generic {
 struct PAS_EXPORT Parent {
   static const inline QString attributeName = u"generic:parent"_qs;
+  static const inline uint8_t attribute = 13;
   QWeakPointer<pas::ast::Node> value = {}; // The direct parent of the owning node (empty if owner is root).
   bool operator==(const Parent &other) const = default;
 };

--- a/logic/asm/pas/ast/generic/attr_sec.hpp
+++ b/logic/asm/pas/ast/generic/attr_sec.hpp
@@ -23,6 +23,7 @@ namespace pas::ast::generic {
 
 struct PAS_EXPORT SectionFlags {
   static const inline QString attributeName = u"generic:section_flags"_qs;
+  static const inline uint8_t attribute = 14;
   struct Flags {
     bool R = 1, W = 1, X = 1, Z = 0;
     bool operator==(const Flags &other) const = default;
@@ -31,6 +32,7 @@ struct PAS_EXPORT SectionFlags {
 };
 struct PAS_EXPORT SectionName {
   static const inline QString attributeName = u"generic:section_name"_qs;
+  static const inline uint8_t attribute = 15;
   QString value = {};
   bool operator==(const SectionName &other) const = default;
 };

--- a/logic/asm/pas/ast/generic/attr_symbol.hpp
+++ b/logic/asm/pas/ast/generic/attr_symbol.hpp
@@ -27,12 +27,14 @@ class Table;
 namespace pas::ast::generic {
 struct PAS_EXPORT SymbolDeclaration {
   static const inline QString attributeName = u"generic:symbol_decl"_qs;
+  static const inline uint8_t attribute = 16;
   QSharedPointer<symbol::Entry> value = {};
   bool operator==(const SymbolDeclaration &other) const = default;
 };
 
 struct PAS_EXPORT SymbolTable {
   static const inline QString attributeName = u"generic:symbol_table"_qs;
+  static const inline uint8_t attribute = 17;
   QSharedPointer<symbol::Table> value = {};
   bool operator==(const SymbolTable &other) const = default;
 };

--- a/logic/asm/pas/ast/generic/attr_type.hpp
+++ b/logic/asm/pas/ast/generic/attr_type.hpp
@@ -30,6 +30,7 @@ struct PAS_EXPORT Type {
     Structural, // Root or section group nodes
   };
   static const inline QString attributeName = u"generic:type"_qs;
+  static const inline uint8_t attribute = 18;
   Types value; // The type of the node (i.e., pseudodirective, comment)
   bool operator==(const Type &other) const = default;
 };

--- a/logic/asm/pas/ast/node.cpp
+++ b/logic/asm/pas/ast/node.cpp
@@ -27,14 +27,14 @@ pas::ast::Node::Node(const pas::ast::generic::Type type, QWeakPointer<Node> pare
   set<generic::Children>({});
 }
 
-const QMap<QString, QVariant> pas::ast::Node::attributes() const {
+const QMap<uint8_t, QVariant> pas::ast::Node::attributes() const {
   auto ret = _attributes;
   // Attempt to prevent common data from being modified
   ret.detach();
   return ret;
 }
 
-void pas::ast::Node::fromAttributes(const QMap<QString, QVariant> attributes) {
+void pas::ast::Node::fromAttributes(const QMap<uint8_t, QVariant> attributes) {
   for (auto key = attributes.keyBegin(); key != attributes.keyEnd(); ++key) {
     _attributes[*key] = attributes[*key];
   }

--- a/logic/asm/pas/ast/node.hpp
+++ b/logic/asm/pas/ast/node.hpp
@@ -35,8 +35,8 @@ public:
   // Get && remove from attributes.
   template <typename T> T take();
   // do not modify
-  const QMap<QString, QVariant> attributes() const;
-  void fromAttributes(const QMap<QString, QVariant> attributes);
+  const QMap<uint8_t, QVariant> attributes() const;
+  void fromAttributes(const QMap<uint8_t, QVariant> attributes);
   template <typename T> void set(T attribute);
   template <typename T> T apply_self(ops::ConstOp<T> &transform) const;
   template <typename T> T apply_self(ops::MutatingOp<T> &transform);
@@ -55,31 +55,29 @@ public:
                           ops::MutatingOp<T> &transform);
 
 private:
-  QVariantMap _attributes;
+  QMap<uint8_t, QVariant> _attributes;
 };
 
-template <typename T> bool Node::has() const {
-  return _attributes.contains(T::attributeName);
-}
+template <typename T> bool Node::has() const { return _attributes.contains(T::attribute); }
 
 template <typename T> const T Node::get() const {
-  QVariant attribute = _attributes[T::attributeName];
+  QVariant attribute = _attributes[T::attribute];
   if (attribute.userType() != qMetaTypeId<T>())
     throw std::logic_error("Cannot convert");
   return attribute.value<T>();
 }
 
 template <typename T> T Node::take() {
-  QVariant attribute = _attributes[T::attributeName];
+  QVariant attribute = _attributes[T::attribute];
   if (attribute.userType() != qMetaTypeId<T>())
     throw std::logic_error("Cannot convert");
-  _attributes.remove(T::attributeName);
+  _attributes.remove(T::attribute);
   return attribute.value<T>();
 }
 
 template <typename T> void Node::set(T attribute) {
   // static_assert(QVariant::fromValue(attribute));
-  _attributes[T::attributeName] = QVariant::fromValue(attribute);
+  _attributes[T::attribute] = QVariant::fromValue(attribute);
 }
 
 template <typename T> T Node::apply_self(ops::ConstOp<T> &transform) const {

--- a/logic/asm/pas/ast/pepp/attr_addr.hpp
+++ b/logic/asm/pas/ast/pepp/attr_addr.hpp
@@ -21,6 +21,7 @@
 namespace pas::ast::pepp {
 template <typename ISA> struct AddressingMode {
   static const inline QString attributeName = u"pepp:addr"_qs;
+  static const inline uint8_t attribute = 1;
   typename ISA::AddressingMode value = {};
   bool operator==(const AddressingMode<ISA> &other) const = default;
 };

--- a/logic/asm/pas/ast/pepp/attr_instruction.hpp
+++ b/logic/asm/pas/ast/pepp/attr_instruction.hpp
@@ -21,6 +21,7 @@
 namespace pas::ast::pepp {
 template <typename ISA> struct Instruction {
   static const inline QString attributeName = u"pepp:instr"_qs;
+  static const inline uint8_t attribute = 19;
   typename ISA::Mnemonic value = {};
   bool operator==(const Instruction<ISA> &other) const = default;
 };

--- a/logic/asm/pas/operations/generic/clone.cpp
+++ b/logic/asm/pas/operations/generic/clone.cpp
@@ -32,29 +32,29 @@ QSharedPointer<pas::ast::Node> pas::ops::generic::clone::operator()(const ast::N
   auto attr = cloned->attributes();
   cloned->fromAttributes(attr);
   for (auto key = attr.keyBegin(); key != attr.keyEnd(); ++key) {
-    if (*key == ast::generic::Argument::attributeName) {
+    if (*key == ast::generic::Argument::attribute) {
       auto symbolArg = dynamic_cast<ast::value::Symbolic *>(node.get<Argument>().value.data());
       if (symbolArg != nullptr) {
         auto argument = QSharedPointer<ast::value::Symbolic>::create(entry(&*symbolArg->symbol()));
         cloned->set(Argument{.value = argument});
       } else cloned->set(node.get<Argument>());
-    } else if (*key == ast::generic::ArgumentList::attributeName) {
+    } else if (*key == ast::generic::ArgumentList::attribute) {
       auto args = node.get<ast::generic::ArgumentList>().value;
       for (int it = 0; it < args.size(); it++) {
         auto symbolArg = dynamic_cast<ast::value::Symbolic *>(args[it].data());
         if (symbolArg != nullptr) args[it] = QSharedPointer<ast::value::Symbolic>::create(entry(&*symbolArg->symbol()));
       }
       cloned->set(ArgumentList{.value = args});
-    } else if (*key == ast::generic::SymbolTable::attributeName) {
+    } else if (*key == ast::generic::SymbolTable::attribute) {
       cloned->set(SymbolTable{.value = table(&*cloned->get<ast::generic::SymbolTable>().value)});
-    } else if (*key == ast::generic::SymbolDeclaration::attributeName) {
+    } else if (*key == ast::generic::SymbolDeclaration::attribute) {
       auto oldSymbolDec = node.get<SymbolDeclaration>().value;
       // Value replication is handled by symbol table `fork`.
       auto newSymbolDec = SymbolDeclaration{.value = entry(&*oldSymbolDec)};
       cloned->set<SymbolDeclaration>(newSymbolDec);
-    } else if (*key == ast::generic::Parent::attributeName) {
+    } else if (*key == ast::generic::Parent::attribute) {
       cloned->set(Parent{.value = {}});
-    } else if (*key == ast::generic::Children::attributeName) {
+    } else if (*key == ast::generic::Children::attribute) {
       cloned->set(Children{.value = {}});
     }
   }


### PR DESCRIPTION
Remove string keys from nodes in favor of small integers.
Not really extensible, but I plan on replacing this library anyway.

Should generally help with performance.