### PR TITLE
Disable project reuse outside of help system

### DIFF
--- a/bin/gui/main.qml
+++ b/bin/gui/main.qml
@@ -143,7 +143,7 @@ ApplicationWindow {
 
     ProjectModel {
         id: pm
-        function onAddProject(arch, level, feats, optTexts) {
+        function onAddProject(arch, level, feats, optTexts, reuse) {
             var proj = null
             var cur = window.currentProject
             // Attach a delegate to the project which can render its edit/debug modes. Since it is a C++ property,
@@ -153,14 +153,14 @@ ApplicationWindow {
                 if (Number(level) === Abstraction.ISA3) {
                     if (cur && cur.architecture === Architecture.PEP10
                             && cur.abstraction === Abstraction.ISA3
-                            && cur.isEmpty)
+                            && cur.isEmpty && reuse)
                         proj = cur
                     else
                         proj = pm.pep10ISA(pep10isaComponent)
                 } else {
                     if (cur && cur.architecture === Architecture.PEP10
                             && cur.abstraction === Abstraction.ASMB5
-                            && cur.isEmpty)
+                            && cur.isEmpty && reuse)
                         proj = cur
                     else
                         proj = pm.pep10ASMB(pep10asmbComponent)
@@ -525,7 +525,7 @@ ApplicationWindow {
         standardButtons: Dialog.Close
     }
     function onNew() {
-        pm.onAddProject(Architecture.PEP10, Abstraction.ISA3, "")
+        pm.onAddProject(Architecture.PEP10, Abstraction.ISA3, "", false)
     }
     function onOpenDialog() {}
     function onCloseAllProjects(excludeCurrent: bool) {}

--- a/ui/help/HelpView.qml
+++ b/ui/help/HelpView.qml
@@ -25,11 +25,11 @@ Item {
     id: root
     property alias architecture: filterModel.architecture
     property alias abstraction: filterModel.abstraction
-    signal addProject(int level, int abstraction, string feats, var text)
+    signal addProject(int level, int abstraction, string feats, var text, bool reuse)
     signal setCharIn(string text)
     signal switchToMode(string mode)
     function addProjectWrapper(feats, texts, mode, tests) {
-        root.addProject(root.architecture, root.abstraction, feats, texts)
+        root.addProject(root.architecture, root.abstraction, feats, texts, true)
         if (tests && tests[0])
             root.setCharIn(tests[0].output)
         root.switchToMode(mode ?? "Edit")

--- a/ui/project/Welcome.qml
+++ b/ui/project/Welcome.qml
@@ -5,19 +5,21 @@ import edu.pepp 1.0
 
 Rectangle {
     color: 'purple'
-    signal addProject(string arch, string abstraction, string features)
+    signal addProject(string arch, string abstraction, string features, bool reuse)
     RowLayout {
         anchors.fill: parent
         anchors.centerIn: parent
         Button {
             text: "Create ISA project"
             Layout.alignment: Qt.AlignHCenter
-            onClicked: addProject(Architecture.PEP10, Abstraction.ISA3, "")
+            onClicked: addProject(Architecture.PEP10, Abstraction.ISA3,
+                                  "", false)
         }
         Button {
             text: "Create ASM project"
             Layout.alignment: Qt.AlignHCenter
-            onClicked: addProject(Architecture.PEP10, Abstraction.ASMB5, "")
+            onClicked: addProject(Architecture.PEP10, Abstraction.ASMB5,
+                                  "", false)
         }
     }
 }


### PR DESCRIPTION
Otherwise "+" and Welcome screen buttons do not work. Closes #561.