### PR TITLE
Add stack trace memory view

### DIFF
--- a/lib/memory/stack/ActivationRecordView.qml
+++ b/lib/memory/stack/ActivationRecordView.qml
@@ -47,7 +47,7 @@ Item {
                     width: 8 * tm.width
                     height: tm.height
                     font: tm.font
-                    text: `0x${model.address.toString(16).padStart(
+                    text: `${model.address.toString(16).padStart(
                               4, '0').toUpperCase()}`
                     horizontalAlignment: Text.AlignRight
                 }

--- a/lib/memory/stack/ActivationRecordView.qml
+++ b/lib/memory/stack/ActivationRecordView.qml
@@ -1,0 +1,96 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Item {
+    id: root
+    required property variant lineModel
+    required property bool active
+    // Helpers to "math" the position of the background rectangle.
+    property double valueX: 0
+    property double valueWidth: 0
+    property double valueY: 0
+    property double valueHeight: 0
+    property alias font: tm.font
+    implicitHeight: column.implicitHeight
+    implicitWidth: column.implicitWidth
+
+    TextMetrics {
+        id: tm
+        text: "W" // Dummy value to get width of widest character
+    }
+    // Sorry all, this bit is cursed.
+    // Instead of trying to do the "right thing" and use three columns+repeaters and place a rectangle
+    // around the center column inside the middle repeater, I'm opting to only use a single repeater.
+    // This reducs the amount of synchronization code between the repeaters/columns, but it also means
+    // we no longer obviously know where the middle column is.
+    // So, as we create our rows, we record the location of the middle column.
+    // We'll math out the location of the background rectangle using those values.
+    Rectangle {
+        id: background
+        x: root.valueX - border.width / 2
+        y: root.valueY - border.width / 2
+        color: "transparent"
+        width: root.valueWidth + border.width
+        height: (root.lineModel.lines.length * root.valueHeight) + border.width
+        border.color: root.active ? "black" : "transparent"
+        border.width: 4
+        z: 1
+    }
+    Column {
+        id: column
+        Repeater {
+            model: root.lineModel.lines
+            Row {
+                spacing: 10
+                Label {
+                    width: 8 * tm.width
+                    height: tm.height
+                    font: tm.font
+                    text: `0x${model.address.toString(16).padStart(
+                              4, '0').toUpperCase()}`
+                    horizontalAlignment: Text.AlignRight
+                }
+                Rectangle {
+                    id: valueRect
+                    width: 8 * tm.width
+                    height: tm.height + 2
+                    border.color: "black"
+                    border.width: 1
+                    Label {
+                        anchors.fill: parent
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                        font: tm.font
+                        text: model.value
+                    }
+                }
+                Label {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignLeft
+                    width: 8 * tm.width
+                    height: tm.height
+                    font: tm.font
+                    text: model.name
+                }
+                Component.onCompleted: {
+                    // Record position of the value column so we can place the background rect.
+                    if (model.row == 0) {
+                        root.valueX = Qt.binding(function () {
+                            return valueRect.x
+                        })
+                        root.valueWidth = Qt.binding(function () {
+                            return valueRect.width
+                        })
+                        root.valueY = Qt.binding(function () {
+                            return valueRect.y
+                        })
+                        root.valueHeight = Qt.binding(function () {
+                            return valueRect.height
+                        })
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lib/memory/stack/MemoryStack.qml
+++ b/lib/memory/stack/MemoryStack.qml
@@ -7,15 +7,14 @@ Item {
     property int stateChange: 0
     required property variant itemModel
     property alias font: tm.font
+    implicitHeight: column.childrenRect.height
 
-    Component.onCompleted: {
-        console.log(itemModel)
-    }
     TextMetrics {
         id: tm
         text: "W" // Dummy value to get width of widest character
     }
     Column {
+        id: column
         Repeater {
             id: repeater
             model: root.itemModel.records

--- a/lib/memory/stack/MemoryStack.qml
+++ b/lib/memory/stack/MemoryStack.qml
@@ -1,0 +1,122 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Item {
+    id: root
+    //property bool isHeader: false
+    property int stateChange: 0
+    //property int address: 0 //  Used by stack records
+    //property int charWidth: 8
+    required property variant itemModel
+    property alias font: tm.font
+
+    //anchors.fill: parent
+    Component.onCompleted: {
+        console.log(itemModel)
+    }
+    TextMetrics {
+        id: tm
+        text: "W" // Dummy value to get width of widest character
+    }
+
+    Row {
+        anchors.fill: parent
+
+        Column {
+            spacing: 0
+            Repeater {
+                model: root.itemModel
+                Item {
+                    width: addrCol2.width + 4
+                    height: addrCol2.childrenRect.height + 2
+                    Column {
+                        id: addrCol2
+                        property variant subItemModel: model.subItems
+                        anchors.centerIn: parent
+                        Repeater {
+                            //id: repeater2
+                            model: parent.subItemModel
+
+                            Label {
+                                width: 8 * tm.width
+                                height: tm.height
+                                font: tm.font
+                                text: `0x${model.address.toString(16).padStart(
+                                          4, '0').toUpperCase()}`
+                            }
+                        }
+                    }
+                }
+            }
+        } //  Column id: addrCol
+        Column {
+            spacing: 0
+            Repeater {
+                model: root.itemModel
+                Item {
+                    width: valCol2.width + 4
+                    height: valCol2.childrenRect.height + 2
+                    Rectangle {
+                        anchors.leftMargin: 1
+                        anchors.topMargin: 1
+
+                        border.color: index === 0 ? "tranparent" : "black"
+                        border.width: 1
+                        height: tm.height * model.subItems.count + 2
+                        width: 8 * tm.width + 4
+                        Column {
+                            id: valCol2
+                            property variant subItemModel: model.subItems
+                            anchors.centerIn: parent
+                            Repeater {
+                                model: parent.subItemModel
+
+                                Rectangle {
+                                    id: borderRect
+                                    border.color: "black"
+                                    border.width: 1
+                                    width: 8 * tm.width + 2 //  Margin around text
+                                    height: valLabel.height
+                                    Label {
+                                        id: valLabel
+                                        anchors.horizontalCenter: parent.horizontalCenter
+                                        font: tm.font
+                                        text: model.value
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } //  Column id: valCol
+        Column {
+            //  Name Column
+            spacing: 0
+            Repeater {
+                model: root.itemModel
+                Item {
+                    width: nameCol2.width + 4
+                    height: nameCol2.childrenRect.height + 2
+                    Column {
+                        id: nameCol2
+                        property variant subItemModel: model.subItems
+                        anchors.centerIn: parent
+                        Repeater {
+                            //id: repeater2
+                            model: parent.subItemModel
+
+                            Label {
+                                width: 8 * tm.width
+                                height: tm.height
+                                font: tm.font
+                                text: model.name
+                            }
+                        }
+                    }
+                }
+            }
+        } //  Column id: nameCol
+    } //  Row
+}

--- a/lib/memory/stack/MemoryStack.qml
+++ b/lib/memory/stack/MemoryStack.qml
@@ -4,14 +4,10 @@ import QtQuick.Layouts
 
 Item {
     id: root
-    //property bool isHeader: false
     property int stateChange: 0
-    //property int address: 0 //  Used by stack records
-    //property int charWidth: 8
     required property variant itemModel
     property alias font: tm.font
 
-    //anchors.fill: parent
     Component.onCompleted: {
         console.log(itemModel)
     }
@@ -19,104 +15,16 @@ Item {
         id: tm
         text: "W" // Dummy value to get width of widest character
     }
-
-    Row {
-        anchors.fill: parent
-
-        Column {
-            spacing: 0
-            Repeater {
-                model: root.itemModel
-                Item {
-                    width: addrCol2.width + 4
-                    height: addrCol2.childrenRect.height + 2
-                    Column {
-                        id: addrCol2
-                        property variant subItemModel: model.subItems
-                        anchors.centerIn: parent
-                        Repeater {
-                            //id: repeater2
-                            model: parent.subItemModel
-
-                            Label {
-                                width: 8 * tm.width
-                                height: tm.height
-                                font: tm.font
-                                text: `0x${model.address.toString(16).padStart(
-                                          4, '0').toUpperCase()}`
-                            }
-                        }
-                    }
-                }
+    Column {
+        Repeater {
+            id: repeater
+            model: root.itemModel.records
+            ActivationRecordView {
+                required property variant model
+                font: tm.font
+                lineModel: model
+                active: model.active
             }
-        } //  Column id: addrCol
-        Column {
-            spacing: 0
-            Repeater {
-                model: root.itemModel
-                Item {
-                    width: valCol2.width + 4
-                    height: valCol2.childrenRect.height + 2
-                    Rectangle {
-                        anchors.leftMargin: 1
-                        anchors.topMargin: 1
-
-                        border.color: index === 0 ? "tranparent" : "black"
-                        border.width: 1
-                        height: tm.height * model.subItems.count + 2
-                        width: 8 * tm.width + 4
-                        Column {
-                            id: valCol2
-                            property variant subItemModel: model.subItems
-                            anchors.centerIn: parent
-                            Repeater {
-                                model: parent.subItemModel
-
-                                Rectangle {
-                                    id: borderRect
-                                    border.color: "black"
-                                    border.width: 1
-                                    width: 8 * tm.width + 2 //  Margin around text
-                                    height: valLabel.height
-                                    Label {
-                                        id: valLabel
-                                        anchors.horizontalCenter: parent.horizontalCenter
-                                        font: tm.font
-                                        text: model.value
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        } //  Column id: valCol
-        Column {
-            //  Name Column
-            spacing: 0
-            Repeater {
-                model: root.itemModel
-                Item {
-                    width: nameCol2.width + 4
-                    height: nameCol2.childrenRect.height + 2
-                    Column {
-                        id: nameCol2
-                        property variant subItemModel: model.subItems
-                        anchors.centerIn: parent
-                        Repeater {
-                            //id: repeater2
-                            model: parent.subItemModel
-
-                            Label {
-                                width: 8 * tm.width
-                                height: tm.height
-                                font: tm.font
-                                text: model.name
-                            }
-                        }
-                    }
-                }
-            }
-        } //  Column id: nameCol
-    } //  Row
+        }
+    }
 }

--- a/lib/memory/stack/StackItem.qml
+++ b/lib/memory/stack/StackItem.qml
@@ -1,0 +1,66 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Controls.Material
+import QtQuick.Layouts
+
+Item {
+    id: root
+    property bool isHeader: false
+    property int stateChange: 0
+    property int address: 0 //  Used by stack records
+    property string heading: "" //  Only used by header record
+    property string value: ""
+    property string name: ""
+    property int charWidth: 8
+
+    property color textColor: palette.text
+    property font font: Theme.font
+
+    RowLayout {
+        anchors.fill: parent
+        Rectangle {
+            id: addr
+            Layout.fillHeight: true
+            Layout.fillWidth: false
+            Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+            Layout.minimumWidth: 8 * charWidth
+            Layout.maximumWidth: 8 * charWidth
+            Label {
+                anchors.left: parent.left
+                color: root.textColor
+                font: root.font
+                text: isHeader ? heading : `0x${root.address.toString(
+                                     16).padStart(4, '0').toUpperCase()}`
+            }
+        }
+        Rectangle {
+            id: val
+            border.color: isHeader ? "transparent" : palette.text
+            border.width: 1.5
+            color: stateChange !== 0 ? palette.highlight : palette.base
+            Layout.fillHeight: true
+            Layout.fillWidth: false
+            Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+            Layout.minimumWidth: 7 * charWidth
+            Layout.maximumWidth: 7 * charWidth
+            Label {
+                anchors.centerIn: parent
+                color: stateChange !== 0 ? palette.highlightedText : root.textColor
+                font: root.font
+                text: root.value
+            }
+        }
+        Rectangle {
+            id: name
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+            Label {
+                anchors.left: parent.left
+                color: root.textColor
+                font: root.font
+                text: root.name
+            }
+        }
+    }
+}

--- a/lib/memory/stack/StackTrace.qml
+++ b/lib/memory/stack/StackTrace.qml
@@ -5,7 +5,7 @@ Rectangle {
     color: "orange"
 
     // Create C++ items using the magic of QQmlPropertyList and DefaultProperty
-    /*ActivationModel {
+    ActivationModel {
         id: activationModel
         ActivationRecord {
             active: true
@@ -46,60 +46,6 @@ Rectangle {
                 name: "f"
             }
         }
-    }*/
-
-    ListModel {
-        id: activationModel
-        ListElement {
-            active: false
-            subItems: [
-                ListElement {
-                    address: 0
-                    value: "10"
-                    name: "a"
-                },
-                ListElement {
-                    address: 2
-                    value: "20"
-                    name: "b"
-                }
-            ]
-        }
-        ListElement {
-            active: true
-            subItems: [
-                ListElement {
-                    address: 4
-                    value: "30"
-                    name: "c"
-                },
-                ListElement {
-                    address: 12
-                    value: "200"
-                    name: "b2"
-                }
-            ]
-        }
-        ListElement {
-            active: true
-            subItems: [
-                ListElement {
-                    address: 6
-                    value: "40"
-                    name: "d"
-                },
-                ListElement {
-                    address: 7
-                    value: "50"
-                    name: "e"
-                },
-                ListElement {
-                    address: 9
-                    value: "60"
-                    name: "f"
-                }
-            ]
-        }
     }
 
     //  Globals
@@ -117,58 +63,10 @@ Rectangle {
 
         //Column {
         MemoryStack {
-            //Layout.alignment: Qt.AlignBottom
-            //anchors.fill: parent
             //y: 100
             font: tm.font
             itemModel: activationModel
         }
         //}
     }
-
-
-    /*ListView {
-            anchors.fill: parent
-            spacing: 0
-            //  Using example 5.22 for sample global
-            model: ListModel {
-
-                //active: true
-                ListElement {
-                    address: 3
-                    value: "M"
-                    name: "ch"
-                    action: 0
-                }
-                ListElement {
-                    address: 4
-                    value: "419"
-                    name: "j"
-                    action: 1
-                }
-            }
-
-            header: StackItem {
-                isHeader: true
-                heading: "Address"
-                value: "Value"
-                name: "Name"
-                z: 2 //  Make sure header is on top of children
-                charWidth: tm.width
-                implicitWidth: tm.width * 24
-                implicitHeight: tm.height
-            }
-            delegate: StackItem {
-                address: model.address
-                value: model.value
-                name: model.name
-                stateChange: model.action
-                charWidth: tm.width
-                implicitWidth: tm.width * 24
-                implicitHeight: tm.height
-            }
-
-            //focus: true
-        }
-    }*/
 }

--- a/lib/memory/stack/StackTrace.qml
+++ b/lib/memory/stack/StackTrace.qml
@@ -5,7 +5,7 @@ Rectangle {
     color: "orange"
 
     // Create C++ items using the magic of QQmlPropertyList and DefaultProperty
-    ActivationModel {
+    /*ActivationModel {
         id: activationModel
         ActivationRecord {
             active: true
@@ -46,6 +46,60 @@ Rectangle {
                 name: "f"
             }
         }
+    }*/
+
+    ListModel {
+        id: activationModel
+        ListElement {
+            active: false
+            subItems: [
+                ListElement {
+                    address: 0
+                    value: "10"
+                    name: "a"
+                },
+                ListElement {
+                    address: 2
+                    value: "20"
+                    name: "b"
+                }
+            ]
+        }
+        ListElement {
+            active: true
+            subItems: [
+                ListElement {
+                    address: 4
+                    value: "30"
+                    name: "c"
+                },
+                ListElement {
+                    address: 12
+                    value: "200"
+                    name: "b2"
+                }
+            ]
+        }
+        ListElement {
+            active: true
+            subItems: [
+                ListElement {
+                    address: 6
+                    value: "40"
+                    name: "d"
+                },
+                ListElement {
+                    address: 7
+                    value: "50"
+                    name: "e"
+                },
+                ListElement {
+                    address: 9
+                    value: "60"
+                    name: "f"
+                }
+            ]
+        }
     }
 
     //  Globals
@@ -61,7 +115,19 @@ Rectangle {
             text: "W" // Dummy value to get width of widest character
         }
 
-        ListView {
+        //Column {
+        MemoryStack {
+            //Layout.alignment: Qt.AlignBottom
+            //anchors.fill: parent
+            //y: 100
+            font: tm.font
+            itemModel: activationModel
+        }
+        //}
+    }
+
+
+    /*ListView {
             anchors.fill: parent
             spacing: 0
             //  Using example 5.22 for sample global
@@ -103,29 +169,6 @@ Rectangle {
             }
 
             //focus: true
-        }
-    }
-
-
-    /*
-            text: `0x${root.currentAddress.toString(16).padStart(
-                      4, '0').toUpperCase()}`
-Column {
-        anchors.fill: parent
-        Repeater {
-            model: activationModel.records
-            delegate: Column {
-                id: recordDelegate
-                required property var modelData
-                Repeater {
-                    model: modelData.lines
-                    delegate: Text {
-                        required property var modelData
-                        text: `${modelData.address} -- ${modelData.value} -- ${modelData.name}`
-                        font.bold: recordDelegate.modelData.active
-                    }
-                }
-            }
         }
     }*/
 }

--- a/lib/memory/stack/StackTrace.qml
+++ b/lib/memory/stack/StackTrace.qml
@@ -2,8 +2,6 @@ import QtQuick 2.15
 import edu.pepp 1.0
 
 Rectangle {
-    color: "orange"
-
     // Create C++ items using the magic of QQmlPropertyList and DefaultProperty
     ActivationModel {
         id: activationModel
@@ -53,6 +51,7 @@ Rectangle {
         //width: 180
         //height: 200
         anchors.fill: parent
+        anchors.topMargin: 8
         color: palette.base
 
         TextMetrics {

--- a/lib/memory/stack/StackTrace.qml
+++ b/lib/memory/stack/StackTrace.qml
@@ -3,6 +3,7 @@ import edu.pepp 1.0
 
 Rectangle {
     color: "orange"
+
     // Create C++ items using the magic of QQmlPropertyList and DefaultProperty
     ActivationModel {
         id: activationModel
@@ -47,7 +48,69 @@ Rectangle {
         }
     }
 
-    Column {
+    //  Globals
+    Rectangle {
+        //width: 180
+        //height: 200
+        anchors.fill: parent
+        color: palette.base
+
+        TextMetrics {
+            id: tm
+            font: Theme.font
+            text: "W" // Dummy value to get width of widest character
+        }
+
+        ListView {
+            anchors.fill: parent
+            spacing: 0
+            //  Using example 5.22 for sample global
+            model: ListModel {
+
+                //active: true
+                ListElement {
+                    address: 3
+                    value: "M"
+                    name: "ch"
+                    action: 0
+                }
+                ListElement {
+                    address: 4
+                    value: "419"
+                    name: "j"
+                    action: 1
+                }
+            }
+
+            header: StackItem {
+                isHeader: true
+                heading: "Address"
+                value: "Value"
+                name: "Name"
+                z: 2 //  Make sure header is on top of children
+                charWidth: tm.width
+                implicitWidth: tm.width * 24
+                implicitHeight: tm.height
+            }
+            delegate: StackItem {
+                address: model.address
+                value: model.value
+                name: model.name
+                stateChange: model.action
+                charWidth: tm.width
+                implicitWidth: tm.width * 24
+                implicitHeight: tm.height
+            }
+
+            //focus: true
+        }
+    }
+
+
+    /*
+            text: `0x${root.currentAddress.toString(16).padStart(
+                      4, '0').toUpperCase()}`
+Column {
         anchors.fill: parent
         Repeater {
             model: activationModel.records
@@ -64,5 +127,5 @@ Rectangle {
                 }
             }
         }
-    }
+    }*/
 }

--- a/lib/memory/stack/StackTrace.qml
+++ b/lib/memory/stack/StackTrace.qml
@@ -1,7 +1,16 @@
-import QtQuick 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import edu.pepp 1.0
 
 Rectangle {
+
+    color: palette.base
+    TextMetrics {
+        id: tm
+        font: Theme.font
+        text: "W" // Dummy value to get width of widest character
+    }
     // Create C++ items using the magic of QQmlPropertyList and DefaultProperty
     ActivationModel {
         id: activationModel
@@ -46,26 +55,39 @@ Rectangle {
         }
     }
 
-    //  Globals
-    Rectangle {
-        //width: 180
-        //height: 200
+    ScrollView {
         anchors.fill: parent
         anchors.topMargin: 8
-        color: palette.base
+        contentWidth: column.width // The important part
+        contentHeight: column.height // Same
+        clip: true // Prevent drawing column outside the scrollview borders
 
-        TextMetrics {
-            id: tm
-            font: Theme.font
-            text: "W" // Dummy value to get width of widest character
+        ColumnLayout {
+            id: column
+            MemoryStack {
+                //y: 100
+                id: globals
+                font: tm.font
+                itemModel: activationModel
+            }
+            Item {
+                id: globalHeapBreak
+                implicitHeight: 40
+            }
+            MemoryStack {
+                id: heap
+                font: tm.font
+                itemModel: activationModel
+            }
+            Item {
+                Layout.fillHeight: true
+                implicitHeight: 80
+            }
+            MemoryStack {
+                id: stack
+                font: tm.font
+                itemModel: activationModel
+            }
         }
-
-        //Column {
-        MemoryStack {
-            //y: 100
-            font: tm.font
-            itemModel: activationModel
-        }
-        //}
     }
 }


### PR DESCRIPTION
Add a stack trace (like Pep/9s) to the Asmb/3 & Asmb/5 levels of abstraction.

Unlike Pep/9's stack trace, we want the globals, heap, and stack to be vertical stacked with each other rather than horizontally to preserve space in the UI.
By stacking these memory ranges in this order, the stack trace will be presented in the same logical order as the hex dump (low addresses at the top, high addresses at the bottom).

At the moment, the `C++` data model is **not** tied to the simulator.
To enable this integration, I first need to extend the assembler to handle trace tags.
Until this integration exists, I will continue to use dummy data.