### PR TITLE
Improve tooltip for previous memory values

### DIFF
--- a/lib/memory/hexdump/rawmemory.hpp
+++ b/lib/memory/hexdump/rawmemory.hpp
@@ -25,6 +25,7 @@ public:
   virtual ~ARawMemory() = 0;
   virtual quint32 byteCount() const = 0;
   virtual quint8 read(quint32 address) const = 0;
+  virtual std::optional<quint8> readPrevious(quint32 address) const { return std::nullopt; }
   virtual MemoryHighlight::V status(quint32 address) const;
   virtual void write(quint32 address, quint8 value) = 0;
   virtual void clear() = 0;
@@ -88,6 +89,7 @@ public:
                               QObject *parent = nullptr);
   quint32 byteCount() const override;
   quint8 read(quint32 address) const override;
+  std::optional<quint8> readPrevious(quint32 address) const override;
   void setPC(quint32 start, quint32 end);
   void setSP(quint32 address);
   Q_INVOKABLE quint32 pc() const override;
@@ -104,6 +106,7 @@ public slots:
 
 private:
   sim::memory::SimpleBus<quint16> *_memory;
+  std::map<quint32, quint8> _modifiedCache;
   QSharedPointer<sim::trace2::ModifiedAddressSink<quint16>> _sink;
   static constexpr quint32 n1 = -1;
   sim::trace2::Interval<quint32> _PC = {n1, n1}, _SP = {n1, n1};

--- a/lib/project/pep10.cpp
+++ b/lib/project/pep10.cpp
@@ -750,6 +750,8 @@ void Pep10_ASMB::prepareSim() {
   // Repaint CPU
   _flags->onUpdateGUI();
   _registers->onUpdateGUI();
+  _memory->setSP(-1);
+  _memory->setPC(-1, -1);
   _memory->clearModifiedAndUpdateGUI();
 }
 


### PR DESCRIPTION
Add an API to separately ask for previous memory values. I'll have to modify my address sink to generate the necessary info, and this looks hard. I'll need to create some kind of interval map instead of an interval set.

Hide "previous" entries if there is none recorded. Progress on #588, re-implementing previous values will continue in #589.