### PR TITLE
Disable slashed 0s in default mono font

### DIFF
--- a/3rd-party/scintilla/scintilla/qt/ScintillaEditBase/PlatQt.cpp
+++ b/3rd-party/scintilla/scintilla/qt/ScintillaEditBase/PlatQt.cpp
@@ -108,6 +108,7 @@ public:
     pfont->setPointSizeF(fp.size);
     pfont->setBold(static_cast<int>(fp.weight) > 500);
     pfont->setItalic(fp.italic);
+    pfont->setFeature("cv01", 1);
   }
 };
 

--- a/data/changelog/changes.csv
+++ b/data/changelog/changes.csv
@@ -107,4 +107,5 @@ Changed,,0.9.1,820,"Differentiate conditional and unconditional breakpoints in e
 Changed,Minor,0.9.1,821,"Move `NOTr` after `ASRr` in Pep/10 ISA"
 Changed,,0.9.1,824,"Distinguish macro expansions from user code via italics rather than a different font"
 Fixed,,0.9.1,825,"Fix a bug where memory dump does not use a monospaced font"
-Changed,,0.9.1,826,"Change default monospace font to GitHub's ""Monaspace Argon"" font for increased legibility"
+Changed,,0.9.1,826,"Change default monospaced font to GitHub's ""Monaspace Argon"" font for increased legibility"
+Changed,,0.9.1,,"Disable slashed 0s in default monospaced font"

--- a/lib/memory/hexdump/MemoryDump.qml
+++ b/lib/memory/hexdump/MemoryDump.qml
@@ -14,13 +14,7 @@ Item {
     }
     FontMetrics {
         id: fm
-        font: Qt.font({
-                          "family": settings.extPalette.baseMono.font.family,
-                          "weight": Font.Normal,
-                          "italic": false,
-                          "bold": false,
-                          "pointSize": 10
-                      })
+        font: settings.extPalette.baseMono.font
     }
     property int colWidth: 25
     property int rowHeight: 20

--- a/lib/settings/palette.cpp
+++ b/lib/settings/palette.cpp
@@ -156,8 +156,8 @@ int pepp::settings::Palette::itemToRole(const PaletteItem *item) const {
 }
 
 void pepp::settings::Palette::loadLightDefaults() {
-  static const auto defaultMono = QFont("Monaspace Argon", 12);
-  static const auto defaultMacro = QFont("Monaspace Argon", 12);
+  static const auto defaultMono = pepp::settings::default_mono();
+  static const auto defaultMacro = pepp::settings::default_mono();
   using PO = PaletteItem::Options;
   using EO = EditorPaletteItem::EditorOptions;
   using R = PaletteRoleHelper::Role;

--- a/lib/settings/paletteitem.hpp
+++ b/lib/settings/paletteitem.hpp
@@ -7,6 +7,7 @@
 
 namespace pepp::settings {
 
+QFont default_mono();
 class PaletteItem : public QObject {
   Q_OBJECT
   Q_PROPERTY(PaletteItem *parent READ parent WRITE setParent NOTIFY preferenceChanged)

--- a/lib/text/editor/scintillaasmeditbase.cpp
+++ b/lib/text/editor/scintillaasmeditbase.cpp
@@ -221,7 +221,7 @@ void ScintillaAsmEditBase::applyStyles() {
       f.setItalic(true);
       return f;
     }
-    return QFont("Monaspace Argon", 12, -1, true);
+    return pepp::settings::default_mono();
   };
 
   for (int mask : {0, SCE_PEPASM_DEFAULT_GEN}) {


### PR DESCRIPTION
Should make things easier to read.

Requires setting the character variant flag anytime we create the font. This change must also be propagated to the Scintilla code which handles fonts.

Stan has requested we disable the slashed/dotted 0s