### PR TITLE
Re-enable "Copy to Project" in help system

### DIFF
--- a/lib/project/pep10.hpp
+++ b/lib/project/pep10.hpp
@@ -97,6 +97,7 @@ signals:
   void message(QString message);
   void updateGUI(sim::api2::trace::FrameIterator from);
   void deferredExecution(std::function<bool()> step);
+  void overwriteEditors();
 
 protected:
   void bindToSystem();

--- a/lib/top/ProjectSelectBar.qml
+++ b/lib/top/ProjectSelectBar.qml
@@ -85,6 +85,7 @@ Flickable {
                 for (const list of Object.entries(optTexts))
                     proj.set(list[0], list[1])
             }
+            proj.overwriteEditors()
             onMarkActiveDirty(false)
         }
         function renameCurrentProject(string) {


### PR DESCRIPTION
Usually, data flows unidirectionally from the editor to the project. However, the help system is allowed to replace the "guts" of a project. Using the overwriteEditors signal, we can have a one-off sync from the project to the editor, after which unidirectional dataflow resumes.

Without this modification, "copy to project" is a useless button.