### PR TITLE
Simulator + menu fixes

### DIFF
--- a/lib/menu/Actions.qml
+++ b/lib/menu/Actions.qml
@@ -234,11 +234,15 @@ QtObject {
 
     readonly property var sim: QtObject {
         readonly property var clearCPU: Action {
+            enabled: project
+                     && project?.allowedDebugging & DebugEnableFlags.Start
             text: qsTr("Clear &CPU")
             onTriggered: project.onClearCPU()
             icon.source: "image://icons/blank.svg"
         }
         readonly property var clearMemory: Action {
+            enabled: project
+                     && project?.allowedDebugging & DebugEnableFlags.Start
             text: qsTr("Clear &Memory")
             onTriggered: project.onClearMemory()
             icon.source: "image://icons/blank.svg"

--- a/lib/menu/Actions.qml
+++ b/lib/menu/Actions.qml
@@ -136,6 +136,19 @@ QtObject {
             shortcut: "Ctrl+Shift+B"
             onShortcutChanged: updateNativeText(this)
         }
+        readonly property var assembleThenLoad: Action {
+            enabled: project?.onAssemble !== undefined
+            property string nativeText: ""
+            onTriggered: {
+                // New editor does not lose focus before "assemble" is triggered, so we must save manually.
+                window.preAssemble()
+                project.onAssemble(true)
+            }
+            text: qsTr("Assemble then &Load Object Code")
+            icon.source: `image://icons/build/flash${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`
+            shortcut: "Ctrl+Shift+L"
+            onShortcutChanged: updateNativeText(this)
+        }
         readonly property var assembleThenFormat: Action {
             enabled: project?.onAssembleThenFormat !== undefined
             property string nativeText: ""

--- a/lib/menu/NativeMainMenu.qml
+++ b/lib/menu/NativeMainMenu.qml
@@ -327,10 +327,12 @@ Labs.MenuBar {
     Labs.Menu {
         title: qsTr("&Simulator")
         Labs.MenuItem {
+            enabled: actions.sim.clearCPU.enabled
             text: actions.sim.clearCPU.text
             onTriggered: actions.sim.clearCPU.trigger()
         }
         Labs.MenuItem {
+            enabled: actions.sim.clearMemory.enabled
             text: actions.sim.clearMemory.text
             onTriggered: actions.sim.clearMemory.trigger()
         }

--- a/lib/menu/NativeMainMenu.qml
+++ b/lib/menu/NativeMainMenu.qml
@@ -241,6 +241,15 @@ Labs.MenuBar {
             shortcut: actions.build.assemble.shortcut
         }
         Labs.MenuItem {
+            text: actions.build.assembleThenLoad.text
+            onTriggered: actions.build.assembleThenLoad.trigger()
+            enabled: actions.build.assembleThenLoad.enabled
+            visible: enabled
+            icon.source: fixSuffix(actions.build.assembleThenLoad.icon.source,
+                                   wrapper.darkMode)
+            shortcut: actions.build.assembleThenLoad.shortcut
+        }
+        Labs.MenuItem {
             text: actions.build.assembleThenFormat.text
             onTriggered: actions.build.assembleThenFormat.trigger()
             enabled: actions.build.assembleThenFormat.enabled

--- a/lib/menu/QMLMainMenu.qml
+++ b/lib/menu/QMLMainMenu.qml
@@ -204,6 +204,15 @@ MenuBar {
             onPaletteChanged: fixTextColors(this)
         }
         ShortcutMenuItem {
+            action: actions.build.assembleThenLoad
+            enabled: action.enabled
+            visible: enabled
+            height: enabled ? implicitHeight : 0
+            onEnabledChanged: contentItem.enabled = enabled
+            contentItem.onEnabledChanged: fixTextColors(this)
+            onPaletteChanged: fixTextColors(this)
+        }
+        ShortcutMenuItem {
             action: actions.build.assembleThenFormat
             enabled: action.enabled
             visible: enabled

--- a/lib/menu/QMLMainMenu.qml
+++ b/lib/menu/QMLMainMenu.qml
@@ -281,9 +281,11 @@ MenuBar {
     Menu {
         title: qsTr("&Simulator")
         MenuItem {
+            enabled: actions.sim.clearCPU.enabled
             action: actions.sim.clearCPU
         }
         MenuItem {
+            enabled: actions.sim.clearMemory.enabled
             action: actions.sim.clearMemory
         }
     }

--- a/lib/project/pep10.cpp
+++ b/lib/project/pep10.cpp
@@ -638,7 +638,7 @@ bool Pep10_ASMB::onAssemble(bool doLoad) {
   emit clearListingBreakpoints();
   emit errorsChanged();
   if (!ret) {
-    message(utils::msg_asm_failed);
+    emit message(utils::msg_asm_failed);
     setObjectCodeText("");
     emit listingChanged();
     return false;
@@ -662,6 +662,7 @@ bool Pep10_ASMB::onAssemble(bool doLoad) {
   }
   setObjectCodeText(objectCodeText);
   emit requestSourceBreakpoints();
+  emit message(utils::msg_asm_success);
   return true;
 }
 

--- a/lib/project/pep10.cpp
+++ b/lib/project/pep10.cpp
@@ -394,9 +394,23 @@ bool Pep10_ISA::onISAStepInto() { return false; }
 
 bool Pep10_ISA::onISAStepOut() { return false; }
 
-bool Pep10_ISA::onClearCPU() { return false; }
+bool Pep10_ISA::onClearCPU() {
+  _system->cpu()->csrs()->clear(0);
+  _system->cpu()->regs()->clear(0);
+  // Reset trace buffer, since its content is now meaningless.
+  _tb->clear();
+  _flags->onUpdateGUI();
+  _registers->onUpdateGUI();
+  return true;
+}
 
-bool Pep10_ISA::onClearMemory() { return false; }
+bool Pep10_ISA::onClearMemory() {
+  _system->bus()->clear(0);
+  // Reset trace buffer, since its content is now meaningless.
+  _tb->clear();
+  _memory->clearModifiedAndUpdateGUI();
+  return true;
+}
 
 void Pep10_ISA::onDeferredExecution(sim::api2::trace::Action stopOn, project::StepEnableFlags::Value step) {
   auto pwrOff = _system->output("pwrOff");

--- a/lib/project/pep10.cpp
+++ b/lib/project/pep10.cpp
@@ -466,11 +466,16 @@ void Pep10_ISA::onDeferredExecution(sim::api2::trace::Action stopOn, project::St
   // Only terminates if something written to endpoint or there was an error
   if (endpoint->next_value().has_value() || err) {
     switch (_state) {
+      _system->bus()->trace(false);
+    case State::NormalExec:
+      _state = State::Halted;
+      emit allowedDebuggingChanged();
+      emit allowedStepsChanged();
+      break;
     case State::DebugExec: [[fallthrough]];
     case State::DebugPaused: onDebuggingStop(); break;
     default: break;
     }
-    _system->bus()->trace(false);
   }
   // Trigger a BP if we exceed a resonable number of chained executions
   else if (_stepsSinceLastInteraction++ > 10) {

--- a/lib/project/pep10.hpp
+++ b/lib/project/pep10.hpp
@@ -61,7 +61,7 @@ public:
   Q_INVOKABLE virtual bool isEmpty() const;
 public slots:
   bool onSaveCurrent();
-  bool onLoadObject();
+  virtual bool onLoadObject();
   bool onFormatObject();
   bool onExecute();
   virtual bool onDebuggingStart();

--- a/lib/utils/strings.hpp
+++ b/lib/utils/strings.hpp
@@ -19,5 +19,6 @@
 namespace utils {
 static const char *error_only_enums = "Only contains enums";
 static const char *error_only_project = "Can only be created through Project::";
-static const char *msg_asm_failed = "Assebmly failed; check source pane for errors";
-}
+static const char *msg_asm_failed = "Assembly failed; check source pane for errors";
+static const char *msg_asm_success = "Assembly succeeded";
+} // namespace utils


### PR DESCRIPTION
- Only enable Sim > Clear Memory/CPU when it makes sense.
- And actually do something on those events.
- Upon reaching the end of a simulation started from Build > Execute, notify the UI that sim stopped.
- Some behavior fixes for assembler