### PR TITLE
Fix deployment issues with QML dialogs

### DIFF
--- a/bin/src/commands/gui.cpp
+++ b/bin/src/commands/gui.cpp
@@ -112,14 +112,6 @@ int gui_main(const gui_args &args) {
   // TODO: connect to PreferenceModel, read field corresponding to QPalette (Disabled, Text) field.
   engine.addImageProvider(QLatin1String("icons"), new PreferenceAwareImageProvider);
 
-  /*QDirIterator i(":/qt/qml/Pepp", QDirIterator::Subdirectories);
-  while (i.hasNext()) {
-    auto f = QFileInfo(i.next());
-    if (!f.isFile())
-      continue;
-    qDebug() << f.filePath();
-  }*/
-
   static const auto default_entry = u"qrc:/qt/qml/Pepp/src/main.qml"_s;
   const QUrl url(args.QMLEntry.isEmpty() ? default_entry : args.QMLEntry);
 #ifdef __EMSCRIPTEN__

--- a/bin/src/commands/ls-qrc.cpp
+++ b/bin/src/commands/ls-qrc.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023-2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "ls-qrc.hpp"
+#include <iostream>
+
+ListQRCTask::ListQRCTask(QString path, QObject *parent) : Task(parent), _path(path) {}
+
+void ListQRCTask::run() {
+  QDirIterator i(":/" + _path, QDirIterator::Subdirectories);
+  while (i.hasNext()) {
+    auto f = QFileInfo(i.next());
+    std::cout << f.filePath().toStdString() << std::endl;
+  }
+  return emit finished(0);
+}

--- a/bin/src/commands/ls-qrc.hpp
+++ b/bin/src/commands/ls-qrc.hpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023-2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "../shared.hpp"
+#include "../task.hpp"
+
+class ListQRCTask : public Task {
+public:
+  ListQRCTask(QString path, QObject *parent = nullptr);
+  void run() override;
+
+private:
+  QString _path;
+};
+
+void registerListQRC(auto &app, task_factory_t &task, detail::SharedFlags &flags) {
+  static std::string path = "";
+  static auto list_qrc = app.add_subcommand("ls-qrc", "Produce list of items in Qt's resource system");
+  auto dir = list_qrc->add_option("path", path, "Directory, relative to :/, to recursively enumerate");
+  list_qrc->group("");
+  list_qrc->callback([&]() {
+    flags.kind = detail::SharedFlags::Kind::TERM;
+    task = [&](QObject *parent) { return new ListQRCTask(QString::fromStdString(path), parent); };
+  });
+}

--- a/bin/src/main.cpp
+++ b/bin/src/main.cpp
@@ -25,6 +25,7 @@
 #include "commands/get.hpp"
 #include "commands/gui.hpp"
 #include "commands/license.hpp"
+#include "commands/ls-qrc.hpp"
 #include "commands/ls.hpp"
 #include "commands/run.hpp"
 #include "commands/selftest.hpp"
@@ -60,6 +61,7 @@ int main(int argc, char **argv) {
   registerSelfTest(app, task, shared_flags);
 
   registerList(app, task, shared_flags);
+  registerListQRC(app, task, shared_flags);
   registerGet(app, task, shared_flags);
 
   registerAsm(app, task, shared_flags);

--- a/bin/src/main.qml
+++ b/bin/src/main.qml
@@ -15,10 +15,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+// If you want a plugin loaded, you better import it here.
 import QtQuick
 import QtQuick.Window
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQuick.Dialogs
 import Qt.labs.qmlmodels
 import QtCore
 import "qrc:/edu/pepp/about" as About


### PR DESCRIPTION
For now, all QML modules must be imported in `main.qml` otherwise the build system forgets about them.

I'm sure when I refactor the QML build code this issue will go away, but this hack will remain for now.