### PR TITLE
refactor: silence compiler warnings

### DIFF
--- a/3rd-party/scintilla/scintilla/src/Editor.cxx
+++ b/3rd-party/scintilla/scintilla/src/Editor.cxx
@@ -1522,7 +1522,7 @@ bool Editor::WrapBlock(Surface *surface, Sci::Line lineToWrap, Sci::Line lineToW
 	std::vector<std::future<void>> futures;
 	for (size_t th = 0; th < threads; th++) {
 		std::future<void> fut = std::async(policy,
-			[=, &surface, &nextIndex, &linesAfterWrap, &mutexRetrieve]() {
+            [=, this, &surface, &nextIndex, &linesAfterWrap, &mutexRetrieve]() {
 			// llTemporary is reused for non-significant lines, avoiding allocation costs.
 			std::shared_ptr<LineLayout> llTemporary = std::make_shared<LineLayout>(-1, 200);
 			while (true) {

--- a/lib/settings/paletteitem.hpp
+++ b/lib/settings/paletteitem.hpp
@@ -83,7 +83,6 @@ class EditorPaletteItem : public PaletteItem {
   Q_OBJECT
   QML_ELEMENT
   Q_PROPERTY(QFont macroFont READ macroFont WRITE setMacroFont NOTIFY preferenceChanged);
-  Q_PROPERTY(QFont macroFont READ macroFont WRITE setMacroFont NOTIFY preferenceChanged);
 
 public:
   struct EditorOptions {


### PR DESCRIPTION
Clang compiles about implicit capture of this by =.
Remove duplicated Q_PROPERTY.