### PR TITLE
Allow trackpad to scroll text editor(s)

### DIFF
--- a/lib/text/editor/ScintillaAsmEdit.qml
+++ b/lib/text/editor/ScintillaAsmEdit.qml
@@ -104,6 +104,7 @@ Item {
                 horizontalScrollBar.increase()
             }
         }
+        acceptedDevices: PointerDevice.AllDevices
     }
     // the QuickScintilla control
     Pepp.ScintillaAsmEditBase {


### PR DESCRIPTION
You no longer need to click to refresh the contents of the editor. At this point, it may actually be too touchy.

Closes #747.