### PR TITLE
Differentiate conditional and unconditional breakpoints in editor

### DIFF
--- a/data/changelog/changes.csv
+++ b/data/changelog/changes.csv
@@ -103,3 +103,4 @@ Changed,,0.9.0,,"Increase spacing between columns of (symbol, value) pairs in sy
 Added,,0.9.1,,"Add command line utility to inspect details of Pep/10 object code"
 Fixed,,0.9.1,816,"Fix a bug where OS symbols appear in the user's symbol table"
 Fixed,,0.9.1,817,"Fix a bug where some user program lines do not accept breakpoints"
+Changed,,0.9.1,820,"Differentiate conditional and unconditional breakpoints in editor"

--- a/lib/project/pep10.cpp
+++ b/lib/project/pep10.cpp
@@ -838,6 +838,9 @@ Pep_ASMB::Pep_ASMB(project::Environment env, QVariant delegate, QObject *parent)
   }
   auto bps = _dbg->bps.get();
   connect(bps, &pepp::debug::BreakpointSet::conditionChanged, this, &Pep_ASMB::onBPConditionChanged);
+  // Scopes must be present to allow adding BPs on source programs before assembly
+  _dbg->line_maps->addScope("user");
+  _dbg->line_maps->addScope("os");
 }
 
 void Pep_ASMB::set(int abstraction, QString value) {

--- a/lib/project/pep10.cpp
+++ b/lib/project/pep10.cpp
@@ -1166,7 +1166,6 @@ void Pep_ASMB::updatePCLine() {
   auto listLine = _dbg->line_maps->address2List(pc);
   if (!maybe_user_scope || !maybe_os_scope) return;
   auto userScope = *maybe_user_scope, osScope = *maybe_os_scope;
-  ;
   if (srcLine) {
     auto [scope, line] = *srcLine;
     if (scope == userScope) emit modifyUserSource(line, Action::ScrollTo);

--- a/lib/project/pep10.hpp
+++ b/lib/project/pep10.hpp
@@ -202,6 +202,7 @@ public slots:
   void onModifyOSSource(int line, Action action);
   void onModifyUserList(int line, Action action);
   void onModifyOSList(int line, Action action);
+  void onBPConditionChanged(quint16 address, bool conditional);
 signals:
   void userAsmTextChanged();
   void osAsmTextChanged();

--- a/lib/sim/debug/debugger.cpp
+++ b/lib/sim/debug/debugger.cpp
@@ -29,6 +29,7 @@ void pepp::debug::BreakpointSet::modify_condition(quint16 address, Term *conditi
   auto iter = std::lower_bound(_breakpoints.cbegin(), _breakpoints.cend(), address);
   auto offset = std::distance(_breakpoints.cbegin(), iter);
   _conditions[offset] = condition;
+  emit conditionChanged(address, condition != nullptr);
 }
 
 void pepp::debug::BreakpointSet::removeBP(quint16 address) {

--- a/lib/sim/debug/debugger.hpp
+++ b/lib/sim/debug/debugger.hpp
@@ -32,6 +32,7 @@ public:
 signals:
   void breakpointAdded(quint16 address);
   void breakpointRemoved(quint16 address);
+  void conditionChanged(quint16 address, bool conditional);
   void breakpointsCleared();
 
 private:

--- a/lib/sim/debug/line_map.cpp
+++ b/lib/sim/debug/line_map.cpp
@@ -45,12 +45,10 @@ std::optional<int> Lines2Addresses::list2Source(int list) {
 
 ScopedLines2Addresses::ScopedLines2Addresses(QObject *parent) : QObject(parent) {}
 
-void ScopedLines2Addresses::addScope(QString name, const Lines2Addresses &map) {
-  auto scopeIndex = static_cast<scope>(_scopeNames.size());
-  _scopeNames[scopeIndex] = name;
-  _source2Addr.emplace_back();
-  _list2Addr.emplace_back();
+void ScopedLines2Addresses::addScope(QString name) { auto scopeIndex = add_or_get_scope(name); }
 
+void ScopedLines2Addresses::addScope(QString name, const Lines2Addresses &map) {
+  auto scopeIndex = add_or_get_scope(name);
   for (auto [line, addr] : map._source2Addr) {
     _source2Addr[scopeIndex][line] = addr;
     _addr2Source[addr] = std::make_tuple(scopeIndex, line);
@@ -118,4 +116,17 @@ void ScopedLines2Addresses::onReset() {
   _addr2Source.clear(), _addr2List.clear();
   _scopeNames.clear();
   emit wasReset();
+}
+
+ScopedLines2Addresses::scope ScopedLines2Addresses::add_or_get_scope(QString name) {
+  auto it = std::find_if(_scopeNames.begin(), _scopeNames.end(), [&name](const auto &it) { return it.second == name; });
+  if (it == _scopeNames.end()) {
+    auto scopeIndex = static_cast<scope>(_scopeNames.size());
+    _scopeNames[scopeIndex] = name;
+    _source2Addr.emplace_back();
+    _list2Addr.emplace_back();
+    return scopeIndex;
+  } else {
+    return it->first;
+  }
 }

--- a/lib/sim/debug/line_map.hpp
+++ b/lib/sim/debug/line_map.hpp
@@ -26,6 +26,7 @@ public:
   using scope = int;
   ScopedLines2Addresses(QObject *parent = nullptr);
   ~ScopedLines2Addresses() = default;
+  void addScope(QString name);
   void addScope(QString name, const Lines2Addresses &map);
   std::optional<QString> scope2name(scope) const;
   std::optional<scope> name2scope(QString) const;
@@ -52,4 +53,5 @@ private:
   // Addresses are unique, so we can fuse all scopes into a single map.
   std::map<quint32, std::tuple<scope, int>> _addr2Source{}, _addr2List{};
   std::map<scope, QString> _scopeNames;
+  scope add_or_get_scope(QString name);
 };

--- a/lib/text/editor/scintillaasmeditbase.cpp
+++ b/lib/text/editor/scintillaasmeditbase.cpp
@@ -90,7 +90,7 @@ void ScintillaAsmEditBase::onClearAllBreakpoints() { send(SCI_MARKERDELETEALL); 
 void ScintillaAsmEditBase::onRequestAllBreakpoints() {
   int totalLines = send(SCI_GETLINECOUNT);
   for (int line = 0; line < totalLines; ++line) {
-    if (send(SCI_MARKERGET, line) & (conditionalBPStyle | BPStyleMask)) modifyLine(line, Action::AddBP);
+    if (send(SCI_MARKERGET, line) & (conditionalBPStyleMask | BPStyleMask)) modifyLine(line, Action::AddBP);
   }
 }
 

--- a/lib/text/editor/scintillaasmeditbase.cpp
+++ b/lib/text/editor/scintillaasmeditbase.cpp
@@ -90,7 +90,7 @@ void ScintillaAsmEditBase::onClearAllBreakpoints() { send(SCI_MARKERDELETEALL); 
 void ScintillaAsmEditBase::onRequestAllBreakpoints() {
   int totalLines = send(SCI_GETLINECOUNT);
   for (int line = 0; line < totalLines; ++line) {
-    if (send(SCI_MARKERGET, line) & (conditionalBPStyleMask | BPStyleMask)) modifyLine(line, Action::AddBP);
+    if (send(SCI_MARKERGET, line) & (conditionalBPStyleMask | BPStyleMask)) emit modifyLine(line, Action::AddBP);
   }
 }
 

--- a/lib/text/editor/scintillaasmeditbase.hpp
+++ b/lib/text/editor/scintillaasmeditbase.hpp
@@ -18,7 +18,7 @@ class ScintillaAsmEditBase : public ScintillaEditBase {
   QML_ELEMENT
 
 public:
-  enum class Action { ToggleBP, AddBP, RemoveBP, ScrollTo, HighlightExclusive };
+  enum class Action { ToggleBP, AddBP, RemoveBP, ScrollTo, HighlightExclusive, MakeConditional, MakeUnconditional };
   Q_ENUM(Action);
   ScintillaAsmEditBase(QQuickItem *parent = 0);
 public slots:
@@ -58,6 +58,11 @@ private:
   const int charStyle = SCE_PEPASM_CHARACTER;
   const int stringStyle = SCE_PEPASM_STRING;
   const int commentStyle = SCE_PEPASM_COMMENT;
+
+  const int BPStyle = 1;
+  const int BPStyleMask = 1 << BPStyle;
+  const int conditionalBPStyle = 2;
+  const int conditionalBPStyleMask = 1 << conditionalBPStyle;
   QString lexerLanguage() const;
   void setLexerLanguage(const QString &language);
   pepp::settings::Palette *_theme = nullptr;


### PR DESCRIPTION
This [MS Visual Studio link](https://learn.microsoft.com/en-us/visualstudio/debugger/using-breakpoints?view=vs-2022&pivots=programming-language-dotnet) shows how they differentiate conditional and unconditional breakpoints.

I've opted to use a cirle+plus as my debug marker, since it was a builtin marker to scintilla.
My other option was to use a different color (say, magenta), but I wanted to avoid adding another entry to the palette for now.

I think this will make the debugging experience more straightforward.
Users may be confused why a breakpoint is not hit, not realizing it has a condition attached.

Inlined below are relevant photos:
![unconditional bp](https://github.com/user-attachments/assets/13aaf3b0-a273-4ac4-b8b5-c2c56028b5d2)
![conditional bp](https://github.com/user-attachments/assets/c04d5680-6838-4a16-a6d7-77e21a76e33a)
