### PR TITLE
fix(targets): store data necessary for re-loading OS

### DIFF
--- a/lib/sim/device/simple_bus.hpp
+++ b/lib/sim/device/simple_bus.hpp
@@ -190,7 +190,7 @@ void SimpleBus<Address>::pushFrontTarget(AddressSpan at, api2::memory::Target<Ad
 template <typename Address> sim::api2::memory::Target<Address> *SimpleBus<Address>::deviceAt(Address address) {
   auto region = _addrs.region_at(address);
   if (!region) return nullptr;
-  return _devices[region.device];
+  return _devices[region.value().device].second;
 }
 
 template <typename Address>

--- a/lib/targets/pep10/isa3/system.hpp
+++ b/lib/targets/pep10/isa3/system.hpp
@@ -66,6 +66,14 @@ private:
   sim::api2::device::IDGenerator _nextIDGenerator = [this]() { return _nextID++; };
   sim::api2::tick::Type _tick = 0;
   std::optional<quint16> _bootFlg = std::nullopt;
+  struct ReloadHelper {
+    QSharedPointer<sim::api2::memory::Target<quint16>> target;
+    quint16 base;
+    std::vector<quint8> data;
+  };
+  void appendReloadEntries(QSharedPointer<sim::api2::memory::Target<quint16>> mem, const obj::MemoryRegion &reg,
+                           quint16 baseOffset = 0);
+  QList<ReloadHelper> _regions;
 
   QSharedPointer<CPU> _cpu = nullptr;
   QSharedPointer<sim::memory::SimpleBus<quint16>> _bus = nullptr;


### PR DESCRIPTION
Trying to use the ELF file here is a pain, since I do not have the segment:target mappings Instead, copy over this data into a temporary struct which holds all the loading info.

In the future, my loadFromElf/loadRegions should probably use this too.