### PR TITLE
Do not show whole changelog in "What's New"

### DIFF
--- a/data/changelog/changes.csv
+++ b/data/changelog/changes.csv
@@ -30,3 +30,4 @@ Changed,Minor,0.7.4,,Made custom themes persistent between sessions in WASM
 Changed,,0.7.4,629,Re-order "Welcome" mode cards to match order of presentation in text
 Changed,,0.7.4,630,Remove banding for "Help" rows
 Fixed,,0.7.4,634,"In assembler symbol tables, differentiate between user program and OS symbols"
+Fixed,,0.7.4,638,Only show relevant changes in "What's New" startup dialog

--- a/lib/builtins/changelogmodel.cpp
+++ b/lib/builtins/changelogmodel.cpp
@@ -128,6 +128,16 @@ QHash<int, QByteArray> ChangelogModel::roleNames() const {
   return ret;
 }
 
+QVersionNumber ChangelogModel::min() const {
+  if (_versions.empty()) return {};
+  return _versions.last()->version();
+}
+
+QVersionNumber ChangelogModel::max() const {
+  if (_versions.empty()) return {};
+  return _versions.first()->version();
+}
+
 ChangelogFilterModel::ChangelogFilterModel(QObject *parent) : QSortFilterProxyModel(parent) {}
 
 void ChangelogFilterModel::setSourceModel(QAbstractItemModel *sourceModel) {
@@ -135,6 +145,8 @@ void ChangelogFilterModel::setSourceModel(QAbstractItemModel *sourceModel) {
   else if (auto casted = qobject_cast<ChangelogModel *>(sourceModel); casted == nullptr)
     qFatal("ChangelogFilterModel only accepts ChangelogModel as sourceModel");
   QSortFilterProxyModel::setSourceModel(sourceModel);
+  if (_min.isNull()) setMin(static_cast<ChangelogModel *>(sourceModel)->min().toString());
+  if (_max.isNull()) setMax(static_cast<ChangelogModel *>(sourceModel)->max().toString());
   emit sourceModelChanged();
 }
 
@@ -161,6 +173,7 @@ bool ChangelogFilterModel::filterAcceptsRow(int source_row, const QModelIndex &s
   if (!sm) return false;
   auto index = sm->index(source_row, 0, source_parent);
   auto version = sm->data(index, Qt::DisplayRole).value<Version *>()->version();
+  // qDebug() << reinterpret_cast<const int *>(this) << _min.toString() << _max.toString() << version.toString();
   if (!_min.isNull() && version < _min) return false;
   if (!_max.isNull() && version > _max) return false;
   return true;

--- a/lib/builtins/changelogmodel.hpp
+++ b/lib/builtins/changelogmodel.hpp
@@ -80,6 +80,8 @@ public:
   // Returns lots of Version objects
   QVariant data(const QModelIndex &index, int role) const override;
   QHash<int, QByteArray> roleNames() const override;
+  QVersionNumber min() const;
+  QVersionNumber max() const;
 
 private:
   QList<Version *> _versions{};


### PR DESCRIPTION
My dataflow was poorly designed before.
Setting the min would cause the min to become the minimum version ever. With some simplifications to the bindings, I have been able to avoid these propagation issues Closes #638.