### PR TITLE
Add watch expression UI

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -47,7 +47,7 @@ target_include_directories(pepp-lib PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${ANTLR4_
 target_include_directories(pepp-lib PRIVATE
         about builtins components cpu helpers isa
         link macro memory memory/hexdump memory/stack preferences project
-        sim targets text utils text/editor menu settings top
+        sim sim/debug targets text utils text/editor menu settings top
 )
 
 # Add additional JS support files

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -58,6 +58,7 @@ Item {
         wrapper.actions.build.execute.triggered.connect(
                     wrapper.requestModeSwitchToDebugger)
         onOverwriteEditors()
+        project.updateGUI.connect(watchExpr.updateGUI)
     }
     // Will be called before project is changed on unload, so we can disconnect save-triggering signals.
     Component.onDestruction: {
@@ -91,6 +92,7 @@ Item {
                     wrapper.requestModeSwitchToDebugger)
         wrapper.actions.build.execute.triggered.disconnect(
                     wrapper.requestModeSwitchToDebugger)
+        project.updateGUI.disconnect(watchExpr.updateGUI)
     }
     signal requestModeSwitchTo(string mode)
     function requestModeSwitchToDebugger() {

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -7,6 +7,7 @@ import "qrc:/edu/pepp/memory/hexdump" as Memory
 import "qrc:/edu/pepp/memory/io" as IO
 import "qrc:/edu/pepp/cpu" as Cpu
 import "qrc:/edu/pepp/symtab" as SymTab
+import "qrc:/edu/pepp/sim/debug" as Debug
 import edu.pepp 1.0
 
 Item {
@@ -257,6 +258,9 @@ Item {
                         TabButton {
                             text: qsTr(`Symbol Table: ${textSelector.currentText}`)
                         }
+                        TabButton {
+                            text: qsTr(`Watch Expressions`)
+                        }
                     }
                     StackLayout {
                         Layout.fillWidth: true
@@ -273,6 +277,9 @@ Item {
                             id: symTab
                             model: textSelector.currentIndex
                                    === 0 ? project?.userSymbols : project?.osSymbols
+                        }
+                        Debug.WatchExpressions {
+                            id: watchExpr
                         }
                     }
                 }

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -280,6 +280,7 @@ Item {
                         }
                         Debug.WatchExpressions {
                             id: watchExpr
+                            watchExpressions: project.watchExpressions
                         }
                     }
                 }

--- a/lib/project/pep10.cpp
+++ b/lib/project/pep10.cpp
@@ -839,6 +839,21 @@ int Pep_ASMB::allowedDebugging() const {
   }
 }
 
