### PR TITLE
Fix copying & importing palettes on Mac

### DIFF
--- a/lib/settings/palettemanager.cpp
+++ b/lib/settings/palettemanager.cpp
@@ -57,11 +57,11 @@ QHash<int, QByteArray> pepp::settings::PaletteManager::roleNames() const
 QString userThemeDir() { return QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/themes"; }
 void pepp::settings::PaletteManager::reload()
 {
-  emit beginResetModel();
+  beginResetModel();
   _palettes.clear();
   loadFrom(":/themes");
   loadFrom(userThemeDir());
-  emit endResetModel();
+  endResetModel();
 }
 
 int pepp::settings::PaletteManager::copy(int row) {

--- a/lib/settings/palettemanager.cpp
+++ b/lib/settings/palettemanager.cpp
@@ -74,6 +74,8 @@ int pepp::settings::PaletteManager::copy(int row) {
   else targetFile.setFile(targetFile.absolutePath(), entry.name + ".theme");
   entry.path = targetFile.absoluteFilePath();
   entry.isSystem = false;
+  // Maye need to create the directory or copy will fail.
+  QDir().mkpath(userThemeDir());
   if (!QFile::copy(_palettes[row].path, entry.path)) return -1;
   beginInsertRows({}, row, row);
   _palettes.append(entry);
@@ -96,6 +98,8 @@ int pepp::settings::PaletteManager::importTheme(QString path) {
   else name = src.completeBaseName();
 
   QFileInfo dest(userThemeDir(), src.fileName());
+  // Maye need to create the directory or copy will fail.
+  QDir().mkpath(userThemeDir());
   if (!QFile::copy(path, dest.absoluteFilePath())) return -1;
 
   beginInsertRows({}, _palettes.size() - 1, _palettes.size() - 1);


### PR DESCRIPTION
Probably helps Linux too.

Closes #689.