### PR TITLE
Disable OS4 projects by default

### DIFF
--- a/lib/top/Welcome.qml
+++ b/lib/top/Welcome.qml
@@ -5,6 +5,10 @@ import edu.pepp 1.0
 
 Flickable {
     signal addProject(string arch, string abstraction, string features, bool reuse)
+    NuAppSettings {
+        id: settings
+    }
+
     ScrollView {
         anchors.fill: parent
         GridLayout {
@@ -99,7 +103,7 @@ Flickable {
                 text: "Pep/10, OS4"
                 architecture: Architecture.PEP10
                 abstraction: Abstraction.OS4
-                enabled: true
+                enabled: settings.general.showDebugComponents
             }
             WelcomeCard {
                 text: "Pep/10, Mc2, 1-byte bus"


### PR DESCRIPTION
The UI is not fully implemented, so I do not want the feature visible in main.

Visibility is controlled with the "hide debug components" setting.