### PR TITLE
More last-minute fixes

### DIFF
--- a/lib/builtins/HelpRoot.qml
+++ b/lib/builtins/HelpRoot.qml
@@ -100,7 +100,7 @@ Item {
                         helpModel.architecture = Qt.binding(
                                     () => architectureModel.get(
                                         architectureCombo.currentIndex)?.value
-                                    ?? Architecture.PEP10)
+                                    ?? Architecture.PEP9)
                     }
                 }
             }
@@ -138,7 +138,7 @@ Item {
                 model: HelpModel {}
                 // Sane defaults
                 abstraction: Abstraction.ASMB5
-                architecture: Architecture.PEP10
+                architecture: Architecture.PEP9
                 onAbstractionChanged: root.selected = treeView.index(0, 0)
                 onArchitectureChanged: root.selected = treeView.index(0, 0)
                 Component.onCompleted: {

--- a/lib/builtins/HelpRoot.qml
+++ b/lib/builtins/HelpRoot.qml
@@ -8,6 +8,10 @@ Item {
     id: root
     property var architecture: 0
     property var abstraction: 0
+    NuAppSettings {
+        id: settings
+    }
+
     onArchitectureChanged: {
         var idx = 0
         for (var i = 0; i < architectureModel.count; i++) {
@@ -139,6 +143,7 @@ Item {
                 // Sane defaults
                 abstraction: Abstraction.ASMB5
                 architecture: Architecture.PEP9
+                showWIPItems: settings.general.showDebugComponents
                 onAbstractionChanged: root.selected = treeView.index(0, 0)
                 onArchitectureChanged: root.selected = treeView.index(0, 0)
                 Component.onCompleted: {

--- a/lib/builtins/helpdata.cpp
+++ b/lib/builtins/helpdata.cpp
@@ -24,27 +24,33 @@ QSharedPointer<HelpEntry> writing_root() {
   auto microcode10_language =
       QSharedPointer<HelpEntry>::create(HelpCategory::Category::Text, mc10, "Microcode", "MDText.qml");
   microcode10_language->props = QVariantMap{{"file", QVariant(u":/help/pep10/writing_mc.md"_s)}};
+  microcode10_language->isWIP = true;
   auto machine10_language =
       QSharedPointer<HelpEntry>::create(HelpCategory::Category::Text, oc10, "Machine Language", "MDText.qml");
   machine10_language->props = QVariantMap{{"file", QVariant(u":/help/pep10/writing_oc.md"_s)}};
+  machine10_language->isWIP = true;
   auto assembly10_language =
       QSharedPointer<HelpEntry>::create(HelpCategory::Category::Text, as10, "Assembly Language", "MDText.qml");
   assembly10_language->props = QVariantMap{{"file", QVariant(u":/help/pep10/writing_asmb.md"_s)}};
+  assembly10_language->isWIP = true;
   auto root = QSharedPointer<HelpEntry>::create(HelpCategory::Category::Text, p10, "Writing Programs", "MDText.qml");
   root->props = QVariantMap{{"file", QVariant(u":/help/pep10/writing_progs.md"_s)}},
   root->addChildren({microcode10_language, machine10_language, assembly10_language});
+  root->isWIP = true;
   return root;
 }
 
 QSharedPointer<HelpEntry> debugging_root() {
   auto root = QSharedPointer<HelpEntry>::create(HelpCategory::Category::Text, -1, "Debugging Programs", "MDText.qml");
   root->props = QVariantMap{{"file", QVariant(u":/help/pep10/debugging_progs.md"_s)}};
+  root->isWIP = true;
   return root;
 }
 
 QSharedPointer<HelpEntry> systemcalls_root() {
   auto root = QSharedPointer<HelpEntry>::create(HelpCategory::Category::Text, -1, "Writing System Calls", "MDText.qml");
   root->props = QVariantMap{{"file", QVariant(u":/help/pep10/debugging_progs.md"_s)}};
+  root->isWIP = true;
   return root;
 }
 
@@ -64,7 +70,10 @@ QSharedPointer<HelpEntry> greencard10_root() {
   auto alu = QSharedPointer<HelpEntry>::create(HelpCategory::Category::Text, -1, "ALU Functions", "MDText.qml");
   alu->props = QVariantMap{{"file", QVariant(u":/help/pep10/debugging_progs.md"_s)}};
   auto root = QSharedPointer<HelpEntry>::create(HelpCategory::Category::ISAGreenCard, -1, "Pep/10 Reference", "ISA");
-  root->addChildren({c_bit, n_bit, addr, reg, mmio, alu});
+  QVector<QSharedPointer<HelpEntry>> children{c_bit, n_bit, addr, reg, mmio, alu};
+  for (auto &c : children) c->isWIP = true;
+  root->addChildren(children);
+  root->isWIP = true;
   // TODO: probably need to add props...
   return root;
 }

--- a/lib/builtins/helpmodel.hpp
+++ b/lib/builtins/helpmodel.hpp
@@ -32,6 +32,8 @@ public:
   QVariantMap props = {};
   void addChild(QSharedPointer<HelpEntry> child);
   void addChildren(QVector<QSharedPointer<HelpEntry>> children);
+  // TODO: remove when all are no longer WIP.
+  bool isWIP = false;
 
 private:
   friend HelpModel;
@@ -45,7 +47,7 @@ class HelpModel : public QAbstractItemModel {
   QML_ELEMENT
 
 public:
-  enum class Roles { Category = Qt::UserRole + 1, Tags, Name, Delegate, Props };
+  enum class Roles { Category = Qt::UserRole + 1, Tags, Name, Delegate, Props, WIP };
   Q_ENUM(Roles);
   explicit HelpModel(QObject *parent = nullptr);
   QModelIndex index(int row, int column, const QModelIndex &parent) const override;
@@ -73,6 +75,7 @@ class HelpFilterModel : public QSortFilterProxyModel {
   Q_PROPERTY(builtins::Architecture architecture READ architecture WRITE setArchitecture NOTIFY architectureChanged)
   Q_PROPERTY(builtins::Abstraction abstraction READ abstraction WRITE setAbstraction NOTIFY abstractionChanged)
   Q_PROPERTY(QAbstractItemModel *model READ sourceModel WRITE setSourceModel NOTIFY sourceModelChanged)
+  Q_PROPERTY(bool showWIPItems READ showWIPItems WRITE setShowWIPItems NOTIFY showWIPItemsChanged)
   QML_NAMED_ELEMENT(FilteredHelpModel)
 
 public:
@@ -83,6 +86,8 @@ public:
   void setArchitecture(builtins::Architecture architecture);
   builtins::Abstraction abstraction() const;
   void setAbstraction(builtins::Abstraction abstraction);
+  bool showWIPItems() const;
+  void setShowWIPItems(bool show);
 
 protected:
   bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
@@ -91,8 +96,10 @@ signals:
   void sourceModelChanged();
   void architectureChanged();
   void abstractionChanged();
+  void showWIPItemsChanged();
 
 private:
   builtins::Architecture _architecture = builtins::Architecture::NONE;
   builtins::Abstraction _abstraction = builtins::Abstraction::NONE;
+  bool _showWIPItems = false;
 };

--- a/lib/menu/Actions.qml
+++ b/lib/menu/Actions.qml
@@ -252,15 +252,13 @@ QtObject {
 
     readonly property var sim: QtObject {
         readonly property var clearCPU: Action {
-            enabled: project
-                     && project?.allowedDebugging & DebugEnableFlags.Start
+            enabled: project?.allowedDebugging & DebugEnableFlags.Start
             text: qsTr("Clear &CPU")
             onTriggered: project.onClearCPU()
             icon.source: "image://icons/blank.svg"
         }
         readonly property var clearMemory: Action {
-            enabled: project
-                     && project?.allowedDebugging & DebugEnableFlags.Start
+            enabled: project?.allowedDebugging & DebugEnableFlags.Start
             text: qsTr("Clear &Memory")
             onTriggered: project.onClearMemory()
             icon.source: "image://icons/blank.svg"

--- a/lib/menu/NativeMainMenu.qml
+++ b/lib/menu/NativeMainMenu.qml
@@ -64,12 +64,6 @@ Labs.MenuBar {
                                    wrapper.darkMode)
             shortcut: actions.file.save.shortcut
         }
-        Labs.MenuSeparator {
-            id: _saveAsPrev
-        }
-        Labs.MenuSeparator {
-            id: _closePrev
-        }
         Labs.MenuSeparator {}
         Labs.MenuItem {
             text: actions.edit.prefs.text

--- a/lib/menu/ShortcutMenuItem.qml
+++ b/lib/menu/ShortcutMenuItem.qml
@@ -6,7 +6,8 @@ import edu.pepp 1.0
 MenuItem {
     id: wrapper
     property var color: palette.text
-    Label {
+
+    /*Label {
         anchors.verticalCenter: parent.verticalCenter
         anchors.right: parent.right
         text: wrapper.action.nativeText
@@ -14,5 +15,5 @@ MenuItem {
         horizontalAlignment: Text.AlignLeft
         rightPadding: tm.width
         color: wrapper.color
-    }
+    }*/
 }

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -325,6 +325,8 @@ Item {
                     text: qsTr("Hex Dump")
                 }
                 TabButton {
+                    visible: settings.general.showDebugComponents
+                    enabled: visible
                     text: qsTr("Stack Trace")
                 }
             }

--- a/lib/settings/GeneralCategoryDelegate.qml
+++ b/lib/settings/GeneralCategoryDelegate.qml
@@ -93,6 +93,20 @@ Item {
                     Label {
                         text: qsTr("Default project abstraction")
                     }
+                    CheckBox {
+                        id: showDebug
+                        Component.onCompleted: checked = category.showDebugComponents
+                        onCheckedChanged: category.showDebugComponents = checked
+                        Connections {
+                            target: category
+                            function onShowDebugComponentsChanged() {
+                                showDebug.checked = category.showDebugComponents
+                            }
+                        }
+                    }
+                    Label {
+                        text: "Show work-in-progress UI components"
+                    }
                 }
             }
             GroupBox {

--- a/lib/settings/settings.cpp
+++ b/lib/settings/settings.cpp
@@ -6,6 +6,7 @@ pepp::settings::Category::Category(QObject *parent) : QObject(parent) {}
 // General
 static const char *defaultArchKey = "General/defaultArch";
 static const char *defaultAbstractionKey = "General/defaultAbstraction";
+static const char *showDebugKey = "General/showDebug";
 static const char *maxRecentFilesKey = "General/maxRecentFiles";
 static const char *showMenuHotkeysKey = "General/showMenuHotkeys";
 static const char *showChangeDialogKey = "General/showChangeDialog";
@@ -56,6 +57,22 @@ builtins::Abstraction pepp::settings::GeneralCategory::defaultAbstraction() cons
     _settings.setValue(defaultAbstractionKey, (int)defaultDefaultAbstraction);
     return defaultDefaultAbstraction;
   }
+}
+
+bool pepp::settings::GeneralCategory::showDebugComponents() const
+{
+  auto value = _settings.value(showDebugKey);
+  if (value.isValid()) return value.toBool();
+  else {
+    _settings.setValue(showDebugKey, defaultShowDebugComponents);
+    return defaultShowDebugComponents;
+  }
+}
+
+void pepp::settings::GeneralCategory::setShowDebugComponents(bool show)
+{
+  _settings.setValue(showDebugKey, show);
+  emit showDebugComponentsChanged();
 }
 
 void pepp::settings::GeneralCategory::setDefaultAbstraction(builtins::Abstraction abstraction) {

--- a/lib/settings/settings.hpp
+++ b/lib/settings/settings.hpp
@@ -72,7 +72,7 @@ signals:
 
 private:
   mutable QSettings _settings;
-  const builtins::Architecture defaultDefaultArch = builtins::Architecture::PEP10;
+  const builtins::Architecture defaultDefaultArch = builtins::Architecture::PEP9;
   const builtins::Abstraction defaultDefaultAbstraction = builtins::Abstraction::ASMB5;
   const bool defaultShowDebugComponents = false;
   bool validateMaxRecentFiles(int max) const;

--- a/lib/settings/settings.hpp
+++ b/lib/settings/settings.hpp
@@ -34,6 +34,8 @@ class GeneralCategory : public Category {
   Q_PROPERTY(builtins::Architecture defaultArch READ defaultArch WRITE setDefaultArch NOTIFY defaultArchChanged)
   Q_PROPERTY(builtins::Abstraction defaultAbstraction READ defaultAbstraction WRITE setDefaultAbstraction NOTIFY
                  defaultAbstractionChanged)
+  Q_PROPERTY(
+      bool showDebugComponents READ showDebugComponents WRITE setShowDebugComponents NOTIFY showDebugComponentsChanged)
   // "Menus" group box
   Q_PROPERTY(int maxRecentFiles READ maxRecentFiles WRITE setMaxRecentFiles NOTIFY maxRecentFilesChanged)
   Q_PROPERTY(bool showMenuHotkeys READ showMenuHotkeys WRITE setShowMenuHotkeys NOTIFY showMenuHotkeysChanged)
@@ -50,6 +52,8 @@ public:
   builtins::Architecture defaultArch() const;
   void setDefaultArch(builtins::Architecture arch);
   builtins::Abstraction defaultAbstraction() const;
+  bool showDebugComponents() const;
+  void setShowDebugComponents(bool show);
   void setDefaultAbstraction(builtins::Abstraction abstraction);
   int maxRecentFiles() const;
   void setMaxRecentFiles(int max);
@@ -61,6 +65,7 @@ public:
 signals:
   void defaultArchChanged();
   void defaultAbstractionChanged();
+  void showDebugComponentsChanged();
   void maxRecentFilesChanged();
   void showMenuHotkeysChanged();
   void showChangeDialogChanged();
@@ -69,6 +74,7 @@ private:
   mutable QSettings _settings;
   const builtins::Architecture defaultDefaultArch = builtins::Architecture::PEP10;
   const builtins::Abstraction defaultDefaultAbstraction = builtins::Abstraction::ASMB5;
+  const bool defaultShowDebugComponents = false;
   bool validateMaxRecentFiles(int max) const;
   const int defaultMaxRecentFiles = 5;
   const bool defaultShowMenuHotkeys = true;

--- a/lib/top/WelcomeCard.qml
+++ b/lib/top/WelcomeCard.qml
@@ -91,6 +91,7 @@ Rectangle {
             }
         ]
         transitions: Transition {
+            id: slideAnimation
             NumberAnimation {
                 properties: "height"
             }
@@ -106,12 +107,28 @@ Rectangle {
                 border.width: height
                 width: parent.width
             }
-            Text {
-                id: description
-                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
-                color: palette.text
-                wrapMode: Text.WordWrap
+            Flickable {
+                id: flickable
+                clip: true
                 width: parent.width
+                height: parent.height - bar.height
+                contentHeight: description.height
+                ScrollBar.vertical: ScrollBar {
+                    id: scrollBar
+                    anchors.right: parent.right
+                    // Don't show bar if animating.
+                    policy: (!slideAnimation.running && flickable.contentHeight
+                             > flickable.height) ? ScrollBar.AlwaysOn : ScrollBar.AlwaysOff
+                }
+                Text {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    id: description
+                    text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                    color: palette.text
+                    wrapMode: Text.WordWrap
+                    width: parent.width - scrollBar.width
+                }
             }
         }
     }


### PR DESCRIPTION
- Set default arch to Pep/9
- Hide WIP components (stack trace, unimplemented help categories) by default. Can be changed in settings.
- Remove redundant menu spacers, disable simulator menus where appropriate.
- Prevent overflow on welcome card text