### PR TITLE
Update CI builds to use Qt 6.8

### DIFF
--- a/.github/actions/install-qt-cmake/action.yml
+++ b/.github/actions/install-qt-cmake/action.yml
@@ -2,7 +2,7 @@ name: 'Install CMake & Qt'
 inputs:
   qt_version:
     required: true
-    default: '6.7.2'
+    default: '6.8.0'
   cache-key-prefix:
     required: false
 runs:
@@ -12,10 +12,11 @@ runs:
     - name: Install CMake and Ninja
       uses: lukka/get-cmake@v3.27.9
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
         version: ${{ inputs.qt_version }}
         cache: true
+        arch: ${runner.os == 'Windows' ? win64_msvc2019_64 : ''}
         extra: "--base https://mirrors.ocf.berkeley.edu/qt"
         tools: 'tools_ifw,qt.tools.ifw.47'
-        add-tools-to-path: true
+        modules: 'qtshadertools'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,11 @@ if (ONLY STREQUAL "BUILD")
     # Do not enable feature if lacking python.
     if(Python_FOUND AND (NOT FORCE_DISABLE_CHANGEDB))
         message("Generating changelog")
+        # Ensure that changelog exists at configure time, otherwise qt_add_resources will fail on some Mac platforms.
+        execute_process(
+            OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/changelog.db
+            COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/changelog_tools.py to_sql ${CMAKE_CURRENT_BINARY_DIR}/changelog.db
+            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
         # Ensure that target only rebuils iff the CSV files change using depends.
         add_custom_command(
                 OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/changelog.db


### PR DESCRIPTION
See Qt 6.8.0 release notes at:
  https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.8.0/release-note.md
Features we care about:
- [svgtoqml](https://doc.qt.io/qt-6.8/qtqml-tooling-svgtoqml.html) to make adapting the MC2 drawing easiers.
- [Qt Graphs](https://doc.qt.io/qt-6.8/qtgraphs-index.html) for drawing statistics-stuff
Also resolve build issues caused by version change.