+uint8_t Pep_ASMB::read_mem_u8(uint32_t address) const {
+  if (_system == nullptr) return 0;
+  quint8 temp = 0;
+  _system->bus()->read((uint16_t)address, {&temp, 1}, gs);
+  return temp;
+}
+
+uint16_t Pep_ASMB::read_mem_u16(uint32_t address) const {
+  if (_system == nullptr) return 0;
+  quint16 temp = 0;
+  _system->bus()->read((uint16_t)address, {(quint8 *)&temp, 2}, gs);
+  if (bits::hostOrder() != bits::Order::BigEndian) temp = bits::byteswap(temp);
+  return temp;
+}
+
 pepp::debug::TypedBits Pep_ASMB::evaluate_variable(QStringView name) const {
   using T = pepp::debug::ExpressionType;
   return {.allows_address_of = true, .type = T::i16, .bits = (uint64_t)name.length()};

--- a/lib/project/pep10.cpp
+++ b/lib/project/pep10.cpp
@@ -740,7 +740,8 @@ project::DebugEnableFlags::DebugEnableFlags(QObject *parent) : QObject(parent) {
 project::StepEnableFlags::StepEnableFlags(QObject *parent) : QObject(parent) {}
 
 Pep_ASMB::Pep_ASMB(project::Environment env, QVariant delegate, QObject *parent)
-    : Pep_ISA(env, delegate, parent, false), _userModel(new SymbolModel(this)), _osModel(new SymbolModel(this)) {
+    : Pep_ISA(env, delegate, parent, false), _userModel(new SymbolModel(this)), _osModel(new SymbolModel(this)),
+      _watchExpressions(new pepp::debug::WatchExpressionModel(this)) {
 
   switch (_env.arch) {
   case builtins::Architecture::PEP9: _osAsmText = cs5e_os(); break;
@@ -773,7 +774,6 @@ Pep_ASMB::Pep_ASMB(project::Environment env, QVariant delegate, QObject *parent)
   }
   default: throw std::logic_error("Unimplemented architecture");
   }
-
 }
 
 void Pep_ASMB::set(int abstraction, QString value) {
@@ -825,6 +825,8 @@ bool Pep_ASMB::isEmpty() const { return _userAsmText.isEmpty(); }
 
 SymbolModel *Pep_ASMB::userSymbols() const { return _userModel; }
 SymbolModel *Pep_ASMB::osSymbols() const { return _osModel; }
+
+pepp::debug::WatchExpressionModel *Pep_ASMB::watchExpressions() const { return _watchExpressions; }
 
 int Pep_ASMB::allowedDebugging() const {
   using D = project::DebugEnableFlags;

--- a/lib/project/pep10.cpp
+++ b/lib/project/pep10.cpp
@@ -862,10 +862,10 @@ pepp::debug::TypedBits Pep_ASMB::evaluate_debug_variable(uint32_t cache_id) cons
   switch (cache_id) {
   case static_cast<uint32_t>(DV::A):
     targets::isa::readRegister<isa::Pep10>(cpu->regs(), isa::Pep10::Register::A, reg16, gs);
-    return pepp::debug::from_int(reg16);
+    return pepp::debug::from_int((int16_t)reg16);
   case static_cast<uint32_t>(DV::X):
     targets::isa::readRegister<isa::Pep10>(cpu->regs(), isa::Pep10::Register::X, reg16, gs);
-    return pepp::debug::from_int(reg16);
+    return pepp::debug::from_int((int16_t)reg16);
   case static_cast<uint32_t>(DV::SP):
     targets::isa::readRegister<isa::Pep10>(cpu->regs(), isa::Pep10::Register::SP, reg16, gs);
     return pepp::debug::from_int(reg16);
@@ -874,7 +874,7 @@ pepp::debug::TypedBits Pep_ASMB::evaluate_debug_variable(uint32_t cache_id) cons
     return pepp::debug::from_int(reg16);
   case static_cast<uint32_t>(DV::IS):
     targets::isa::readRegister<isa::Pep10>(cpu->regs(), isa::Pep10::Register::IS, reg16, gs);
-    return pepp::debug::from_int(reg16);
+    return pepp::debug::from_int((int8_t)reg16);
   case static_cast<uint32_t>(DV::OS):
     targets::isa::readRegister<isa::Pep10>(cpu->regs(), isa::Pep10::Register::OS, reg16, gs);
     return pepp::debug::from_int(reg16);

--- a/lib/project/pep10.hpp
+++ b/lib/project/pep10.hpp
@@ -185,6 +185,8 @@ public:
   Q_INVOKABLE SymbolModel *osSymbols() const;
   Q_INVOKABLE pepp::debug::WatchExpressionModel *watchExpressions() const;
   int allowedDebugging() const override;
+  uint8_t read_mem_u8(uint32_t address) const override;
+  uint16_t read_mem_u16(uint32_t address) const override;
   pepp::debug::TypedBits evaluate_variable(QStringView name) const override;
   uint32_t cache_debug_variable_name(QStringView name) const override;
   pepp::debug::TypedBits evaluate_debug_variable(uint32_t name) const override;

--- a/lib/project/pep10.hpp
+++ b/lib/project/pep10.hpp
@@ -40,6 +40,16 @@ class Pep_ISA : public QObject {
   QML_UNCREATABLE("Can only be created through Project::")
 
 public:
+  enum class DebugVariables {
+    A = 10,
+    X,
+    SP,
+    PC,
+    IS,
+    OS,
+  };
+  Q_ENUM(DebugVariables);
+
   enum class UpdateType {
     Partial,
     Full,
@@ -142,7 +152,7 @@ public:
   QString error;
 };
 
-class Pep_ASMB final : public Pep_ISA {
+class Pep_ASMB final : public Pep_ISA, public pepp::debug::Environment {
   Q_OBJECT
   Q_PROPERTY(QString userAsmText READ userAsmText WRITE setUserAsmText NOTIFY userAsmTextChanged);
   Q_PROPERTY(QString userList READ userList NOTIFY listingChanged);
@@ -175,6 +185,9 @@ public:
   Q_INVOKABLE SymbolModel *osSymbols() const;
   Q_INVOKABLE pepp::debug::WatchExpressionModel *watchExpressions() const;
   int allowedDebugging() const override;
+  pepp::debug::TypedBits evaluate_variable(QStringView name) const override;
+  uint32_t cache_debug_variable_name(QStringView name) const override;
+  pepp::debug::TypedBits evaluate_debug_variable(uint32_t name) const override;
 public slots:
   bool onDebuggingStart() override;
   bool onAssemble(bool doLoad = false);

--- a/lib/project/pep10.hpp
+++ b/lib/project/pep10.hpp
@@ -10,6 +10,7 @@
 #include "debug/debugger.hpp"
 #include "helpers/asmb.hpp"
 #include "memory/hexdump/rawmemory.hpp"
+#include "sim/debug/watchexpressionmodel.hpp"
 #include "symtab/symbolmodel.hpp"
 #include "targets/isa3/system.hpp"
 #include "text/editor/scintillaasmeditbase.hpp"
@@ -152,6 +153,7 @@ class Pep_ASMB final : public Pep_ISA {
   Q_PROPERTY(QList<Error *> assemblerErrors READ errors NOTIFY errorsChanged)
   Q_PROPERTY(SymbolModel *userSymbols READ userSymbols CONSTANT)
   Q_PROPERTY(SymbolModel *osSymbols READ osSymbols CONSTANT)
+  Q_PROPERTY(pepp::debug::WatchExpressionModel *watchExpressions READ watchExpressions CONSTANT)
   QML_UNCREATABLE("Can only be created through Project::")
   using Action = ScintillaAsmEditBase::Action;
 
@@ -171,6 +173,7 @@ public:
   bool isEmpty() const override;
   Q_INVOKABLE SymbolModel *userSymbols() const;
   Q_INVOKABLE SymbolModel *osSymbols() const;
+  Q_INVOKABLE pepp::debug::WatchExpressionModel *watchExpressions() const;
   int allowedDebugging() const override;
 public slots:
   bool onDebuggingStart() override;
@@ -206,4 +209,5 @@ protected:
   QString _userList = {}, _osList = {};
   QList<QPair<int, QString>> _errors = {}, _userListAnnotations = {}, _osListAnnotations = {};
   helpers::AsmHelper::Lines2Addresses _userLines2Address = {}, _osLines2Address = {};
+  pepp::debug::WatchExpressionModel *_watchExpressions = nullptr;
 };

--- a/lib/sim/debug/WatchExpressions.qml
+++ b/lib/sim/debug/WatchExpressions.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.15
+
+Rectangle {
+    color: "magenta"
+}

--- a/lib/sim/debug/WatchExpressions.qml
+++ b/lib/sim/debug/WatchExpressions.qml
@@ -36,6 +36,7 @@ Item {
         model: WatchExpressionTableModel {
             id: tableModel
         }
+        clip: true
 
         delegate: Item {
             implicitWidth: Math.max(8 * fm.averageCharacterWidth,

--- a/lib/sim/debug/WatchExpressions.qml
+++ b/lib/sim/debug/WatchExpressions.qml
@@ -3,6 +3,9 @@ import QtQuick.Controls
 import edu.pepp
 
 Item {
+    NuAppSettings {
+        id: settings
+    }
     FontMetrics {
         id: fm
     }
@@ -50,7 +53,7 @@ Item {
                 text: model.display ?? ""
                 rightPadding: 10
                 leftPadding: 2
-                color: model.changed ? palette.brightText : palette.windowText
+                color: model.changed ? settings.extPalette.error.background : palette.windowText
                 visible: !editing
                 font.italic: model.italicize
             }

--- a/lib/sim/debug/WatchExpressions.qml
+++ b/lib/sim/debug/WatchExpressions.qml
@@ -39,16 +39,28 @@ Item {
 
         delegate: Item {
             implicitWidth: Math.max(8 * fm.averageCharacterWidth,
-                                    label.implicitWidth + 12)
-            implicitHeight: label.implicitHeight
+                                    textView.implicitWidth + 12)
+            implicitHeight: textView.implicitHeight * 1.3
+            required property bool editing
 
             Text {
-                id: label
+                id: textView
                 anchors.fill: parent
                 text: model.display
                 rightPadding: 10
                 leftPadding: 2
                 color: model.changed ? palette.brightText : palette.windowText
+                visible: !editing
+            }
+
+            TableView.editDelegate: TextField {
+                id: textEdit
+                x: textView.x
+                y: textView.y
+                width: textView.width
+                height: textView.height
+                text: display
+                TableView.onCommit: display = text
             }
         }
     }

--- a/lib/sim/debug/WatchExpressions.qml
+++ b/lib/sim/debug/WatchExpressions.qml
@@ -1,5 +1,59 @@
-import QtQuick 2.15
+import QtQuick
+import QtQuick.Controls
+import Qt.labs.qmlmodels
 
-Rectangle {
-    color: "magenta"
+Item {
+    HorizontalHeaderView {
+        id: horizontalHeader
+        anchors.left: tableView.left
+        anchors.top: parent.top
+        syncView: tableView
+        clip: true
+        model: tableView.model
+        textRole: "display"
+        delegate: TextInput {
+            text: model.display
+        }
+    }
+    TableView {
+        id: tableView
+        anchors.left: parent.left
+        anchors.top: horizontalHeader.bottom
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        boundsBehavior: Flickable.StopAtBounds
+        resizableColumns: true
+        model: TableModel {
+            TableModelColumn {
+                display: "Expression"
+            }
+            TableModelColumn {
+                display: "Value"
+            }
+            TableModelColumn {
+                display: "Type"
+            }
+
+            rows: [{
+                    "Value": 1,
+                    "Expression": "$x",
+                    "Type": "i16"
+                }, {
+                    "Value": 4,
+                    "Expression": "(u8)($x + 3)",
+                    "Type": "u8"
+                }, {
+                    "Value": 1,
+                    "Expression": "$X * $x",
+                    "Type": "i16"
+                }]
+        }
+        delegate: TextInput {
+            text: model.display
+            selectByMouse: true
+            onAccepted: model.display = text
+            rightPadding: 10
+            leftPadding: 2
+        }
+    }
 }

--- a/lib/sim/debug/WatchExpressions.qml
+++ b/lib/sim/debug/WatchExpressions.qml
@@ -6,6 +6,10 @@ Item {
     FontMetrics {
         id: fm
     }
+    signal updateGUI
+    Component.onCompleted: {
+        updateGUI.connect(tableModel.onUpdateGUI)
+    }
 
     property alias watchExpressions: tableModel.watchExpressions
     HorizontalHeaderView {
@@ -44,6 +48,7 @@ Item {
                 text: model.display
                 rightPadding: 10
                 leftPadding: 2
+                color: model.changed ? palette.brightText : palette.windowText
             }
         }
     }

--- a/lib/sim/debug/WatchExpressions.qml
+++ b/lib/sim/debug/WatchExpressions.qml
@@ -46,11 +46,12 @@ Item {
             Text {
                 id: textView
                 anchors.fill: parent
-                text: model.display
+                text: model.display ?? ""
                 rightPadding: 10
                 leftPadding: 2
                 color: model.changed ? palette.brightText : palette.windowText
                 visible: !editing
+                font.italic: model.italicize
             }
 
             TableView.editDelegate: TextField {
@@ -59,7 +60,7 @@ Item {
                 y: textView.y
                 width: textView.width
                 height: textView.height
-                text: display
+                text: model.italicize ? "" : display
                 TableView.onCommit: display = text
             }
         }

--- a/lib/sim/debug/WatchExpressions.qml
+++ b/lib/sim/debug/WatchExpressions.qml
@@ -1,18 +1,24 @@
 import QtQuick
 import QtQuick.Controls
-import Qt.labs.qmlmodels
+import edu.pepp
 
 Item {
+    FontMetrics {
+        id: fm
+    }
+
+    property alias watchExpressions: tableModel.watchExpressions
     HorizontalHeaderView {
         id: horizontalHeader
-        anchors.left: tableView.left
         anchors.top: parent.top
+        anchors.left: tableView.left
+        anchors.right: parent.right
         syncView: tableView
         clip: true
-        model: tableView.model
         textRole: "display"
-        delegate: TextInput {
+        delegate: Text {
             text: model.display
+            horizontalAlignment: Text.AlignLeft
         }
     }
     TableView {
@@ -23,37 +29,22 @@ Item {
         anchors.bottom: parent.bottom
         boundsBehavior: Flickable.StopAtBounds
         resizableColumns: true
-        model: TableModel {
-            TableModelColumn {
-                display: "Expression"
-            }
-            TableModelColumn {
-                display: "Value"
-            }
-            TableModelColumn {
-                display: "Type"
-            }
-
-            rows: [{
-                    "Value": 1,
-                    "Expression": "$x",
-                    "Type": "i16"
-                }, {
-                    "Value": 4,
-                    "Expression": "(u8)($x + 3)",
-                    "Type": "u8"
-                }, {
-                    "Value": 1,
-                    "Expression": "$X * $x",
-                    "Type": "i16"
-                }]
+        model: WatchExpressionTableModel {
+            id: tableModel
         }
-        delegate: TextInput {
-            text: model.display
-            selectByMouse: true
-            onAccepted: model.display = text
-            rightPadding: 10
-            leftPadding: 2
+
+        delegate: Item {
+            implicitWidth: Math.max(8 * fm.averageCharacterWidth,
+                                    label.implicitWidth + 12)
+            implicitHeight: label.implicitHeight
+
+            Text {
+                id: label
+                anchors.fill: parent
+                text: model.display
+                rightPadding: 10
+                leftPadding: 2
+            }
         }
     }
 }

--- a/lib/sim/debug/expr_ast.cpp
+++ b/lib/sim/debug/expr_ast.cpp
@@ -67,8 +67,24 @@ QString pepp::debug::Constant::to_string() const {
   using namespace Qt::Literals::StringLiterals;
   using namespace pepp::debug;
   switch (format_hint) {
-  case detail::UnsignedConstant::Format::Dec: return u"%1"_s.arg(value.bits, 0, 10);
-  case detail::UnsignedConstant::Format::Hex: return u"0x%1"_s.arg(value.bits, 0, 16);
+  case detail::UnsignedConstant::Format::Dec:
+    switch (value.type) {
+    case pepp::debug::ExpressionType::i8: return u"%1_i8"_s.arg((int8_t)value.bits, 0, 10);
+    case pepp::debug::ExpressionType::u8: return u"%1_u8"_s.arg((uint8_t)value.bits, 0, 10);
+    case pepp::debug::ExpressionType::i16: return u"%1"_s.arg((int16_t)value.bits, 0, 10);
+    case pepp::debug::ExpressionType::u16: return u"%1_u16"_s.arg((uint16_t)value.bits, 0, 10);
+    case pepp::debug::ExpressionType::i32: return u"%1_i32"_s.arg((int32_t)value.bits, 0, 10);
+    case pepp::debug::ExpressionType::u32: return u"%1_u32"_s.arg((uint32_t)value.bits, 0, 10);
+    }
+  case detail::UnsignedConstant::Format::Hex:
+    switch (value.type) {
+    case pepp::debug::ExpressionType::i8: return u"0x%1_i8"_s.arg((uint8_t)value.bits, 0, 16);
+    case pepp::debug::ExpressionType::u8: return u"0x%1_u8"_s.arg((uint8_t)value.bits, 0, 16);
+    case pepp::debug::ExpressionType::i16: return u"0x%1"_s.arg((uint16_t)value.bits, 0, 16);
+    case pepp::debug::ExpressionType::u16: return u"0x%1_u16"_s.arg((uint16_t)value.bits, 0, 16);
+    case pepp::debug::ExpressionType::i32: return u"0x%1_i32"_s.arg((uint32_t)value.bits, 0, 16);
+    case pepp::debug::ExpressionType::u32: return u"0x%1_u32"_s.arg((uint32_t)value.bits, 0, 16);
+    }
   }
 }
 

--- a/lib/sim/debug/expr_ast.cpp
+++ b/lib/sim/debug/expr_ast.cpp
@@ -144,6 +144,7 @@ pepp::debug::TypedBits pepp::debug::UnaryPrefix::evaluate(CachePolicy mode, Envi
   case Operators::NOT: return *(_state.value = !v);
   case Operators::NEGATE: return *(_state.value = ~v);
   }
+  throw std::logic_error("Unimplemented");
 }
 
 int pepp::debug::UnaryPrefix::cv_qualifiers() const {
@@ -255,6 +256,7 @@ pepp::debug::TypedBits pepp::debug::BinaryInfix::evaluate(CachePolicy mode, Envi
   case Operators::BIT_OR: return *(_state.value = v_lhs | v_rhs);
   case Operators::BIT_XOR: return *(_state.value = v_lhs ^ v_rhs);
   }
+  throw std::logic_error("Unimplemented");
 }
 int pepp::debug::BinaryInfix::cv_qualifiers() const {
   switch (op) {

--- a/lib/sim/debug/expr_ast.cpp
+++ b/lib/sim/debug/expr_ast.cpp
@@ -433,8 +433,10 @@ pepp::debug::TypedBits pepp::debug::DebuggerVariable::evaluate(CachePolicy mode,
     default: break;
     }
   }
+  if (!_name_cache_id.has_value()) _name_cache_id = env.cache_debug_variable_name(name);
+
   _state.dirty = false;
-  return *(_state.value = env.evaluate_debug_variable(name));
+  return *(_state.value = env.evaluate_debug_variable(*_name_cache_id));
 }
 
 int pepp::debug::DebuggerVariable::cv_qualifiers() const { return CVQualifiers::Volatile; }

--- a/lib/sim/debug/expr_ast.hpp
+++ b/lib/sim/debug/expr_ast.hpp
@@ -106,6 +106,7 @@ struct DebuggerVariable : public Term {
   const QString name;
 
 private:
+  std::optional<uint32_t> _name_cache_id = std::nullopt;
   EvaluationCache _state;
 };
 

--- a/lib/sim/debug/expr_ast_ops.cpp
+++ b/lib/sim/debug/expr_ast_ops.cpp
@@ -70,10 +70,10 @@ void pepp::debug::detail::GatherVolatileTerms::accept(const ExplicitCast &node) 
 
 void pepp::debug::mark_parents_dirty(Term &base) {
   if (base.dirty()) return;
-  base.mark_dirty();
   for (const auto &weak : base.dependents()) {
     if (weak.expired()) continue;
     auto shared = weak.lock();
     mark_parents_dirty(*shared);
   }
+  base.mark_dirty();
 }

--- a/lib/sim/debug/expr_ast_ops.hpp
+++ b/lib/sim/debug/expr_ast_ops.hpp
@@ -4,7 +4,7 @@
 
 namespace pepp::debug {
 bool is_constant_expression(const Term &term);
-std::vector<std::shared_ptr<const Term>> volatiles(const Term &term);
+std::vector<std::shared_ptr<Term>> volatiles(Term &term);
 void mark_parents_dirty(Term &base);
 
 namespace detail {
@@ -18,16 +18,19 @@ struct IsConstantExpressionVisitor : public ConstantTermVisitor {
   void accept(const Parenthesized &node) override;
   void accept(const ExplicitCast &node) override;
 };
-struct GatherVolatileTerms : public ConstantTermVisitor {
+
+// Mutating because used may want to evaluate() on gathered terms, which is non-const
+struct GatherVolatileTerms : public MutatingTermVisitor {
   // Use set to de-duplicate repeated terms.
-  std::set<std::shared_ptr<const Term>> volatiles;
-  void accept(const Variable &node) override;
-  void accept(const DebuggerVariable &node) override;
-  void accept(const Constant &node) override;
-  void accept(const BinaryInfix &node) override;
-  void accept(const UnaryPrefix &node) override;
-  void accept(const Parenthesized &node) override;
-  void accept(const ExplicitCast &node) override;
+  std::set<std::shared_ptr<Term>> volatiles;
+  std::vector<std::shared_ptr<Term>> to_vector();
+  void accept(Variable &node) override;
+  void accept(DebuggerVariable &node) override;
+  void accept(Constant &node) override;
+  void accept(BinaryInfix &node) override;
+  void accept(UnaryPrefix &node) override;
+  void accept(Parenthesized &node) override;
+  void accept(ExplicitCast &node) override;
 };
 } // namespace detail
 

--- a/lib/sim/debug/expr_eval.hpp
+++ b/lib/sim/debug/expr_eval.hpp
@@ -33,12 +33,15 @@ struct Environment {
   // Read some bytes of memory (modulo the size of the address space) in the platform's preferred endianness
   std::function<uint8_t(uint32_t)> read_mem_u8 = [](uint32_t) { return 0; };
   std::function<uint16_t(uint32_t)> read_mem_u16 = [](uint32_t) { return 0; };
-  virtual TypedBits evaluate_variable(QStringView name) const {
-    return {.allows_address_of = true, .type = ExpressionType::i16, .bits = (uint64_t)name.length()};
-  }
-  virtual TypedBits evaluate_debug_variable(QStringView name) {
-    return {.allows_address_of = true, .type = ExpressionType::i16, .bits = (uint64_t)name.length()};
-  }
+
+  virtual TypedBits evaluate_variable(QStringView name) const = 0;
+  virtual uint32_t cache_debug_variable_name(QStringView name) const = 0;
+  virtual TypedBits evaluate_debug_variable(uint32_t cache_index) const = 0;
+};
+struct ZeroEnvironment : public Environment {
+  inline TypedBits evaluate_variable(QStringView name) const { return from_int(int16_t(0)); };
+  inline uint32_t cache_debug_variable_name(QStringView name) const { return 0; }
+  inline TypedBits evaluate_debug_variable(uint32_t cache_index) const { return from_int(int16_t(0)); };
 };
 } // namespace pepp::debug
 

--- a/lib/sim/debug/expr_eval.hpp
+++ b/lib/sim/debug/expr_eval.hpp
@@ -31,17 +31,18 @@ struct EvaluationCache {
 
 struct Environment {
   // Read some bytes of memory (modulo the size of the address space) in the platform's preferred endianness
-  std::function<uint8_t(uint32_t)> read_mem_u8 = [](uint32_t) { return 0; };
-  std::function<uint16_t(uint32_t)> read_mem_u16 = [](uint32_t) { return 0; };
-
+  virtual uint8_t read_mem_u8(uint32_t address) const = 0;
+  virtual uint16_t read_mem_u16(uint32_t address) const = 0;
   virtual TypedBits evaluate_variable(QStringView name) const = 0;
   virtual uint32_t cache_debug_variable_name(QStringView name) const = 0;
   virtual TypedBits evaluate_debug_variable(uint32_t cache_index) const = 0;
 };
 struct ZeroEnvironment : public Environment {
-  inline TypedBits evaluate_variable(QStringView name) const { return from_int(int16_t(0)); };
-  inline uint32_t cache_debug_variable_name(QStringView name) const { return 0; }
-  inline TypedBits evaluate_debug_variable(uint32_t cache_index) const { return from_int(int16_t(0)); };
+  inline uint8_t read_mem_u8(uint32_t address) const override { return 0; }
+  inline uint16_t read_mem_u16(uint32_t address) const override { return 0; }
+  inline TypedBits evaluate_variable(QStringView name) const override { return from_int(int16_t(0)); };
+  inline uint32_t cache_debug_variable_name(QStringView name) const override { return 0; }
+  inline TypedBits evaluate_debug_variable(uint32_t cache_index) const override { return from_int(int16_t(0)); };
 };
 } // namespace pepp::debug
 

--- a/lib/sim/debug/expr_parser.cpp
+++ b/lib/sim/debug/expr_parser.cpp
@@ -126,6 +126,18 @@ pepp::debug::detail::Memo::operator QString() const {
 
 pepp::debug::Parser::Parser(ExpressionCache &cache) : _cache(cache) {}
 
+std::shared_ptr<pepp::debug::Term> pepp::debug::Parser::compile(QStringView expr, void *builtins) {
+  detail::TokenBuffer tok(expr);
+  detail::MemoCache cache{};
+  auto ret = parse_p7(tok, cache);
+  auto at_end = tok.peek<detail::Eof>();
+  return (std::holds_alternative<std::monostate>(at_end)) ? nullptr : ret;
+}
+
+std::shared_ptr<pepp::debug::Term> pepp::debug::Parser::compile(QString expr, void *builtins) {
+  return compile(QStringView(expr), builtins);
+}
+
 std::shared_ptr<pepp::debug::DebuggerVariable> pepp::debug::Parser::parse_debug_identifier(detail::TokenBuffer &tok,
                                                                                            detail::MemoCache &cache) {
   using DBG = detail::DebugIdentifier;
@@ -373,10 +385,3 @@ std::shared_ptr<pepp::debug::Term> pepp::debug::Parser::parse_parened(detail::To
   else return cp.memoize(accept(Parenthesized(inner)), rule);
 }
 
-std::shared_ptr<pepp::debug::Term> pepp::debug::Parser::compile(QStringView expr, void *builtins) {
-  detail::TokenBuffer tok(expr);
-  detail::MemoCache cache{};
-  auto ret = parse_p7(tok, cache);
-  auto at_end = tok.peek<detail::Eof>();
-  return (std::holds_alternative<std::monostate>(at_end)) ? nullptr : ret;
-}

--- a/lib/sim/debug/expr_parser.hpp
+++ b/lib/sim/debug/expr_parser.hpp
@@ -55,6 +55,7 @@ struct Parser {
 
   explicit Parser(ExpressionCache &cache);
   std::shared_ptr<Term> compile(QStringView expr, void *builtins = nullptr);
+  std::shared_ptr<Term> compile(QString expr, void *builtins = nullptr);
 
 private:
   ExpressionCache &_cache;

--- a/lib/sim/debug/expr_types.hpp
+++ b/lib/sim/debug/expr_types.hpp
@@ -6,7 +6,9 @@
 #include <type_traits>
 
 namespace pepp::debug {
+Q_NAMESPACE
 enum class ExpressionType : uint8_t { i8, u8, i16, u16, i32, u32 };
+Q_ENUM_NS(ExpressionType);
 bool is_unsigned(ExpressionType t);
 // Returns the number of bits in t.
 uint32_t bitness(ExpressionType t);

--- a/lib/sim/debug/expr_types.hpp
+++ b/lib/sim/debug/expr_types.hpp
@@ -20,6 +20,7 @@ struct TypedBits {
   uint64_t bits;
 
   std::strong_ordering operator<=>(const TypedBits &rhs) const;
+  bool operator==(const TypedBits &) const = default;
 
   friend pepp::debug::TypedBits operator+(const pepp::debug::TypedBits &arg);
   friend pepp::debug::TypedBits operator-(const pepp::debug::TypedBits &arg);

--- a/lib/sim/debug/watchexpressionmodel.cpp
+++ b/lib/sim/debug/watchexpressionmodel.cpp
@@ -1,14 +1,33 @@
 #include "watchexpressionmodel.hpp"
+#include "expr_ast_ops.hpp"
 
 pepp::debug::WatchExpressionModel::WatchExpressionModel(QObject *parent) : QObject(parent) {
   pepp::debug::Parser p(_c);
-  add_root(p.compile("$x - 3"));
+  add_root(p.compile("1 - 3"));
   add_root(p.compile("3_u16 * (x + 2)"));
   add_root(p.compile("y + 1 ==  m * x + b"));
 }
 
+std::span<const uint8_t> pepp::debug::WatchExpressionModel::was_dirty() const { return _root_was_dirty; }
+
 std::span<const std::shared_ptr<pepp::debug::Term>> pepp::debug::WatchExpressionModel::root_terms() const {
   return _root_terms;
+}
+
+void pepp::debug::WatchExpressionModel::update_volatile_values() {
+  std::fill(_root_was_dirty.begin(), _root_was_dirty.end(), 0);
+  for (const auto &ptr : _volatiles) {
+    auto old_v = ptr->evaluate(CachePolicy::UseAlways, _env);
+    auto new_v = ptr->evaluate(CachePolicy::UseNonVolatiles, _env);
+    pepp::debug::mark_parents_dirty(*ptr);
+    // if (auto cmp = old_v <=> new_v; cmp != 0) pepp::debug::mark_parents_dirty(*ptr);
+  }
+
+  // Later term could be a a subexpression of current one.
+  // We cannot re-order the terms because we want to preserve UI order.
+  // Therefore must iterate over whole list once to collect all dirty terms before updating.
+  for (int it = 0; it < _root_terms.size(); it++) _root_was_dirty[it] = _root_terms[it]->dirty();
+  for (const auto &ptr : _root_terms) ptr->evaluate(CachePolicy::UseNonVolatiles, _env);
 }
 
 pepp::debug::Environment &pepp::debug::WatchExpressionModel::env() { return _env; }
@@ -16,6 +35,10 @@ pepp::debug::Environment &pepp::debug::WatchExpressionModel::env() { return _env
 void pepp::debug::WatchExpressionModel::add_root(std::shared_ptr<Term> term) {
   if (term == nullptr) return;
   _root_terms.emplace_back(std::move(term));
+  _root_was_dirty.emplace_back(0);
+  detail::GatherVolatileTerms vols;
+  for (const auto &ptr : _root_terms) ptr->accept(vols);
+  _volatiles = vols.to_vector();
 }
 
 pepp::debug::WatchExpressionTableModel::WatchExpressionTableModel(QObject *parent) : QAbstractTableModel(parent) {}
@@ -51,6 +74,7 @@ QVariant variant_from_bits(const pepp::debug::TypedBits &bits) {
   }
 }
 QVariant pepp::debug::WatchExpressionTableModel::data(const QModelIndex &index, int role) const {
+  using WER = WatchExpressionRoles::Roles;
   if (!index.isValid() || _expressionModel == nullptr) return QVariant();
   int row = index.row(), col = index.column();
   auto terms = _expressionModel->root_terms();
@@ -63,12 +87,14 @@ QVariant pepp::debug::WatchExpressionTableModel::data(const QModelIndex &index, 
       QMetaEnum metaEnum = QMetaEnum::fromType<ExpressionType>();
       return metaEnum.valueToKey((int)terms[row]->evaluate(CachePolicy::UseAlways, env).type);
     }
+  case (int)WER::Changed: return _expressionModel->was_dirty()[row];
   }
   return {};
 }
 
 QHash<int, QByteArray> pepp::debug::WatchExpressionTableModel::roleNames() const {
-  static const QHash<int, QByteArray> roles = {{Qt::DisplayRole, "display"}};
+  using WER = WatchExpressionRoles::Roles;
+  static const QHash<int, QByteArray> roles = {{Qt::DisplayRole, "display"}, {(int)WER::Changed, "changed"}};
   return roles;
 }
 
@@ -82,4 +108,19 @@ void pepp::debug::WatchExpressionTableModel::setExpressionModel(pepp::debug::Wat
   _expressionModel = new_model;
   emit expressionModelChanged();
   endResetModel();
+}
+
+void pepp::debug::WatchExpressionTableModel::onUpdateGUI() {
+  if (!_expressionModel) return;
+  _expressionModel->update_volatile_values();
+  auto dirtied = _expressionModel->was_dirty();
+  int start = -1;
+  for (int i = 0; i <= dirtied.size(); i++) {
+    if (dirtied[i] && start == -1) start = i;
+    else if (!dirtied[i] && start != -1) {
+      emit dataChanged(index(start, 0), index(i - 1, 2));
+      start = -1;
+    }
+  }
+  if (start != -1) emit dataChanged(index(start, 0), index(dirtied.size() - 1, 2));
 }

--- a/lib/sim/debug/watchexpressionmodel.cpp
+++ b/lib/sim/debug/watchexpressionmodel.cpp
@@ -2,8 +2,8 @@
 
 pepp::debug::WatchExpressionModel::WatchExpressionModel(QObject *parent) : QObject(parent) {
   pepp::debug::Parser p(_c);
-  add_root(p.compile("x + 2"));
-  add_root(p.compile("3 * (x + 2)"));
+  add_root(p.compile("$x - 3"));
+  add_root(p.compile("3_u16 * (x + 2)"));
   add_root(p.compile("y + 1 ==  m * x + b"));
 }
 
@@ -40,6 +40,16 @@ int pepp::debug::WatchExpressionTableModel::columnCount(const QModelIndex &paren
   return 3;
 }
 
+QVariant variant_from_bits(const pepp::debug::TypedBits &bits) {
+  switch (bits.type) {
+  case pepp::debug::ExpressionType::i8: return QVariant::fromValue((int8_t)bits.bits);
+  case pepp::debug::ExpressionType::u8: return QVariant::fromValue((uint8_t)bits.bits);
+  case pepp::debug::ExpressionType::i16: return QVariant::fromValue((int16_t)bits.bits);
+  case pepp::debug::ExpressionType::u16: return QVariant::fromValue((uint16_t)bits.bits);
+  case pepp::debug::ExpressionType::i32: return QVariant::fromValue((int32_t)bits.bits);
+  case pepp::debug::ExpressionType::u32: return QVariant::fromValue((uint32_t)bits.bits);
+  }
+}
 QVariant pepp::debug::WatchExpressionTableModel::data(const QModelIndex &index, int role) const {
   if (!index.isValid() || _expressionModel == nullptr) return QVariant();
   int row = index.row(), col = index.column();
@@ -48,7 +58,7 @@ QVariant pepp::debug::WatchExpressionTableModel::data(const QModelIndex &index, 
   switch (role) {
   case Qt::DisplayRole:
     if (col == 0) return terms[row]->to_string();
-    else if (col == 1) return QVariant((qulonglong)terms[row]->evaluate(CachePolicy::UseAlways, env).bits);
+    else if (col == 1) return variant_from_bits(terms[row]->evaluate(CachePolicy::UseAlways, env));
     else {
       QMetaEnum metaEnum = QMetaEnum::fromType<ExpressionType>();
       return metaEnum.valueToKey((int)terms[row]->evaluate(CachePolicy::UseAlways, env).type);

--- a/lib/sim/debug/watchexpressionmodel.cpp
+++ b/lib/sim/debug/watchexpressionmodel.cpp
@@ -43,6 +43,7 @@ bool pepp::debug::WatchExpressionModel::recompile(const QString &new_expr, int i
   auto term = p.compile(new_expr);
   if (term == nullptr) return false;
   _root_terms[index] = term;
+  term->evaluate(CachePolicy::UseNonVolatiles, *_env);
   _root_was_dirty[index] = true;
   detail::GatherVolatileTerms vols;
   for (const auto &ptr : _root_terms) ptr->accept(vols);
@@ -52,8 +53,9 @@ bool pepp::debug::WatchExpressionModel::recompile(const QString &new_expr, int i
 
 void pepp::debug::WatchExpressionModel::add_root(std::shared_ptr<Term> term) {
   if (term == nullptr) return;
+  term->evaluate(CachePolicy::UseNonVolatiles, *_env);
   _root_terms.emplace_back(std::move(term));
-  _root_was_dirty.emplace_back(0);
+  _root_was_dirty.emplace_back(false);
   detail::GatherVolatileTerms vols;
   for (const auto &ptr : _root_terms) ptr->accept(vols);
   _volatiles = vols.to_vector();

--- a/lib/sim/debug/watchexpressionmodel.cpp
+++ b/lib/sim/debug/watchexpressionmodel.cpp
@@ -1,0 +1,75 @@
+#include "watchexpressionmodel.hpp"
+
+pepp::debug::WatchExpressionModel::WatchExpressionModel(QObject *parent) : QObject(parent) {
+  pepp::debug::Parser p(_c);
+  add_root(p.compile("x + 2"));
+  add_root(p.compile("3 * (x + 2)"));
+  add_root(p.compile("y + 1 ==  m * x + b"));
+}
+
+std::span<const std::shared_ptr<pepp::debug::Term>> pepp::debug::WatchExpressionModel::root_terms() const {
+  return _root_terms;
+}
+
+pepp::debug::Environment &pepp::debug::WatchExpressionModel::env() { return _env; }
+
+void pepp::debug::WatchExpressionModel::add_root(std::shared_ptr<Term> term) {
+  if (term == nullptr) return;
+  _root_terms.emplace_back(std::move(term));
+}
+
+pepp::debug::WatchExpressionTableModel::WatchExpressionTableModel(QObject *parent) : QAbstractTableModel(parent) {}
+
+namespace {
+const char *col_names[] = {"Expression", "Value", "Type"};
+}
+QVariant pepp::debug::WatchExpressionTableModel::headerData(int section, Qt::Orientation orientation, int role) const {
+  switch (role) {
+  case Qt::DisplayRole: return col_names[section];
+  }
+  return {};
+}
+
+int pepp::debug::WatchExpressionTableModel::rowCount(const QModelIndex &parent) const {
+  if (parent.isValid() || _expressionModel == nullptr) return 0;
+  return _expressionModel->root_terms().size();
+}
+
+int pepp::debug::WatchExpressionTableModel::columnCount(const QModelIndex &parent) const {
+  if (parent.isValid() || _expressionModel == nullptr) return 0;
+  return 3;
+}
+
+QVariant pepp::debug::WatchExpressionTableModel::data(const QModelIndex &index, int role) const {
+  if (!index.isValid() || _expressionModel == nullptr) return QVariant();
+  int row = index.row(), col = index.column();
+  auto terms = _expressionModel->root_terms();
+  auto env = _expressionModel->env();
+  switch (role) {
+  case Qt::DisplayRole:
+    if (col == 0) return terms[row]->to_string();
+    else if (col == 1) return QVariant((qulonglong)terms[row]->evaluate(CachePolicy::UseAlways, env).bits);
+    else {
+      QMetaEnum metaEnum = QMetaEnum::fromType<ExpressionType>();
+      return metaEnum.valueToKey((int)terms[row]->evaluate(CachePolicy::UseAlways, env).type);
+    }
+  }
+  return {};
+}
+
+QHash<int, QByteArray> pepp::debug::WatchExpressionTableModel::roleNames() const {
+  static const QHash<int, QByteArray> roles = {{Qt::DisplayRole, "display"}};
+  return roles;
+}
+
+pepp::debug::WatchExpressionModel *pepp::debug::WatchExpressionTableModel::expressionModel() {
+  return _expressionModel;
+}
+
+void pepp::debug::WatchExpressionTableModel::setExpressionModel(pepp::debug::WatchExpressionModel *new_model) {
+  if (_expressionModel == new_model) return;
+  beginResetModel();
+  _expressionModel = new_model;
+  emit expressionModelChanged();
+  endResetModel();
+}

--- a/lib/sim/debug/watchexpressionmodel.hpp
+++ b/lib/sim/debug/watchexpressionmodel.hpp
@@ -17,6 +17,8 @@ public:
   void add_root(std::shared_ptr<pepp::debug::Term>);
   void update_volatile_values();
   pepp::debug::Environment &env();
+  // Compile an expression without adding it to roots
+  std::shared_ptr<pepp::debug::Term> compile(const QString &new_expr);
   bool recompile(const QString &new_expr, int index);
 
 private:
@@ -35,6 +37,7 @@ class WatchExpressionRoles : public QObject {
 public:
   enum Roles {
     Changed = Qt::UserRole + 1,
+    Italicize,
   };
   Q_ENUM(Roles)
 };

--- a/lib/sim/debug/watchexpressionmodel.hpp
+++ b/lib/sim/debug/watchexpressionmodel.hpp
@@ -17,6 +17,7 @@ public:
   void add_root(std::shared_ptr<pepp::debug::Term>);
   void update_volatile_values();
   pepp::debug::Environment &env();
+  bool recompile(const QString &new_expr, int index);
 
 private:
   pepp::debug::Environment _env;
@@ -49,6 +50,8 @@ public:
   int rowCount(const QModelIndex &parent = QModelIndex()) const override;
   int columnCount(const QModelIndex &parent = QModelIndex()) const override;
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+  bool setData(const QModelIndex &index, const QVariant &value, int role) override;
+  Qt::ItemFlags flags(const QModelIndex &index) const override;
   QHash<int, QByteArray> roleNames() const override;
 
   WatchExpressionModel *expressionModel();

--- a/lib/sim/debug/watchexpressionmodel.hpp
+++ b/lib/sim/debug/watchexpressionmodel.hpp
@@ -11,18 +11,18 @@ class WatchExpressionModel : public QObject {
   QML_UNCREATABLE("");
 
 public:
-  explicit WatchExpressionModel(QObject *parent = nullptr);
+  explicit WatchExpressionModel(pepp::debug::Environment *env, QObject *parent = nullptr);
   std::span<const uint8_t> was_dirty() const;
   std::span<const std::shared_ptr<pepp::debug::Term>> root_terms() const;
   void add_root(std::shared_ptr<pepp::debug::Term>);
   void update_volatile_values();
-  pepp::debug::Environment &env();
+  pepp::debug::Environment *env();
   // Compile an expression without adding it to roots
   std::shared_ptr<pepp::debug::Term> compile(const QString &new_expr);
   bool recompile(const QString &new_expr, int index);
 
 private:
-  pepp::debug::Environment _env;
+  pepp::debug::Environment *_env;
   pepp::debug::ExpressionCache _c;
   std::vector<uint8_t> _root_was_dirty;
   std::vector<std::shared_ptr<pepp::debug::Term>> _root_terms;

--- a/lib/sim/debug/watchexpressionmodel.hpp
+++ b/lib/sim/debug/watchexpressionmodel.hpp
@@ -12,14 +12,30 @@ class WatchExpressionModel : public QObject {
 
 public:
   explicit WatchExpressionModel(QObject *parent = nullptr);
+  std::span<const uint8_t> was_dirty() const;
   std::span<const std::shared_ptr<pepp::debug::Term>> root_terms() const;
   void add_root(std::shared_ptr<pepp::debug::Term>);
+  void update_volatile_values();
   pepp::debug::Environment &env();
 
 private:
   pepp::debug::Environment _env;
   pepp::debug::ExpressionCache _c;
+  std::vector<uint8_t> _root_was_dirty;
   std::vector<std::shared_ptr<pepp::debug::Term>> _root_terms;
+  std::vector<std::shared_ptr<pepp::debug::Term>> _volatiles;
+};
+
+class WatchExpressionRoles : public QObject {
+  Q_OBJECT
+  QML_ELEMENT
+  QML_UNCREATABLE("Error: only enums")
+
+public:
+  enum Roles {
+    Changed = Qt::UserRole + 1,
+  };
+  Q_ENUM(Roles)
 };
 
 class WatchExpressionTableModel : public QAbstractTableModel {
@@ -37,7 +53,8 @@ public:
 
   WatchExpressionModel *expressionModel();
   void setExpressionModel(WatchExpressionModel *new_model);
-
+public slots:
+  void onUpdateGUI();
 signals:
   void expressionModelChanged();
 

--- a/lib/sim/debug/watchexpressionmodel.hpp
+++ b/lib/sim/debug/watchexpressionmodel.hpp
@@ -1,0 +1,48 @@
+#pragma once
+#include <QAbstractTableModel>
+#include <QtQmlIntegration>
+#include "sim/debug/expr_ast.hpp"
+#include "sim/debug/expr_parser.hpp"
+
+namespace pepp::debug {
+class WatchExpressionModel : public QObject {
+  Q_OBJECT
+  QML_ELEMENT
+  QML_UNCREATABLE("");
+
+public:
+  explicit WatchExpressionModel(QObject *parent = nullptr);
+  std::span<const std::shared_ptr<pepp::debug::Term>> root_terms() const;
+  void add_root(std::shared_ptr<pepp::debug::Term>);
+  pepp::debug::Environment &env();
+
+private:
+  pepp::debug::Environment _env;
+  pepp::debug::ExpressionCache _c;
+  std::vector<std::shared_ptr<pepp::debug::Term>> _root_terms;
+};
+
+class WatchExpressionTableModel : public QAbstractTableModel {
+  Q_OBJECT
+  Q_PROPERTY(WatchExpressionModel *watchExpressions READ expressionModel WRITE setExpressionModel NOTIFY
+                 expressionModelChanged)
+  QML_ELEMENT
+public:
+  explicit WatchExpressionTableModel(QObject *parent = nullptr);
+  QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+  int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+  int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+  QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+  QHash<int, QByteArray> roleNames() const override;
+
+  WatchExpressionModel *expressionModel();
+  void setExpressionModel(WatchExpressionModel *new_model);
+
+signals:
+  void expressionModelChanged();
+
+private:
+  // Not owning!! Do not delete!!
+  WatchExpressionModel *_expressionModel = nullptr;
+};
+} // namespace pepp::debug

--- a/test/sim/debug/evaluator.cpp
+++ b/test/sim/debug/evaluator.cpp
@@ -177,13 +177,20 @@ TEST_CASE("Evaluating watch expressions", "[scope:debug][kind:unit][arch:*]") {
   }
 }
 
+namespace {
+struct MemoryArrayEnvironment : public pepp::debug::ZeroEnvironment {
+  std::vector<uint8_t> mem = std::vector<uint8_t>(0x1'00'00, 7);
+  inline uint8_t read_mem_u8(uint32_t addr) const override { return mem[addr % 0x1'00'00]; }
+  inline uint16_t read_mem_u16(uint32_t addr) const override {
+    return (uint16_t)(mem[addr % 0x1'00'00] << 8 | mem[(addr + 1) % 0x1'00'00]);
+  }
+};
+} // namespace
+
 TEST_CASE("Evaluations with environment access", "[scope:debug][kind:unit][arch:*]") {
   using namespace pepp::debug;
-  ZeroEnvironment env;
-  auto mem = std::vector<uint8_t>(0x1'00'00, 7);
-  env.read_mem_u16 = [&mem](uint32_t addr) {
-    return (uint16_t)(mem[addr % 0x1'00'00] << 8 | mem[(addr + 1) % 0x1'00'00]);
-  };
+  MemoryArrayEnvironment env;
+
   SECTION("Memory Access") {
     ExpressionCache c;
     Parser p(c);
@@ -191,7 +198,7 @@ TEST_CASE("Evaluations with environment access", "[scope:debug][kind:unit][arch:
     auto ast = p.compile(body);
     REQUIRE(ast != nullptr);
     CHECK(ast->evaluate(CachePolicy::UseNonVolatiles, env).bits == 0x0707);
-    mem[0] = 8;
+    env.mem[0] = 8;
     // Ignoring requirement from volatiles to re-compute.
     CHECK(ast->evaluate(CachePolicy::UseAlways, env).bits == 0x0707);
     CHECK(ast->evaluate(CachePolicy::UseNonVolatiles, env).bits == 0x0807);

--- a/test/sim/debug/evaluator.cpp
+++ b/test/sim/debug/evaluator.cpp
@@ -21,7 +21,7 @@
 
 TEST_CASE("Evaluating watch expressions", "[scope:debug][kind:unit][arch:*]") {
   using namespace pepp::debug;
-  Environment env;
+  ZeroEnvironment env;
   SECTION("Expressions caching between compliations") {
     ExpressionCache c;
     Parser p(c);
@@ -179,7 +179,7 @@ TEST_CASE("Evaluating watch expressions", "[scope:debug][kind:unit][arch:*]") {
 
 TEST_CASE("Evaluations with environment access", "[scope:debug][kind:unit][arch:*]") {
   using namespace pepp::debug;
-  Environment env;
+  ZeroEnvironment env;
   auto mem = std::vector<uint8_t>(0x1'00'00, 7);
   env.read_mem_u16 = [&mem](uint32_t addr) {
     return (uint16_t)(mem[addr % 0x1'00'00] << 8 | mem[(addr + 1) % 0x1'00'00]);
@@ -202,6 +202,6 @@ TEST_CASE("Evaluations with environment access", "[scope:debug][kind:unit][arch:
     QString body = "$x";
     auto ast = p.compile(body);
     REQUIRE(ast != nullptr);
-    CHECK(ast->evaluate(CachePolicy::UseNonVolatiles, env).bits == 1);
+    CHECK(ast->evaluate(CachePolicy::UseNonVolatiles, env).bits == 0);
   }
 }

--- a/test/sim/debug/parser.cpp
+++ b/test/sim/debug/parser.cpp
@@ -31,7 +31,7 @@ TEST_CASE("Parsing watch expressions", "[scope:debug][kind:unit][arch:*]") {
     REQUIRE(as_const != nullptr);
     CHECK(as_const->format_hint == detail::UnsignedConstant::Format::Hex);
     CHECK(as_const->value.bits == 0x15);
-    CHECK(as_const->to_string() == "0x15");
+    CHECK(as_const->to_string().toStdString() == "0x15");
   }
   SECTION("Unsigned Decimal constants") {
     ExpressionCache c;
@@ -44,7 +44,7 @@ TEST_CASE("Parsing watch expressions", "[scope:debug][kind:unit][arch:*]") {
     CHECK(as_const->format_hint == detail::UnsignedConstant::Format::Dec);
     CHECK(as_const->value.type == ExpressionType::i16);
     CHECK(as_const->value.bits == 115);
-    CHECK(as_const->to_string() == "115");
+    CHECK(as_const->to_string().toStdString() == "115");
   }
   SECTION("Decimal constant with trailing type") {
     ExpressionCache c;
@@ -57,7 +57,7 @@ TEST_CASE("Parsing watch expressions", "[scope:debug][kind:unit][arch:*]") {
     CHECK(as_const->format_hint == detail::UnsignedConstant::Format::Dec);
     CHECK(as_const->value.type == ExpressionType::u8);
     CHECK(as_const->value.bits == 115);
-    CHECK(as_const->to_string() == "115");
+    CHECK(as_const->to_string() == "115_u8");
   }
   SECTION("Identifier") {
     ExpressionCache c;


### PR DESCRIPTION
Adds a table view to the debugger which exposes the expression evaluator.

Completes open items from #799 except for the following shortcomings:
- Missing symbols return 0 instead of a meaningful error
- Mistyped expressions get deleted
- Memory operations are not evaluated -- fixed in 0ff799ae980b496a812d4b75116f983b6ceffb60