### PR TITLE
Main Menu Improvements in Qt 6.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,7 @@ if (ONLY STREQUAL "BUILD")
     set(CMAKE_CXX_STANDARD 20)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
     # We always want universal builds, so do not set on a per-target basis
-    find_package(Qt6 6.5 COMPONENTS REQUIRED Svg Quick Core Gui Qml Test Widgets QuickControls2 Xml Sql)
+    find_package(Qt6 6.8 COMPONENTS REQUIRED Svg Quick Core Gui Qml Test Widgets QuickControls2 Xml Sql)
     if(Qt6_VERSION  VERSION_GREATER_EQUAL 6.8)
       # Qt6.8/WASM stopped building without this flag being set.
       if(EMSCRIPTEN)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ When cloning this project, use `--recurse-submodules` to install relevant source
 
 | Required Build Tools                                               | Reason                                                                                                  |
 |--------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
-| [Qt 6.7](https://doc.qt.io/qt-6/get-and-install-qt.html) or later  | Required for cross-platform GUIs. Under "Additional libraries", install `Qt WebEngine` and `Qt WebView` |
+| [Qt 6.8](https://doc.qt.io/qt-6/get-and-install-qt.html) or later  | Required for cross-platform GUIs. Under "Additional libraries", install `Qt WebEngine` and `Qt WebView` |
 | [CMake 3.24](https://cmake.org/download/)or later                  | Required build system; usually bundled with Qt                                                          | 
 | [git lfs](https://git-lfs.com/)                                    | Required for binary assets, such as images an icons                                                     |
 
@@ -30,7 +30,7 @@ While not required, the following tools enable additional features in built appl
 
 | Optional Build Tools                                                         | Reason                                   |
 |------------------------------------------------------------------------------|------------------------------------------|
-| [Qt Creator 12](https://www.qt.io/download) or later                         | Preferred IDE for this project           |
+| [Qt Creator 14](https://www.qt.io/download) or later                         | Preferred IDE for this project           |
 | [QT IFW 4.7](https://doc.qt.io/qtinstallerframework/) or later               | Creates Windows installers               |
 | [Sphinx 7.1.2](https://www.sphinx-doc.org/en/master/usage/installation.html) | Generates application help documentation |
 


### PR DESCRIPTION
While I am planning to reject this, I want notes that I worked on it.
I tried to use the native menus described in the [linked blog](https://www.qt.io/blog/popups-and-menus-in-qt-quick-6.8).
However, menus fall back to Items in Windows and not a main menu bar.
At this time, I will skip this feature.
 