### PR TITLE
Replace splitters with docking widgets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "3rd-party/zpp_bits"]
 	path = 3rd-party/zpp_bits
 	url = https://github.com/eyalz800/zpp_bits.git
+[submodule "3rd-party/KDDockWidgets"]
+	path = 3rd-party/KDDockWidgets
+	url = https://github.com/Matthew-McRaven/KDDockWidgets

--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -19,3 +19,25 @@ target_include_directories(zpp_bits INTERFACE zpp_bits)
 
 add_subdirectory(lru)
 add_subdirectory(scintilla)
+
+set(KDDockWidgets_FRONTENDS "qtquick" CACHE STRING "" FORCE)
+set(KDDW_FRONTEND_QTQUICK ON CACHE BOOL "" FORCE)
+if(EMSCRIPTEN)
+    set(KDDockWidgets_STATIC TRUE CACHE BOOL "" FORCE)
+endif()
+
+add_subdirectory(KDDockWidgets/)
+
+# Inject --bind flag into KDDockWidgets targets on WASM builds
+if(EMSCRIPTEN)
+    get_directory_property(submodule_targets DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/KDDockWidgets BUILDSYSTEM_TARGETS)
+    foreach(tgt IN LISTS submodule_targets)
+        get_target_property(existing_flags ${tgt} LINK_FLAGS)
+        if(NOT existing_flags)
+            set(existing_flags "")
+        endif()
+        set_target_properties(${tgt} PROPERTIES LINK_FLAGS "${existing_flags} --bind")
+    endforeach()
+endif()
+
+

--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -22,9 +22,8 @@ add_subdirectory(scintilla)
 
 set(KDDockWidgets_FRONTENDS "qtquick" CACHE STRING "" FORCE)
 set(KDDW_FRONTEND_QTQUICK ON CACHE BOOL "" FORCE)
-if(EMSCRIPTEN)
-    set(KDDockWidgets_STATIC TRUE CACHE BOOL "" FORCE)
-endif()
+set(KDDockWidgets_STATIC TRUE CACHE BOOL "" FORCE)
+set(KDDockWidgets_QML_MODULE TRUE CACHE BOOL "" FORCE)
 
 add_subdirectory(KDDockWidgets/)
 

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -2,7 +2,6 @@ file(GLOB_RECURSE sources_and_tests CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}
 file(GLOB_RECURSE tests CONFIGURE_DEPENDS "test/*.cpp" "test/*.hpp")
 list(APPEND sources ${sources_and_tests})
 list(REMOVE_ITEM sources ${tests})
-
 # Set icon for the application if it exists.
 if (EXISTS "${PROJECT_DATA_DIR}/app_icon/icon.ico" AND WIN32)
     LIST(APPEND sources "${PROJECT_DATA_DIR}/app_icon/res.rc")
@@ -17,12 +16,14 @@ else ()
 endif ()
 
 qt6_add_executable(pepp ${sources} ${guis} ${CMAKE_SOURCE_DIR}/data/icons/icons.qrc)
-qt_import_qml_plugins(pepp)
+
+
 target_link_libraries(pepp PRIVATE cli catch Qt6::Core Qt6::Gui
     Qt::Qml Qt::Quick  Qt::QuickControls2 Qt6::Svg Qt6::Xml Qt::Widgets
-    test-lib-all pepp-lib pepp-libplugin KDAB::kddockwidgets
+    test-lib-all pepp-lib pepp-libplugin KDAB::kddockwidgets kddockwidgetsplugin
 )
-qt_import_plugins(pepp INCLUDE pepp-libplugin)
+qt_import_qml_plugins(pepp)
+qt_import_plugins(pepp INCLUDE pepp-libplugin kddockwidgetsplugin)
 target_compile_definitions(pepp PRIVATE "INCLUDE_GUI=1")
 # Must occur before install scripts, otherwise MacOS builds will fail.
 set_target_properties(pepp PROPERTIES

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -18,7 +18,10 @@ endif ()
 
 qt6_add_executable(pepp ${sources} ${guis} ${CMAKE_SOURCE_DIR}/data/icons/icons.qrc)
 qt_import_qml_plugins(pepp)
-target_link_libraries(pepp PRIVATE cli catch Qt6::Core Qt6::Gui Qt::Qml Qt::Quick Qt::QuickControls2 Qt6::Svg Qt6::Xml Qt::Widgets test-lib-all pepp-lib pepp-libplugin)
+target_link_libraries(pepp PRIVATE cli catch Qt6::Core Qt6::Gui
+    Qt::Qml Qt::Quick  Qt::QuickControls2 Qt6::Svg Qt6::Xml Qt::Widgets
+    test-lib-all pepp-lib pepp-libplugin KDAB::kddockwidgets
+)
 qt_import_plugins(pepp INCLUDE pepp-libplugin)
 target_compile_definitions(pepp PRIVATE "INCLUDE_GUI=1")
 # Must occur before install scripts, otherwise MacOS builds will fail.

--- a/bin/src/commands/gui.cpp
+++ b/bin/src/commands/gui.cpp
@@ -156,6 +156,7 @@ int gui_main(const gui_args &args) {
   flags.setFlag(KDDockWidgets::Config::Flag_TabsHaveCloseButton, false);
   flags.setFlag(KDDockWidgets::Config::Flag_TitleBarHasMaximizeButton, false);
   flags.setFlag(KDDockWidgets::Config::Flag_DoubleClickMaximizes, false);
+  flags.setFlag(KDDockWidgets::Config::Flag_DisableDoubleClick, true);
   // flags.setFlag(KDDockWidgets::Config::Flag_DontUseUtilityFloatingWindows, true);
   flags |= KDDockWidgets::Config::Flag_HideTitleBarWhenTabsVisible;
   config.setFlags(flags);

--- a/bin/src/commands/gui.cpp
+++ b/bin/src/commands/gui.cpp
@@ -149,7 +149,7 @@ int gui_main(const gui_args &args) {
   flags.setFlag(KDDockWidgets::Config::Flag_TabsHaveCloseButton, false);
   flags.setFlag(KDDockWidgets::Config::Flag_TitleBarHasMaximizeButton, false);
   flags.setFlag(KDDockWidgets::Config::Flag_DoubleClickMaximizes, false);
-  flags.setFlag(KDDockWidgets::Config::Flag_DontUseUtilityFloatingWindows, true);
+  // flags.setFlag(KDDockWidgets::Config::Flag_DontUseUtilityFloatingWindows, true);
   flags |= KDDockWidgets::Config::Flag_HideTitleBarWhenTabsVisible;
   config.setFlags(flags);
   KDDockWidgets::QtQuick::Platform::instance()->setQmlEngine(&engine);

--- a/bin/src/commands/gui.cpp
+++ b/bin/src/commands/gui.cpp
@@ -28,6 +28,7 @@
 #include <kddockwidgets/core/FloatingWindow.h>
 #include <kddockwidgets/core/TitleBar.h>
 #include <kddockwidgets/qtquick/Platform.h>
+#include <kddockwidgets/qtquick/ViewFactory.h>
 #include <kddockwidgets/qtquick/views/DockWidget.h>
 #include <kddockwidgets/qtquick/views/MainWindow.h>
 #include "../iconprovider.hpp"
@@ -46,9 +47,15 @@ struct default_data : public gui_globals {
   QTimer interval;
 };
 
-void default_init(QQmlApplicationEngine &engine, default_data *data) {
-  auto *ctx = engine.rootContext();
-}
+void default_init(QQmlApplicationEngine &engine, default_data *data) { auto *ctx = engine.rootContext(); }
+
+class CustomViewFactory : public KDDockWidgets::QtQuick::ViewFactory {
+public:
+  ~CustomViewFactory() override;
+
+  QUrl titleBarFilename() const override { return QUrl("qrc:/qt/qml/edu/pepp/top/DockTitleBar.qml"); }
+};
+CustomViewFactory::~CustomViewFactory() = default;
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
@@ -152,6 +159,7 @@ int gui_main(const gui_args &args) {
   // flags.setFlag(KDDockWidgets::Config::Flag_DontUseUtilityFloatingWindows, true);
   flags |= KDDockWidgets::Config::Flag_HideTitleBarWhenTabsVisible;
   config.setFlags(flags);
+  config.setViewFactory(new CustomViewFactory());
   KDDockWidgets::QtQuick::Platform::instance()->setQmlEngine(&engine);
 
   // Don't block the event loop in WASM, especially important if wasm-exceptions are enabled.

--- a/bin/src/commands/gui.cpp
+++ b/bin/src/commands/gui.cpp
@@ -23,6 +23,13 @@
 #include <QQmlContext>
 #include <QQuickStyle>
 #include <QTimer>
+#include <kddockwidgets/Config.h>
+#include <kddockwidgets/core/DockRegistry.h>
+#include <kddockwidgets/core/FloatingWindow.h>
+#include <kddockwidgets/core/TitleBar.h>
+#include <kddockwidgets/qtquick/Platform.h>
+#include <kddockwidgets/qtquick/views/DockWidget.h>
+#include <kddockwidgets/qtquick/views/MainWindow.h>
 #include "../iconprovider.hpp"
 #include "help/about/version.hpp"
 //  Testing only
@@ -31,6 +38,7 @@
 #include "settings/settings.hpp"
 
 Q_IMPORT_PLUGIN(PeppLibPlugin)
+// Q_IMPORT_PLUGIN(KDDockWidgetsPlugin);
 
 struct default_data : public gui_globals {
   default_data() = default;
@@ -111,7 +119,6 @@ int gui_main(const gui_args &args) {
 
   // TODO: connect to PreferenceModel, read field corresponding to QPalette (Disabled, Text) field.
   engine.addImageProvider(QLatin1String("icons"), new PreferenceAwareImageProvider);
-
   static const auto default_entry = u"qrc:/qt/qml/Pepp/src/main.qml"_s;
   const QUrl url(args.QMLEntry.isEmpty() ? default_entry : args.QMLEntry);
 #ifdef __EMSCRIPTEN__
@@ -126,10 +133,31 @@ int gui_main(const gui_args &args) {
         if (!obj && url == objUrl) QCoreApplication::exit(-1);
       },
       Qt::QueuedConnection);
-  engine.load(url);
+  // Configure dock widgets to use QML
+  KDDockWidgets::initFrontend(KDDockWidgets::FrontendType::QtQuick);
+  auto &config = KDDockWidgets::Config::self();
+
+  // I dislike floating windows. This prevents windows from staying in a floating state after being dragged.
+  KDDockWidgets::Config::self().setDragEndedFunc([] {
+    const auto floatingWindows = KDDockWidgets::DockRegistry::self()->floatingWindows();
+    for (auto fw : floatingWindows) {
+      if (!fw->beingDeleted()) fw->titleBar()->onFloatClicked();
+    }
+  });
+  // Make it impossible for a docking widget to be closed / maximized / floated.
+  auto flags = config.flags() | KDDockWidgets::Config::Flag_TitleBarIsFocusable;
+  flags.setFlag(KDDockWidgets::Config::Flag_TabsHaveCloseButton, false);
+  flags.setFlag(KDDockWidgets::Config::Flag_TitleBarHasMaximizeButton, false);
+  flags.setFlag(KDDockWidgets::Config::Flag_DoubleClickMaximizes, false);
+  flags.setFlag(KDDockWidgets::Config::Flag_DontUseUtilityFloatingWindows, true);
+  flags |= KDDockWidgets::Config::Flag_HideTitleBarWhenTabsVisible;
+  config.setFlags(flags);
+  KDDockWidgets::QtQuick::Platform::instance()->setQmlEngine(&engine);
+
   // Don't block the event loop in WASM, especially important if wasm-exceptions are enabled.
   // See: https://doc.qt.io/qt-6/wasm.html#wasm-exceptions
   // See: https://doc.qt.io/qt-6/wasm.html#application-startup-and-the-event-loop
+  engine.load(url);
 #ifdef __EMSCRIPTEN__
   return 0;
 #else

--- a/bin/src/main.qml
+++ b/bin/src/main.qml
@@ -213,6 +213,18 @@ ApplicationWindow {
                             "mode": Qt.binding(() => window.mode),
                             "actions": window.actionRef
                         });
+                        // Do not attempt to put docking widgets in main area until size is non-0.
+                        // Instead, listen for updates in attemptDock, and perform docking as soon as we have real sizes.
+                        widthChanged.connect(attemptDock);
+                        heightChanged.connect(attemptDock);
+                    }
+                    function attemptDock() {
+                        if (height == 0 || width == 0) {} else if (item !== null && item.needsDock) {
+                            item.dock();
+                            // Once docked, stop handling docking attempts for each resize.
+                            widthChanged.disconnect(attemptDock);
+                            heightChanged.disconnect(attemptDock);
+                        }
                     }
 
                     Connections {

--- a/bin/src/main.qml
+++ b/bin/src/main.qml
@@ -237,29 +237,6 @@ ApplicationWindow {
                 }
             }
         }
-        KDDW.DockingArea {
-            id: dockWidgetArea
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-
-            uniqueName: "MyMainLayout"
-
-            KDDW.DockWidget {
-                id: dock1
-                uniqueName: "dock1"
-                source: "qrc:/qt/qml/edu/pepp/top/Guest1.qml"
-            }
-            KDDW.DockWidget {
-                id: dock2
-                uniqueName: "dock2"
-                source: "qrc:/qt/qml/edu/pepp/top/Guest2.qml"
-            }
-
-            Component.onCompleted: {
-                addDockWidget(dock1, KDDW.KDDockWidgets.Location_OnTop);
-                addDockWidget(dock2, KDDW.KDDockWidgets.Location_OnBottom);
-            }
-        }
         Component.onCompleted: {
             window.modeChanged.connect(onModeChanged);
             onModeChanged();
@@ -271,9 +248,6 @@ ApplicationWindow {
                 break;
             case "help":
                 mainArea.currentIndex = 1;
-                break;
-            case "dock":
-                mainArea.currentIndex = 3;
                 break;
             default:
                 mainArea.currentIndex = 2;

--- a/bin/src/main.qml
+++ b/bin/src/main.qml
@@ -127,7 +127,6 @@ ApplicationWindow {
 
     signal message(string message)
     footer: Label {
-        anchors.left: sidebar.right
         anchors.leftMargin: 10
         text: "test message"
         Timer {
@@ -157,7 +156,7 @@ ApplicationWindow {
         anchors.left: parent.left
         anchors.right: sidebar.right
         anchors.top: parent.top
-        anchors.bottom: footer.bottom
+        anchors.bottom: parent.bottom
         color: palette.shadow
     }
 

--- a/bin/src/main.qml
+++ b/bin/src/main.qml
@@ -26,6 +26,7 @@ import "qrc:/qt/qml/edu/pepp/settings" as AppSettings
 import "qrc:/qt/qml/edu/pepp/help/builtins" as Builtins
 import "qrc:/qt/qml/edu/pepp/menu" as Menu
 import edu.pepp 1.0
+import com.kdab.dockwidgets 2 as KDDW
 
 ApplicationWindow {
     id: window
@@ -231,7 +232,29 @@ ApplicationWindow {
                 }
             }
         }
+        KDDW.DockingArea {
+            id: dockWidgetArea
+            Layout.fillHeight: true
+            Layout.fillWidth: true
 
+            uniqueName: "MyMainLayout"
+
+            KDDW.DockWidget {
+                id: dock1
+                uniqueName: "dock1"
+                source: "qrc:/qt/qml/edu/pepp/top/Guest1.qml"
+            }
+            KDDW.DockWidget {
+                id: dock2
+                uniqueName: "dock2"
+                source: "qrc:/qt/qml/edu/pepp/top/Guest2.qml"
+            }
+
+            Component.onCompleted: {
+                addDockWidget(dock1, KDDW.KDDockWidgets.Location_OnTop);
+                addDockWidget(dock2, KDDW.KDDockWidgets.Location_OnBottom);
+            }
+        }
         Component.onCompleted: {
             window.modeChanged.connect(onModeChanged);
             onModeChanged();
@@ -243,6 +266,9 @@ ApplicationWindow {
                 break;
             case "help":
                 mainArea.currentIndex = 1;
+                break;
+            case "dock":
+                mainArea.currentIndex = 3;
                 break;
             default:
                 mainArea.currentIndex = 2;

--- a/bin/src/main.qml
+++ b/bin/src/main.qml
@@ -98,7 +98,7 @@ ApplicationWindow {
         actions.help.about.triggered.connect(aboutDialog.open);
         actions.view.fullscreen.triggered.connect(onToggleFullScreen);
         actions.file.save.triggered.connect(() => {
-            preAssemble();
+            syncEditors();
             pm.onSave(currentProjectRow);
         });
         actions.appdev.reloadFigures.triggered.connect(help.reloadFiguresRequested);
@@ -117,13 +117,6 @@ ApplicationWindow {
         const loader = delegateRepeater.itemAt(innerLayout.currentIndex);
         if (loader.item)
             loader.item.syncEditors();
-    }
-
-    // Helper to propogate to current delegate.
-    function preAssemble() {
-        const loader = delegateRepeater.itemAt(innerLayout.currentIndex);
-        if (loader.item)
-            loader.item.preAssemble();
     }
 
     Menu.Actions {

--- a/data/about/dep/kddw.txt
+++ b/data/about/dep/kddw.txt
@@ -1,0 +1,7 @@
+KDDockWidgets © Klarälvdalens Datakonsult AB (KDAB) and is licensed according
+to the terms of the:
+ GNU General Public License version 2.0 (see LICENSES/GPL-2.0-only.txt)
+or the
+ GNU General Public License version 3.0 (see LICENSES/GPL-3.0-only.txt).
+
+Contact KDAB at <info@kdab.com> to inquire about commercial licensing.

--- a/data/about/dependencies.csv
+++ b/data/about/dependencies.csv
@@ -13,3 +13,4 @@ Scintilla,https://www.scintilla.org/,MIT License,MIT,:/about/dep/scintilla.txt, 
 SciTEQt,https://github.com/mneuroth/SciTEQt,MIT License,MIT,:/about/dep/scintilla.txt, 1
 Courier Prime,https://github.com/quoteunquoteapps/CourierPrime,SIL Open Font License 1.1,OFL-1.1,:/about/dep/ofl-prime.txt, 0
 Monaspace,https://monaspace.githubnext.com,SIL Open Font License 1.1,OFL-1.1,:/about/dep/ofl-mona.txt, 0
+KDDockWidgets,https://github.com/KDAB/KDDockWidgets,GNU General Public License v3.0 only,GPL-3.0-only,:/about/dep/kddw.txt, 0

--- a/lib/cpu/RegisterView.qml
+++ b/lib/cpu/RegisterView.qml
@@ -21,10 +21,8 @@ import Qt.labs.qmlmodels
 import "../cpu" as Ui
 import edu.pepp
 
-ColumnLayout {
+Column {
     id: layout
-    implicitHeight: layout.implicitHeight
-    implicitWidth: layout.implicitWidth
     property alias registers: registers.model
     property alias flags: flags.model
     NuAppSettings {
@@ -56,76 +54,70 @@ ColumnLayout {
 
         MenuItem {}
     }
-
-    ListView {
-        id: flags
+    Row {
+        id: flagsContainer
         property real overrideLeftMargin: 0
-        Layout.leftMargin: overrideLeftMargin
-        Layout.alignment: Qt.AlignVCenter
         spacing: metrics.averageCharacterWidth * 1.5
-        clip: true
-        boundsMovement: Flickable.StopAtBounds
-        Layout.minimumWidth: contentItem.childrenRect.width
-        Layout.minimumHeight: contentItem.childrenRect.height
-        orientation: Qt.Horizontal
-        delegate: Row {
-            id: del
-            Layout.alignment: Qt.AlignVCenter
-            required property bool checked
-            required property string text
-            Rectangle {
-                id: borderRect
-                implicitWidth: innerText.implicitWidth + 2 * border.width + 2 * innerText.anchors.margins
-                implicitHeight: innerText.implicitHeight + 2 * border.width + 2 * innerText.anchors.margins
-                Text {
-                    id: innerText
-                    anchors.fill: parent
-                    anchors.margins: 3
-                    text: del.checked ? "1" : "0"
-                    horizontalAlignment: Qt.AlignHCenter
-                    verticalAlignment: Qt.AlignVCenter
-                    font: settings.extPalette.baseMono.font
-                }
-                color: "transparent"
-                border {
-                    color: palette.shadow
-                    width: 1
-                }
-                radius: 2
-            }
-            // Wrap label in item as work-around for Label not expanding to match height of borderRect
-            Item {
-                Layout.fillHeight: true
-                implicitWidth: label.implicitWidth
-                implicitHeight: innerText.implicitHeight + 2 * borderRect.border.width + 2 * innerText.anchors.margins
-                Label {
-                    id: label
-                    leftPadding: 2
-                    text: del.text
-                    anchors.centerIn: parent
-                }
-            }
+        Item {
+            width: flagsContainer.overrideLeftMargin
+            height: 1
+        }
 
-            Item {
-                implicitHeight: 1
-                implicitWidth: 8
+        Repeater {
+            id: flags
+            clip: true
+            delegate: Row {
+                id: del
+                required property bool checked
+                required property string text
+                Rectangle {
+                    id: borderRect
+                    implicitWidth: innerText.implicitWidth + 2 * border.width + 2 * innerText.anchors.margins
+                    implicitHeight: innerText.implicitHeight + 2 * border.width + 2 * innerText.anchors.margins
+                    Text {
+                        id: innerText
+                        anchors.fill: parent
+                        anchors.margins: 3
+                        text: del.checked ? "1" : "0"
+                        horizontalAlignment: Qt.AlignHCenter
+                        verticalAlignment: Qt.AlignVCenter
+                        font: settings.extPalette.baseMono.font
+                    }
+                    color: "transparent"
+                    border {
+                        color: palette.shadow
+                        width: 1
+                    }
+                    radius: 2
+                }
+                // Wrap label in item as work-around for Label not expanding to match height of borderRect
+                Item {
+                    Layout.fillHeight: true
+                    implicitWidth: label.implicitWidth
+                    implicitHeight: innerText.implicitHeight + 2 * borderRect.border.width + 2 * innerText.anchors.margins
+                    Label {
+                        id: label
+                        leftPadding: 2
+                        text: del.text
+                        anchors.centerIn: parent
+                    }
+                }
+
+                Item {
+                    implicitHeight: 1
+                    implicitWidth: 8
+                }
             }
         }
     }
-    ListView {
+    Repeater {
         id: registers
-        Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-        Layout.fillHeight: true
         clip: true
-        spacing: 1
-        boundsMovement: Flickable.StopAtBounds
-        Layout.minimumWidth: contentItem.childrenRect.width
-        Layout.minimumHeight: contentItem.childrenRect.height
         property int innerSpacing: 5
 
         function updateFlagMargin() {
-            // I don't know _why_ I need an offset of 1.5x. I must be missing some edge-padding factor of the flags
-            flags.overrideLeftMargin = Qt.binding(() => registers.x + pm.width * 1.2 + 1.5 * registers.innerSpacing);
+            // Need an offset of 3 to account for border width of 1 + radius 2, maybe?
+            flagsContainer.overrideLeftMargin = Qt.binding(() => registers.x + pm.width * 1.2 - 3);
         }
         onWidthChanged: {
             updateFlagMargin();
@@ -162,6 +154,10 @@ ColumnLayout {
                     Layout.minimumHeight: textField.height + 1
                     Layout.preferredWidth: childrenRect.width
                     color: "transparent"
+                    Component.onCompleted: {
+                        if (column == 1 && row == 0)
+                            registers.updateFlagMargin();
+                    }
 
                     TextField {
                         id: textField
@@ -215,6 +211,6 @@ ColumnLayout {
     }
     // Provide some padding at the bottom
     Item {
-        height: 10
+        Layout.fillHeight: true
     }
 }

--- a/lib/memory/io/Batch.qml
+++ b/lib/memory/io/Batch.qml
@@ -9,13 +9,11 @@ ColumnLayout {
         id: settings
     }
 
-    property alias label: label.text
     property alias text: area.text
-    property real minimumHeight: label.height + scrollViewMinHeight
+    property alias readOnly: area.readOnly
+    property real minimumHeight: scrollViewMinHeight
     property real scrollViewMinHeight: 100
-    Label {
-        id: label
-    }
+
     ScrollView {
         id: scrollView
         Layout.minimumHeight: root.scrollViewMinHeight

--- a/lib/menu/Actions.qml
+++ b/lib/menu/Actions.qml
@@ -7,8 +7,7 @@ QtObject {
     required property var project
     property bool dark: window.palette.text.hslLightness < 0.5
     function updateNativeText(obj) {
-        obj.nativeText = Qt.binding(() => SequenceConverter.toNativeText(
-                                        obj.shortcut))
+        obj.nativeText = Qt.binding(() => SequenceConverter.toNativeText(obj.shortcut));
     }
 
     readonly property var file: QtObject {
@@ -91,8 +90,7 @@ QtObject {
             icon.source: `image://icons/file/cut${dark ? '' : '_dark'}.svg`
             shortcut: StandardKey.Cut
             onShortcutChanged: updateNativeText(this)
-            enabled: !!activeFocusItem && !!activeFocusItem["cut"]
-            && (!activeFocusItem.readOnly ?? true)
+            enabled: !!activeFocusItem && !!activeFocusItem["cut"] && (!activeFocusItem.readOnly ?? true)
             onTriggered: activeFocusItem.cut()
         }
         readonly property var paste: Action {
@@ -101,8 +99,7 @@ QtObject {
             icon.source: `image://icons/file/paste${dark ? '' : '_dark'}.svg`
             shortcut: StandardKey.Paste
             onShortcutChanged: updateNativeText(this)
-            enabled: !!activeFocusItem && !!activeFocusItem["paste"]
-            && (!activeFocusItem.readOnly ?? true)
+            enabled: !!activeFocusItem && !!activeFocusItem["paste"] && (!activeFocusItem.readOnly ?? true)
             onTriggered: activeFocusItem.paste()
         }
         readonly property var prefs: Action {
@@ -116,8 +113,8 @@ QtObject {
             enabled: project?.allowedDebugging & DebugEnableFlags.LoadObject
             property string nativeText: ""
             onTriggered: {
-                window.syncEditors()
-                project.onFormatObject()
+                window.syncEditors();
+                project.onFormatObject();
             }
             text: "&Format Object Code"
             icon.source: "image://icons/blank.svg"
@@ -128,8 +125,8 @@ QtObject {
             enabled: project?.allowedDebugging & DebugEnableFlags.LoadObject
             property string nativeText: ""
             onTriggered: {
-                window.syncEditors()
-                project.onLoadObject()
+                window.syncEditors();
+                project.onLoadObject();
             }
             text: qsTr("&Load Object Code")
             icon.source: `image://icons/build/flash${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`
@@ -141,8 +138,8 @@ QtObject {
             property string nativeText: ""
             onTriggered: {
                 // New editor does not lose focus before "assemble" is triggered, so we must save manually.
-                window.preAssemble()
-                project.onAssemble()
+                window.syncEditors();
+                project.onAssemble();
             }
             text: qsTr("&Assemble")
             icon.source: `image://icons/build/build${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`
@@ -154,8 +151,8 @@ QtObject {
             property string nativeText: ""
             onTriggered: {
                 // New editor does not lose focus before "assemble" is triggered, so we must save manually.
-                window.preAssemble()
-                project.onAssembleThenLoad()
+                window.syncEditors();
+                project.onAssembleThenLoad();
             }
             text: qsTr("Assemble &Load Object Code")
             icon.source: `image://icons/build/flash${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`
@@ -167,8 +164,8 @@ QtObject {
             property string nativeText: ""
             onTriggered: {
                 // New editor does not lose focus before "assemble" is triggered, so we must save manually.
-                window.preAssemble()
-                project.onAssembleThenFormat()
+                window.syncEditors();
+                project.onAssembleThenFormat();
             }
             text: qsTr("&Format Assembly Code")
             // Use blank icon to force menu items to line up.
@@ -180,8 +177,8 @@ QtObject {
             property string nativeText: ""
             onTriggered: {
                 // New editor does not lose focus before "assemble" is triggered, so we must save manually.
-                window.preAssemble()
-                project.onExecute()
+                window.syncEditors();
+                project.onExecute();
             }
             text: qsTr("&Execute")
             icon.source: `image://icons/debug/start_normal${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`
@@ -196,8 +193,8 @@ QtObject {
             property string nativeText: ""
             onTriggered: {
                 // New editor does not lose focus before "assemble" is triggered, so we must save manually.
-                window.preAssemble()
-                project.onDebuggingStart()
+                window.syncEditors();
+                project.onDebuggingStart();
             }
             text: qsTr("Start &Debugging")
             icon.source: `image://icons/debug/start_debug${enabled ? '' : '_disabled'}${dark ? '' : '_dark'}.svg`

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -78,13 +78,13 @@ FocusScope {
             project.requestSourceBreakpoints.disconnect(userAsmEdit.editor.onRequestAllBreakpoints);
             project.requestSourceBreakpoints.disconnect(osAsmEdit.editor.onRequestAllBreakpoints);
             project.switchTo.disconnect(wrapper.onSwitchTo);
+            project.updateGUI.disconnect(watchExpr.updateGUI);
+            project.updateGUI.disconnect(bpViewer.updateGUI);
         }
         onProjectChanged.disconnect(fixListings);
 
         wrapper.actions.debug.start.triggered.disconnect(wrapper.requestModeSwitchToDebugger);
         wrapper.actions.build.execute.triggered.disconnect(wrapper.requestModeSwitchToDebugger);
-        project.updateGUI.disconnect(watchExpr.updateGUI);
-        project.updateGUI.disconnect(bpViewer.updateGUI);
     }
     signal requestModeSwitchTo(string mode)
     function requestModeSwitchToDebugger() {
@@ -152,7 +152,7 @@ FocusScope {
         osAsmEdit.readOnly = false;
         userAsmEdit.text = project?.userAsmText ?? "";
         osAsmEdit.text = project?.osAsmText ?? "";
-        osAsmEdit.readOnly = Qt.binding(() => !project.abstraction === Abstraction.OS4);
+        osAsmEdit.readOnly = Qt.binding(() => !project?.abstraction === Abstraction.OS4);
     }
 
     SplitView {
@@ -280,12 +280,12 @@ FocusScope {
                         }
                         Debug.WatchExpressions {
                             id: watchExpr
-                            watchExpressions: project.watchExpressions ?? null
+                            watchExpressions: project?.watchExpressions ?? null
                         }
                         BreakpointViewer {
                             id: bpViewer
-                            model: project.breakpointModel
-                            lineInfo: project.lines2addr ?? null
+                            model: project?.breakpointModel ?? null
+                            lineInfo: project?.lines2addr ?? null
                         }
                     }
                 }

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -281,10 +281,9 @@ FocusScope {
             id: dock_input
             title: "Batch Input"
             uniqueName: `BatchInput-${dockWidgetArea.uniqueName}`
-            IO.Labeled {
+            IO.Batch {
                 id: batchInput
                 anchors.fill: parent
-                label: ""
                 property bool ignoreTextChange: false
                 Component.onCompleted: {
                     onTextChanged.connect(() => {
@@ -303,11 +302,11 @@ FocusScope {
             id: dock_output
             title: "Batch Output"
             uniqueName: `BatchOutput-${dockWidgetArea.uniqueName}`
-            IO.Labeled {
+            IO.Batch {
                 id: batchOutput
                 anchors.fill: parent
-                label: ""
                 text: project?.charOut ?? ""
+                readOnly: true
             }
         }
         KDDW.DockWidget {

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -21,7 +21,39 @@ FocusScope {
     NuAppSettings {
         id: settings
     }
+    onModeChanged: modeVisibilityChange()
 
+    function modeVisibilityChange() {
+        // Don't allow triggering before initial docking, otherwise the layout can be 1) slow and 2) wrong.
+        if (needsDock) {
+            return;
+        } else if (mode === "editor") {
+            dock_source.open();
+            dock_listing.close();
+            dock_input.open();
+            dock_output.close();
+            dock_object.close();
+            dock_symbol.open();
+            dock_watch.close();
+            dock_breakpoints.close();
+            dock_cpu.close();
+            dock_stack.close();
+            dock_hexdump.close();
+        } else if (mode === "debugger") {
+            dock_source.close();
+            dock_listing.open();
+            dock_input.open();
+            dock_output.open();
+            dock_object.open();
+            dock_symbol.open();
+            dock_watch.open();
+            dock_breakpoints.open();
+            dock_cpu.open();
+            // Most recently opened tab is made active, so open hex dump last.
+            dock_stack.open();
+            dock_hexdump.open();
+        }
+    }
     // Call when the height, width have been finalized.
     // Otherwise, we attempt to layout when height/width == 0, and all our requests are ignored.
     function dock() {
@@ -53,6 +85,7 @@ FocusScope {
         dockWidgetArea.addDockWidget(dock_hexdump, KDDW.KDDockWidgets.Location_OnBottom, dock_cpu, Qt.size(regmemcol_width, memdump_height));
         dock_hexdump.addDockWidgetAsTab(dock_stack, PreserveCurrent);
         wrapper.needsDock = Qt.binding(() => false);
+        modeVisibilityChange();
     }
     Component.onCompleted: {
         // Must connect and disconnect manually, otherwise project may be changed underneath us, and "save" targets wrong project.

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -291,8 +291,7 @@ FocusScope {
                 id: registers
                 anchors {
                     top: parent.top
-                    left: parent.left
-                    right: parent.right
+                    horizontalCenter: parent.horizontalCenter
                 }
 
                 registers: project?.registers ?? null

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -27,21 +27,30 @@ FocusScope {
     function dock() {
         const StartHidden = 1;
         const PreserveCurrent = 2;
-        const memcolwidth = registers.implicitWidth;
-        const memdumpheight = parent.height - registers.implicitHeight;
-        const gcwidth = parent.width * .3;
-        const ioheight = 200;
-        // Dock source editors
-        dockWidgetArea.addDockWidget(dock_source, KDDW.KDDockWidgets.Location_OnLeft, dockWidgetArea);
-        dockWidgetArea.addDockWidget(dock_listing, KDDW.KDDockWidgets.Location_OnBottom, dock_source);
-        dockWidgetArea.addDockWidget(dock_object, KDDW.KDDockWidgets.Location_OnBottom, null);
+
+        const reg_height = registers.childrenRect.height;
+        const regmemcol_width = registers.implicitWidth;
+        const memdump_height = parent.height - registers.implicitHeight;
+
+        const bottom_height = Math.max(200, parent.height * .1);
+        const io_width = Math.max(300, parent.width * .2);
+        const editor_height = (parent.height - bottom_height) / 2;
+        const editor_width = parent.width - regmemcol_width - io_width;
+        // Dock text
+        dockWidgetArea.addDockWidget(dock_source, KDDW.KDDockWidgets.Location_OnLeft, dockWidgetArea, Qt.size(editor_width, editor_height));
+        dockWidgetArea.addDockWidget(dock_listing, KDDW.KDDockWidgets.Location_OnBottom, dock_source, Qt.size(editor_width, editor_height));
+        // Dock IOs to right of editors
+        dockWidgetArea.addDockWidget(dock_input, KDDW.KDDockWidgets.Location_OnRight, dockWidgetArea, Qt.size(io_width, editor_height));
+        dockWidgetArea.addDockWidget(dock_output, KDDW.KDDockWidgets.Location_OnBottom, dock_input, Qt.size(io_width, editor_height));
+        // Dock "helpers" below everything
+        dockWidgetArea.addDockWidget(dock_object, KDDW.KDDockWidgets.Location_OnBottom, null, Qt.size(editor_width, bottom_height));
         dock_object.addDockWidgetAsTab(dock_symbol, PreserveCurrent);
         dock_object.addDockWidgetAsTab(dock_watch, PreserveCurrent);
         dock_object.addDockWidgetAsTab(dock_breakpoints, PreserveCurrent);
-        dock_object.addDockWidgetAsTab(dock_input);
-        dock_object.addDockWidgetAsTab(dock_output, PreserveCurrent);
-        dockWidgetArea.addDockWidget(dock_cpu, KDDW.KDDockWidgets.Location_OnRight, null);
-        dockWidgetArea.addDockWidget(dock_hexdump, KDDW.KDDockWidgets.Location_OnBottom, dock_cpu);
+
+        // Setup memory area
+        dockWidgetArea.addDockWidget(dock_cpu, KDDW.KDDockWidgets.Location_OnRight, null, Qt.size(regmemcol_width, reg_height));
+        dockWidgetArea.addDockWidget(dock_hexdump, KDDW.KDDockWidgets.Location_OnBottom, dock_cpu, Qt.size(regmemcol_width, memdump_height));
         dock_hexdump.addDockWidgetAsTab(dock_stack, PreserveCurrent);
         wrapper.needsDock = Qt.binding(() => false);
     }

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -27,14 +27,14 @@ FocusScope {
     function dock() {
         const StartHidden = 1;
         const PreserveCurrent = 2;
-
+        const total_height = parent.height - visibilityBar.height;
         const reg_height = registers.childrenRect.height;
         const regmemcol_width = registers.implicitWidth;
-        const memdump_height = parent.height - registers.implicitHeight;
+        const memdump_height = total_height - registers.implicitHeight;
 
-        const bottom_height = Math.max(200, parent.height * .1);
+        const bottom_height = Math.max(200, total_height * .1);
         const io_width = Math.max(300, parent.width * .2);
-        const editor_height = (parent.height - bottom_height) / 2;
+        const editor_height = (total_height - bottom_height) / 2;
         const editor_width = parent.width - regmemcol_width - io_width;
         // Dock text
         dockWidgetArea.addDockWidget(dock_source, KDDW.KDDockWidgets.Location_OnLeft, dockWidgetArea, Qt.size(editor_width, editor_height));
@@ -154,7 +154,12 @@ FocusScope {
 
     KDDW.DockingArea {
         id: dockWidgetArea
-        anchors.fill: parent
+        anchors {
+            top: parent.top
+            left: parent.left
+            right: parent.right
+            bottom: visibilityBar.top
+        }
         // Need application-wide unique ID, otherwise opening a new project will confuse the global name resolution algorithm.
         // TODO: Not gauranteed to be unique, but should be good enough for our purposes.
         uniqueName: Math.ceil(Math.random() * 1000000000).toString(16)
@@ -374,6 +379,23 @@ FocusScope {
             Stack.StackTrace {
                 anchors.fill: parent
             }
+        }
+    }
+    ListView {
+        id: visibilityBar
+        anchors {
+            left: parent.left
+            right: parent.right
+            bottom: parent.bottom
+        }
+        height: 15
+        orientation: Qt.Horizontal
+        model: [dock_source, dock_listing, dock_object, dock_symbol, dock_watch, dock_breakpoints, dock_input, dock_output, dock_cpu, dock_hexdump, dock_stack]
+        delegate: CheckBox {
+            text: modelData.title
+            checked: modelData.isOpen
+            onClicked: checked ? modelData.open() : modelData.close()
+            Layout.alignment: Qt.AlignBottom
         }
     }
 

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -101,28 +101,21 @@ FocusScope {
             osList.readOnly = curORO;
         }
     }
-    // TODO: replace preAssemble someday...
     function syncEditors() {
         save();
     }
     function save() {
         // Supress saving messages when there is no project.
-        if (project === null)
-            return;
-        if (!userAsmEdit.readOnly) {
-            project.userAsmText = userAsmEdit.text;
-        }
-        if (!osAsmEdit.readOnly) {
-            project.osAsmText = osAsmEdit.text;
+        if (project) {
+            if (!userAsmEdit.readOnly) {
+                project.userAsmText = userAsmEdit.text;
+            }
+            if (!osAsmEdit.readOnly) {
+                project.osAsmText = osAsmEdit.text;
+            }
         }
     }
 
-    function preAssemble() {
-        if (project === null)
-            return;
-        project.userAsmText = userAsmEdit.text;
-        project.osAsmText = osAsmEdit.text;
-    }
     function onOverwriteEditors() {
         osAsmEdit.readOnly = false;
         userAsmEdit.text = project?.userAsmText ?? "";

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -157,7 +157,7 @@ FocusScope {
         anchors.fill: parent
         // Need application-wide unique ID, otherwise opening a new project will confuse the global name resolution algorithm.
         // TODO: Not gauranteed to be unique, but should be good enough for our purposes.
-        uniqueName: `${Math.ceil(Math.random() * 1_000_000_000).toString(16)}`
+        uniqueName: Math.ceil(Math.random() * 1000000000).toString(16)
         KDDW.DockWidget {
             id: dock_source
             title: "Source Editor"

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -207,7 +207,7 @@ FocusScope {
                     id: listingSelector
                     model: ["User", "OS"]
                     Layout.fillWidth: true
-                    visible: !dock_source.visible
+                    visible: !sourceSelector.visible
                     onActivated: function (new_index) {
                         sourceSelector.currentIndex = Qt.binding(() => new_index);
                     }

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -57,32 +57,7 @@ FocusScope {
         project.updateGUI.connect(bpViewer.updateGUI);
         userAsmEdit.forceActiveFocus();
     }
-    // Will be called before project is changed on unload, so we can disconnect save-triggering signals.
     Component.onDestruction: {
-        userAsmEdit.editingFinished.disconnect(save);
-        osAsmEdit.editingFinished.disconnect(save);
-        if (project) {
-            userAsmEdit.editor.modifyLine.disconnect(project.onModifyUserSource);
-            osAsmEdit.editor.modifyLine.disconnect(project.onModifyOSSource);
-            userList.editor.modifyLine.disconnect(project.onModifyUserList);
-            osList.editor.modifyLine.disconnect(project.onModifyOSList);
-            project.errorsChanged.disconnect(displayErrors);
-            project.listingChanged.connect(fixListings);
-            project.overwriteEditors.disconnect(onOverwriteEditors);
-            project.modifyUserSource.disconnect(userAsmEdit.editor.onLineAction);
-            project.modifyOSSource.disconnect(osAsmEdit.editor.onLineAction);
-            project.modifyUserList.disconnect(userList.editor.onLineAction);
-            project.modifyOSList.disconnect(osList.editor.onLineAction);
-            project.clearListingBreakpoints.disconnect(userList.editor.onClearAllBreakpoints);
-            project.clearListingBreakpoints.disconnect(osList.editor.onClearAllBreakpoints);
-            project.requestSourceBreakpoints.disconnect(userAsmEdit.editor.onRequestAllBreakpoints);
-            project.requestSourceBreakpoints.disconnect(osAsmEdit.editor.onRequestAllBreakpoints);
-            project.switchTo.disconnect(wrapper.onSwitchTo);
-            project.updateGUI.disconnect(watchExpr.updateGUI);
-            project.updateGUI.disconnect(bpViewer.updateGUI);
-        }
-        onProjectChanged.disconnect(fixListings);
-
         wrapper.actions.debug.start.triggered.disconnect(wrapper.requestModeSwitchToDebugger);
         wrapper.actions.build.execute.triggered.disconnect(wrapper.requestModeSwitchToDebugger);
     }

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -146,10 +146,13 @@ FocusScope {
     KDDW.DockingArea {
         id: dockWidgetArea
         anchors.fill: parent
-        uniqueName: "ASMBLayout"
+        // Need application-wide unique ID, otherwise opening a new project will confuse the global name resolution algorithm.
+        // TODO: Not gauranteed to be unique, but should be good enough for our purposes.
+        uniqueName: `${Math.ceil(Math.random() * 1_000_000_000).toString(16)}`
         KDDW.DockWidget {
             id: dock_source
-            uniqueName: "Source Editor"
+            title: "Source Editor"
+            uniqueName: `SourceEditor-${dockWidgetArea.uniqueName}`
             ColumnLayout {
                 anchors.fill: parent
                 ComboBox {
@@ -187,7 +190,8 @@ FocusScope {
         }
         KDDW.DockWidget {
             id: dock_listing
-            uniqueName: "Listing"
+            title: "Listing"
+            uniqueName: `Listing-${dockWidgetArea.uniqueName}`
             ColumnLayout {
                 anchors.fill: parent
                 ComboBox {
@@ -231,7 +235,8 @@ FocusScope {
         }
         KDDW.DockWidget {
             id: dock_object
-            uniqueName: "Object Code"
+            title: "Object Code"
+            uniqueName: `ObjectCode-${dockWidgetArea.uniqueName}`
             Text.ObjTextEditor {
                 id: objEdit
                 anchors.fill: parent
@@ -242,8 +247,8 @@ FocusScope {
         }
         KDDW.DockWidget {
             id: dock_symbol
-            uniqueName: "Symbol Table"
             title: qsTr(`Symbol Table: ${sourceSelector.currentText}`)
+            uniqueName: `SymbolTable-${dockWidgetArea.uniqueName}`
             SymTab.SymbolViewer {
                 id: symTab
                 anchors.fill: parent
@@ -253,7 +258,8 @@ FocusScope {
         }
         KDDW.DockWidget {
             id: dock_watch
-            uniqueName: qsTr(`Watch Expressions`)
+            title: qsTr(`Watch Expressions`)
+            uniqueName: `WatchExpressions-${dockWidgetArea.uniqueName}`
             Debug.WatchExpressions {
                 id: watchExpr
                 anchors.fill: parent
@@ -262,7 +268,8 @@ FocusScope {
         }
         KDDW.DockWidget {
             id: dock_breakpoints
-            uniqueName: qsTr(`Breakpoint Viewer`)
+            title: qsTr(`Breakpoint Viewer`)
+            uniqueName: `BreakpointViewer-${dockWidgetArea.uniqueName}`
             BreakpointViewer {
                 id: bpViewer
                 anchors.fill: parent
@@ -272,7 +279,8 @@ FocusScope {
         }
         KDDW.DockWidget {
             id: dock_input
-            uniqueName: "Batch Input"
+            title: "Batch Input"
+            uniqueName: `BatchInput-${dockWidgetArea.uniqueName}`
             IO.Labeled {
                 id: batchInput
                 anchors.fill: parent
@@ -293,7 +301,8 @@ FocusScope {
         }
         KDDW.DockWidget {
             id: dock_output
-            uniqueName: "Batch Output"
+            title: "Batch Output"
+            uniqueName: `BatchOutput-${dockWidgetArea.uniqueName}`
             IO.Labeled {
                 id: batchOutput
                 anchors.fill: parent
@@ -303,7 +312,8 @@ FocusScope {
         }
         KDDW.DockWidget {
             id: dock_cpu
-            uniqueName: "Register Dump"
+            title: "Register Dump"
+            uniqueName: `RegisterDump-${dockWidgetArea.uniqueName}`
             ColumnLayout {
                 anchors.fill: parent
                 property size kddockwidgets_min_size: Qt.size(registers.implicitWidth, registers.implicitHeight)
@@ -319,7 +329,8 @@ FocusScope {
         }
         KDDW.DockWidget {
             id: dock_hexdump
-            uniqueName: "Memory Dump"
+            title: "Memory Dump"
+            uniqueName: `MemoryDump-${dockWidgetArea.uniqueName}`
             Loader {
                 id: loader
                 anchors.fill: parent
@@ -350,7 +361,8 @@ FocusScope {
         }
         KDDW.DockWidget {
             id: dock_stack
-            uniqueName: "Stack Trace"
+            title: "Stack Trace"
+            uniqueName: `StackTrace-${dockWidgetArea.uniqueName}`
             Stack.StackTrace {
                 anchors.fill: parent
             }

--- a/lib/project/Pep10ISA.qml
+++ b/lib/project/Pep10ISA.qml
@@ -15,6 +15,7 @@ FocusScope {
     required property var actions
     required property string mode
     property bool needsDock: true
+    focus: true
     signal requestModeSwitchTo(string mode)
 
     function syncEditors() {
@@ -23,17 +24,19 @@ FocusScope {
     // Call when the height, width have been finalized.
     // Otherwise, we attempt to layout when height/width == 0, and all our requests are ignored.
     function dock() {
+        const StartHidden = 1;
+        const PreserveCurrent = 2;
         const memcolwidth = registers.implicitWidth;
         const memdumpheight = parent.height - registers.implicitHeight;
         const gcwidth = parent.width * .3;
         const ioheight = 200;
         dockWidgetArea.addDockWidget(dock_object, KDDW.KDDockWidgets.Location_OnLeft, dockWidgetArea, Qt.size(parent.width - gcwidth - memcolwidth, parent.height - ioheight));
         dockWidgetArea.addDockWidget(dock_greencard, KDDW.KDDockWidgets.Location_OnRight, dockWidgetArea, Qt.size(gcwidth, parent.height - ioheight));
-        wrapper.needsDock = Qt.binding(() => false);
         dockWidgetArea.addDockWidget(dock_input, KDDW.KDDockWidgets.Location_OnBottom, dockWidgetArea, Qt.size(parent.width - memcolwidth, ioheight));
-        dock_input.addDockWidgetAsTab(dock_output);
+        dock_input.addDockWidgetAsTab(dock_output, PreserveCurrent);
         dockWidgetArea.addDockWidget(dock_cpu, KDDW.KDDockWidgets.Location_OnRight, null, Qt.size(memcolwidth, registers.childrenRect.height));
         dockWidgetArea.addDockWidget(dock_hexdump, KDDW.KDDockWidgets.Location_OnBottom, dock_cpu, Qt.size(memcolwidth, parent.height - registers.childrenRect.height));
+        wrapper.needsDock = Qt.binding(() => false);
     }
 
     Component.onCompleted: {
@@ -104,7 +107,6 @@ FocusScope {
             IO.Labeled {
                 id: batchOutput
                 anchors.fill: parent
-                width: parent.width
                 label: ""
                 text: project?.charOut ?? ""
             }

--- a/lib/project/Pep10ISA.qml
+++ b/lib/project/Pep10ISA.qml
@@ -34,7 +34,7 @@ FocusScope {
         dockWidgetArea.addDockWidget(dock_greencard, KDDW.KDDockWidgets.Location_OnRight, dockWidgetArea, Qt.size(gcwidth, parent.height - ioheight));
         dockWidgetArea.addDockWidget(dock_input, KDDW.KDDockWidgets.Location_OnBottom, dockWidgetArea, Qt.size(parent.width - memcolwidth, ioheight));
         dock_input.addDockWidgetAsTab(dock_output, PreserveCurrent);
-        dockWidgetArea.addDockWidget(dock_cpu, KDDW.KDDockWidgets.Location_OnRight, null, Qt.size(memcolwidth, registers.childrenRect.height));
+        dockWidgetArea.addDockWidget(dock_cpu, KDDW.KDDockWidgets.Location_OnRight, dockWidgetArea, Qt.size(memcolwidth, registers.childrenRect.height));
         dockWidgetArea.addDockWidget(dock_hexdump, KDDW.KDDockWidgets.Location_OnBottom, dock_cpu, Qt.size(memcolwidth, parent.height - registers.childrenRect.height));
         wrapper.needsDock = Qt.binding(() => false);
     }
@@ -53,12 +53,14 @@ FocusScope {
     KDDW.DockingArea {
         id: dockWidgetArea
         anchors.fill: parent
-
-        uniqueName: "ISA3Layout"
-
+        // Need application-wide unique ID, otherwise opening a new project will confuse the global name resolution algorithm.
+        // TODO: Not gauranteed to be unique, but should be good enough for our purposes.
+        uniqueName: `${Math.ceil(Math.random() * 1_000_000_000).toString(16)}`
         KDDW.DockWidget {
             id: dock_object
-            uniqueName: "Object Code"
+            title: "Object Code"
+            uniqueName: `ObjectCode-${dockWidgetArea.uniqueName}`
+
             Text.ObjTextEditor {
                 id: objEdit
                 anchors.fill: parent
@@ -69,7 +71,8 @@ FocusScope {
         }
         KDDW.DockWidget {
             id: dock_greencard
-            uniqueName: "Instructions"
+            title: "Instructions"
+            uniqueName: `Instructions-${dockWidgetArea.uniqueName}`
             Utils.GreencardView {
                 id: greencard
                 // property size kddockwidgets_min_size: Qt.size(300, 100)
@@ -82,7 +85,8 @@ FocusScope {
         }
         KDDW.DockWidget {
             id: dock_input
-            uniqueName: "Batch Input"
+            title: "Batch Input"
+            uniqueName: `BatchInput-${dockWidgetArea.uniqueName}`
             IO.Labeled {
                 id: batchInput
                 anchors.fill: parent
@@ -103,7 +107,8 @@ FocusScope {
         }
         KDDW.DockWidget {
             id: dock_output
-            uniqueName: "Batch Output"
+            title: "Batch Output"
+            uniqueName: `BatchOutput-${dockWidgetArea.uniqueName}`
             IO.Labeled {
                 id: batchOutput
                 anchors.fill: parent
@@ -113,7 +118,8 @@ FocusScope {
         }
         KDDW.DockWidget {
             id: dock_cpu
-            uniqueName: "Register Dump"
+            title: "Register Dump"
+            uniqueName: `RegisterDump-${dockWidgetArea.uniqueName}`
             ColumnLayout {
                 anchors.fill: parent
                 property size kddockwidgets_min_size: Qt.size(registers.implicitWidth, registers.implicitHeight)
@@ -129,7 +135,8 @@ FocusScope {
         }
         KDDW.DockWidget {
             id: dock_hexdump
-            uniqueName: "Memory Dump"
+            title: "Memory Dump"
+            uniqueName: `MemoryDump-${dockWidgetArea.uniqueName}`
             Loader {
                 id: loader
                 anchors.fill: parent

--- a/lib/project/Pep10ISA.qml
+++ b/lib/project/Pep10ISA.qml
@@ -26,11 +26,17 @@ FocusScope {
     function dock() {
         const StartHidden = 1;
         const PreserveCurrent = 2;
+
+        const total_height = parent.height - visibilityBar.height;
+
         const reg_height = registers.childrenRect.height;
         const regmemcol_width = registers.implicitWidth;
-        const memdump_height = parent.height - registers.implicitHeight;
+
+        const memdump_height = total_height - registers.implicitHeight;
         const greencard_width = parent.width * .3;
-        const io_height = Math.max(200, parent.height * .1);
+
+        const io_height = Math.max(200, total_height * .1);
+
         dockWidgetArea.addDockWidget(dock_object, KDDW.KDDockWidgets.Location_OnLeft, dockWidgetArea, Qt.size(parent.width - greencard_width - regmemcol_width, parent.height - io_height));
         dockWidgetArea.addDockWidget(dock_greencard, KDDW.KDDockWidgets.Location_OnRight, dockWidgetArea, Qt.size(greencard_width, parent.height - io_height));
         dockWidgetArea.addDockWidget(dock_input, KDDW.KDDockWidgets.Location_OnBottom, dockWidgetArea, Qt.size(parent.width - regmemcol_width, io_height));
@@ -53,7 +59,12 @@ FocusScope {
     }
     KDDW.DockingArea {
         id: dockWidgetArea
-        anchors.fill: parent
+        anchors {
+            top: parent.top
+            left: parent.left
+            right: parent.right
+            bottom: visibilityBar.top
+        }
         // Need application-wide unique ID, otherwise opening a new project will confuse the global name resolution algorithm.
         // TODO: Not gauranteed to be unique, but should be good enough for our purposes.
         uniqueName: Math.ceil(Math.random() * 1000000000).toString(16)
@@ -164,6 +175,23 @@ FocusScope {
                     }
                 }
             }
+        }
+    }
+    ListView {
+        id: visibilityBar
+        anchors {
+            left: parent.left
+            right: parent.right
+            bottom: parent.bottom
+        }
+        height: 15
+        orientation: Qt.Horizontal
+        model: [dock_object, dock_greencard, dock_input, dock_output, dock_cpu, dock_hexdump]
+        delegate: CheckBox {
+            text: modelData.title
+            checked: modelData.isOpen
+            onClicked: checked ? modelData.open() : modelData.close()
+            Layout.alignment: Qt.AlignBottom
         }
     }
 

--- a/lib/project/Pep10ISA.qml
+++ b/lib/project/Pep10ISA.qml
@@ -21,6 +21,29 @@ FocusScope {
     function syncEditors() {
         project ? save() : null;
     }
+    onModeChanged: modeVisibilityChange()
+
+    function modeVisibilityChange() {
+        // Don't allow triggering before initial docking, otherwise the layout can be 1) slow and 2) wrong.
+        if (needsDock) {
+            return;
+        } else if (mode === "editor") {
+            dock_object.open();
+            dock_greencard.open();
+            dock_input.open();
+            dock_output.close();
+            dock_cpu.close();
+            dock_hexdump.open();
+        } else if (mode === "debugger") {
+            dock_object.open();
+            dock_greencard.close();
+            dock_input.open();
+            dock_output.open();
+            dock_cpu.open();
+            dock_hexdump.open();
+        }
+    }
+
     // Call when the height, width have been finalized.
     // Otherwise, we attempt to layout when height/width == 0, and all our requests are ignored.
     function dock() {
@@ -40,10 +63,11 @@ FocusScope {
         dockWidgetArea.addDockWidget(dock_object, KDDW.KDDockWidgets.Location_OnLeft, dockWidgetArea, Qt.size(parent.width - greencard_width - regmemcol_width, parent.height - io_height));
         dockWidgetArea.addDockWidget(dock_greencard, KDDW.KDDockWidgets.Location_OnRight, dockWidgetArea, Qt.size(greencard_width, parent.height - io_height));
         dockWidgetArea.addDockWidget(dock_input, KDDW.KDDockWidgets.Location_OnBottom, dockWidgetArea, Qt.size(parent.width - regmemcol_width, io_height));
-        dock_input.addDockWidgetAsTab(dock_output, PreserveCurrent);
+        dock_input.addDockWidgetAsTab(dock_output, StartHidden);
         dockWidgetArea.addDockWidget(dock_cpu, KDDW.KDDockWidgets.Location_OnRight, dockWidgetArea, Qt.size(regmemcol_width, reg_height));
         dockWidgetArea.addDockWidget(dock_hexdump, KDDW.KDDockWidgets.Location_OnBottom, dock_cpu, Qt.size(regmemcol_width, memdump_height));
         wrapper.needsDock = Qt.binding(() => false);
+        modeVisibilityChange();
     }
 
     Component.onCompleted: {

--- a/lib/project/Pep10ISA.qml
+++ b/lib/project/Pep10ISA.qml
@@ -18,13 +18,10 @@ Item {
         wrapper.requestModeSwitchTo("debugger");
     }
     function syncEditors() {
-        save();
+        if (project)
+            save();
     }
-    function preAssemble() {
-        if (project === null)
-            return;
-        save();
-    }
+
     Component.onCompleted: {
         // Must connect and disconnect manually, otherwise project may be changed underneath us, and "save" targets wrong project.
         // Do not need to update on mode change, since mode change implies loss of focus of objEdit.
@@ -43,9 +40,7 @@ Item {
 
     function save() {
         // Supress saving messages when there is no project.
-        if (project === null)
-            return;
-        else if (!objEdit.readOnly)
+        if (project && !objEdit.readOnly)
             project.objectCodeText = objEdit.text;
     }
 

--- a/lib/project/Pep10ISA.qml
+++ b/lib/project/Pep10ISA.qml
@@ -87,10 +87,9 @@ FocusScope {
             id: dock_input
             title: "Batch Input"
             uniqueName: `BatchInput-${dockWidgetArea.uniqueName}`
-            IO.Labeled {
+            IO.Batch {
                 id: batchInput
                 anchors.fill: parent
-                label: ""
                 property bool ignoreTextChange: false
                 Component.onCompleted: {
                     onTextChanged.connect(() => {
@@ -109,11 +108,11 @@ FocusScope {
             id: dock_output
             title: "Batch Output"
             uniqueName: `BatchOutput-${dockWidgetArea.uniqueName}`
-            IO.Labeled {
+            IO.Batch {
                 id: batchOutput
                 anchors.fill: parent
-                label: ""
                 text: project?.charOut ?? ""
+                readOnly: true
             }
         }
         KDDW.DockWidget {

--- a/lib/project/Pep10ISA.qml
+++ b/lib/project/Pep10ISA.qml
@@ -36,9 +36,7 @@ Item {
         project.charInChanged.connect(() => batchInput.setInput(project.charIn));
         objEdit.forceActiveFocus();
     }
-    // Will be called before project is changed on unload, so we can disconnect save-triggering signals.
     Component.onDestruction: {
-        objEdit.editingFinished.disconnect(save);
         wrapper.actions.debug.start.triggered.disconnect(wrapper.requestModeSwitchToDebugger);
         wrapper.actions.build.execute.triggered.disconnect(wrapper.requestModeSwitchToDebugger);
     }

--- a/lib/project/Pep10ISA.qml
+++ b/lib/project/Pep10ISA.qml
@@ -26,16 +26,17 @@ FocusScope {
     function dock() {
         const StartHidden = 1;
         const PreserveCurrent = 2;
-        const memcolwidth = registers.implicitWidth;
-        const memdumpheight = parent.height - registers.implicitHeight;
-        const gcwidth = parent.width * .3;
-        const ioheight = 200;
-        dockWidgetArea.addDockWidget(dock_object, KDDW.KDDockWidgets.Location_OnLeft, dockWidgetArea, Qt.size(parent.width - gcwidth - memcolwidth, parent.height - ioheight));
-        dockWidgetArea.addDockWidget(dock_greencard, KDDW.KDDockWidgets.Location_OnRight, dockWidgetArea, Qt.size(gcwidth, parent.height - ioheight));
-        dockWidgetArea.addDockWidget(dock_input, KDDW.KDDockWidgets.Location_OnBottom, dockWidgetArea, Qt.size(parent.width - memcolwidth, ioheight));
+        const reg_height = registers.childrenRect.height;
+        const regmemcol_width = registers.implicitWidth;
+        const memdump_height = parent.height - registers.implicitHeight;
+        const greencard_width = parent.width * .3;
+        const io_height = Math.max(200, parent.height * .1);
+        dockWidgetArea.addDockWidget(dock_object, KDDW.KDDockWidgets.Location_OnLeft, dockWidgetArea, Qt.size(parent.width - greencard_width - regmemcol_width, parent.height - io_height));
+        dockWidgetArea.addDockWidget(dock_greencard, KDDW.KDDockWidgets.Location_OnRight, dockWidgetArea, Qt.size(greencard_width, parent.height - io_height));
+        dockWidgetArea.addDockWidget(dock_input, KDDW.KDDockWidgets.Location_OnBottom, dockWidgetArea, Qt.size(parent.width - regmemcol_width, io_height));
         dock_input.addDockWidgetAsTab(dock_output, PreserveCurrent);
-        dockWidgetArea.addDockWidget(dock_cpu, KDDW.KDDockWidgets.Location_OnRight, dockWidgetArea, Qt.size(memcolwidth, registers.childrenRect.height));
-        dockWidgetArea.addDockWidget(dock_hexdump, KDDW.KDDockWidgets.Location_OnBottom, dock_cpu, Qt.size(memcolwidth, parent.height - registers.childrenRect.height));
+        dockWidgetArea.addDockWidget(dock_cpu, KDDW.KDDockWidgets.Location_OnRight, dockWidgetArea, Qt.size(regmemcol_width, reg_height));
+        dockWidgetArea.addDockWidget(dock_hexdump, KDDW.KDDockWidgets.Location_OnBottom, dock_cpu, Qt.size(regmemcol_width, memdump_height));
         wrapper.needsDock = Qt.binding(() => false);
     }
 

--- a/lib/project/Pep10ISA.qml
+++ b/lib/project/Pep10ISA.qml
@@ -56,7 +56,7 @@ FocusScope {
         anchors.fill: parent
         // Need application-wide unique ID, otherwise opening a new project will confuse the global name resolution algorithm.
         // TODO: Not gauranteed to be unique, but should be good enough for our purposes.
-        uniqueName: `${Math.ceil(Math.random() * 1_000_000_000).toString(16)}`
+        uniqueName: Math.ceil(Math.random() * 1000000000).toString(16)
         KDDW.DockWidget {
             id: dock_object
             title: "Object Code"

--- a/lib/project/pep10.cpp
+++ b/lib/project/pep10.cpp
@@ -747,6 +747,7 @@ void Pep_ISA::prepareSim() {
   auto charOut = _system->output("charOut");
   charOut->clear(0);
   pwrOff->clear(0);
+  emit charOutChanged();
 
   auto charIn = _system->input("charIn");
   charIn->clear(0);
@@ -1125,6 +1126,7 @@ void Pep_ASMB::prepareSim() {
   auto charOut = _system->output("charOut");
   charOut->clear(0);
   pwrOff->clear(0);
+  emit charOutChanged();
 
   auto charIn = _system->input("charIn");
   charIn->clear(0);

--- a/lib/project/pep10.cpp
+++ b/lib/project/pep10.cpp
@@ -265,9 +265,9 @@ template <typename CPU, typename ISA> FlagModel *flag_model(targets::isa::System
   return ret;
 }
 
-Pep_ISA::Pep_ISA(project::Environment env, QVariant delegate, QObject *parent, bool initializeSystem)
-    : QObject(parent), _env(env), _delegate(delegate), _tb(QSharedPointer<sim::trace2::InfiniteBuffer>::create()),
-      _memory(nullptr), _registers(nullptr), _flags(nullptr) {
+Pep_ISA::Pep_ISA(project::Environment env, QObject *parent, bool initializeSystem)
+    : QObject(parent), _env(env), _tb(QSharedPointer<sim::trace2::InfiniteBuffer>::create()), _memory(nullptr),
+      _registers(nullptr), _flags(nullptr) {
   _system.clear();
   assert(_system.isNull());
   _dbg = QSharedPointer<pepp::debug::Debugger>::create(this);
@@ -319,6 +319,8 @@ project::Environment Pep_ISA::env() const {
 pepp::Architecture Pep_ISA::architecture() const { return _env.arch; }
 
 pepp::Abstraction Pep_ISA::abstraction() const { return _env.level; }
+
+QString Pep_ISA::delegatePath() const { return "qrc:/qt/qml/edu/pepp/project/Pep10ISA.qml"; }
 
 ARawMemory *Pep_ISA::memory() const { return _memory; }
 
@@ -819,8 +821,7 @@ project::DebugEnableFlags::DebugEnableFlags(QObject *parent) : QObject(parent) {
 
 project::StepEnableFlags::StepEnableFlags(QObject *parent) : QObject(parent) {}
 
-Pep_ASMB::Pep_ASMB(project::Environment env, QVariant delegate, QObject *parent)
-    : Pep_ISA(env, delegate, parent, false) {
+Pep_ASMB::Pep_ASMB(project::Environment env, QObject *parent) : Pep_ISA(env, parent, false) {
   using enum pepp::Architecture;
   using enum pepp::Abstraction;
   switch (_env.arch) {
@@ -860,6 +861,8 @@ Pep_ASMB::Pep_ASMB(project::Environment env, QVariant delegate, QObject *parent)
   _dbg->line_maps->addScope("user");
   _dbg->line_maps->addScope("os");
 }
+
+QString Pep_ASMB::delegatePath() const { return "qrc:/qt/qml/edu/pepp/project/Pep10ASMB.qml"; }
 
 void Pep_ASMB::set(int abstraction, QString value) {
   using enum pepp::Abstraction;

--- a/lib/project/pep10.hpp
+++ b/lib/project/pep10.hpp
@@ -22,7 +22,6 @@ class Pep_ISA : public QObject, public pepp::debug::Environment {
   Q_PROPERTY(project::Environment env READ env CONSTANT)
   Q_PROPERTY(pepp::Architecture architecture READ architecture CONSTANT)
   Q_PROPERTY(pepp::Abstraction abstraction READ abstraction CONSTANT)
-  Q_PROPERTY(QVariant delegate MEMBER _delegate NOTIFY delegateChanged)
   Q_PROPERTY(QString objectCodeText READ objectCodeText WRITE setObjectCodeText NOTIFY objectCodeTextChanged);
   Q_PROPERTY(ARawMemory *memory READ memory CONSTANT)
   // Preserve the current address in the memory dump pane on tab-switch.
@@ -55,11 +54,11 @@ public:
     Partial,
     Full,
   };
-  explicit Pep_ISA(project::Environment env, QVariant delegate, QObject *parent = nullptr,
-                   bool initializeSystem = true);
+  explicit Pep_ISA(project::Environment env, QObject *parent = nullptr, bool initializeSystem = true);
   virtual project::Environment env() const;
   virtual pepp::Architecture architecture() const;
   virtual pepp::Abstraction abstraction() const;
+  Q_INVOKABLE virtual QString delegatePath() const;
   ARawMemory *memory() const;
   OpcodeModel *mnemonics() const;
   QString objectCodeText() const;
@@ -106,7 +105,6 @@ public slots:
 
 signals:
   void objectCodeTextChanged();
-  void delegateChanged();
   void currentAddressChanged();
   void allowedDebuggingChanged();
   void allowedStepsChanged();
@@ -135,7 +133,6 @@ protected:
   project::Environment _env;
   QString _charIn = {};
   QString _objectCodeText = {};
-  QVariant _delegate = {};
   QSharedPointer<sim::trace2::InfiniteBuffer> _tb = {};
   QSharedPointer<targets::isa::System> _system = {};
   QSharedPointer<ELFIO::elfio> _elf = {};
@@ -176,7 +173,8 @@ class Pep_ASMB final : public Pep_ISA {
   using Action = ScintillaAsmEditBase::Action;
 
 public:
-  explicit Pep_ASMB(project::Environment env, QVariant delegate, QObject *parent = nullptr);
+  explicit Pep_ASMB(project::Environment env, QObject *parent = nullptr);
+  Q_INVOKABLE QString delegatePath() const override;
   // Actually utils::Abstraction, but QM passes it as an int.
   Q_INVOKABLE void set(int abstraction, QString value);
   Q_INVOKABLE QString userAsmText() const;

--- a/lib/project/pep10.hpp
+++ b/lib/project/pep10.hpp
@@ -64,7 +64,7 @@ public:
   QString objectCodeText() const;
   void setObjectCodeText(const QString &objectCodeText);
   Q_INVOKABLE static QStringListModel *modes() {
-    static QStringListModel ret({"Welcome", "Editor", "Debugger", "Help"});
+    static QStringListModel ret({"Welcome", "Help", "Editor", "Debugger"});
     QQmlEngine::setObjectOwnership(&ret, QQmlEngine::CppOwnership);
     return &ret;
   }

--- a/lib/top/DockTitleBar.qml
+++ b/lib/top/DockTitleBar.qml
@@ -1,0 +1,53 @@
+/*
+  This file is part of KDDockWidgets.
+
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  Author: Sérgio Martins <sergio.martins@kdab.com>
+
+  SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+import QtQuick 2.9
+import QtQuick.Window 2.15
+
+// Will be moved to a plugin in the future, if there's enough demand
+import "qrc:/kddockwidgets/qtquick/views/qml/" as KDDW
+
+/**
+  * Copied from TitleBar.qml, with buttons removed
+ */
+KDDW.TitleBarBase {
+    id: root
+
+    color: "#eff0f1"
+    heightWhenVisible: 30
+
+    function dpiSuffix(): string {
+        // Since Qt's built-in @Nx doesn't support fractionals, we load the correct image manually
+        if (Screen.devicePixelRatio === 1) {
+            return "";
+        } else if (Screen.devicePixelRatio === 1.5) {
+            return "-1.5x";
+        } else if (Screen.devicePixelRatio === 2) {
+            return "-2x";
+        } else {
+            return "";
+        }
+    }
+
+    function imagePath(id: string): string {
+        return "qrc:/img/" + id + dpiSuffix() + ".png";
+    }
+
+    Text {
+        id: title
+        text: root.title
+        anchors {
+            left: parent ? parent.left : undefined
+            leftMargin: 5
+            verticalCenter: parent.verticalCenter
+        }
+    }
+}

--- a/lib/top/Guest1.qml
+++ b/lib/top/Guest1.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.15
+
+Rectangle {
+    anchors.fill: parent
+    color: "red"
+}

--- a/lib/top/Guest1.qml
+++ b/lib/top/Guest1.qml
@@ -1,6 +1,0 @@
-import QtQuick 2.15
-
-Rectangle {
-    anchors.fill: parent
-    color: "red"
-}

--- a/lib/top/Guest2.qml
+++ b/lib/top/Guest2.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.15
+
+Rectangle {
+    anchors.fill: parent
+    color: "orange"
+}

--- a/lib/top/Guest2.qml
+++ b/lib/top/Guest2.qml
@@ -1,6 +1,0 @@
-import QtQuick 2.15
-
-Rectangle {
-    anchors.fill: parent
-    color: "orange"
-}

--- a/lib/top/ProjectSelectBar.qml
+++ b/lib/top/ProjectSelectBar.qml
@@ -29,22 +29,22 @@ Flickable {
                     if (cur && cur.architecture === Architecture.PEP10 && cur.abstraction === Abstraction.ISA3 && cur.isEmpty && reuse)
                         proj = cur;
                     else
-                        proj = pm.pep10ISA(pep10isaComponent);
+                        proj = pm.pep10ISA();
                 } else if (Number(level) === Abstraction.ASMB3) {
                     if (cur && cur.architecture === Architecture.PEP10 && cur.abstraction === Abstraction.ASMB3 && cur.isEmpty && reuse)
                         proj = cur;
                     else
-                        proj = pm.pep10ASMB(pep10asmbComponent, Abstraction.ASMB3);
+                        proj = pm.pep10ASMB(Abstraction.ASMB3);
                 } else if (Number(level) === Abstraction.ASMB5) {
                     if (cur && cur.architecture === Architecture.PEP10 && cur.abstraction === Abstraction.ASMB5 && cur.isEmpty && reuse)
                         proj = cur;
                     else
-                        proj = pm.pep10ASMB(pep10asmbComponent, Abstraction.ASMB5);
+                        proj = pm.pep10ASMB(Abstraction.ASMB5);
                 } else if (Number(level) === Abstraction.OS4) {
                     if (cur && cur.architecture === Architecture.PEP10 && cur.abstraction === Abstraction.OS4 && cur.isEmpty && reuse)
                         proj = cur;
                     else
-                        proj = pm.pep10ASMB(pep10asmbComponent, Abstraction.OS4);
+                        proj = pm.pep10ASMB(Abstraction.OS4);
                 }
                 break;
                 break;
@@ -53,12 +53,12 @@ Flickable {
                     if (cur && cur.architecture === Architecture.PEP9 && cur.abstraction === Abstraction.ISA3 && cur.isEmpty && reuse)
                         proj = cur;
                     else
-                        proj = pm.pep9ISA(pep9isaComponent);
+                        proj = pm.pep9ISA();
                 } else if (Number(level) === Abstraction.ASMB5) {
                     if (cur && cur.architecture === Architecture.PEP9 && cur.abstraction === Abstraction.ASMB5 && cur.isEmpty && reuse)
                         proj = cur;
                     else
-                        proj = pm.pep9ASMB(pep9asmbComponent);
+                        proj = pm.pep9ASMB();
                 }
                 break;
             }

--- a/lib/top/SideBar.qml
+++ b/lib/top/SideBar.qml
@@ -8,17 +8,17 @@ Column {
     property var modesModel: undefined
     function switchToMode(mode) {
         // Match the button, case insensitive.
-        const re = new RegExp(mode, "i")
+        const re = new RegExp(mode, "i");
         // Children of sidebar are the repeater's delegates
         for (var button of root.children) {
             if (re.test(button.text)) {
-                button.clicked()
+                button.clicked();
                 // Must set checked in order for ButtonGroup to match current mode.
-                button.checked = true
-                return
+                button.checked = true;
+                return;
             }
         }
-        console.error(`Did not find mode ${mode}`)
+        console.error(`Did not find mode ${mode}`);
     }
     signal modeChanged(string mode)
 
@@ -30,17 +30,20 @@ Column {
         ListElement {
             display: "Help"
         }
+        ListElement {
+            display: "Dock"
+        }
     }
     function mapModeToImage(mode) {
         switch (mode) {
         case "welcome":
-            return "home.svg"
+            return "home.svg";
         case "help":
-            return "help.svg"
+            return "help.svg";
         case "debugger":
-            return "pest_control.svg"
+            return "pest_control.svg";
         case "editor":
-            return "edit.svg"
+            return "edit.svg";
         }
     }
 
@@ -55,8 +58,7 @@ Column {
             text: model.display ?? "ERROR"
             ButtonGroup.group: modeGroup
             onClicked: root.modeChanged(text.toLowerCase())
-            icon.source: `image://icons/modes/${root.mapModeToImage(
-                             text.toLowerCase())}`
+            icon.source: `image://icons/modes/${root.mapModeToImage(text.toLowerCase())}`
             icon.height: 42
             icon.width: 42
             display: AbstractButton.TextUnderIcon

--- a/lib/top/SideBar.qml
+++ b/lib/top/SideBar.qml
@@ -30,9 +30,6 @@ Column {
         ListElement {
             display: "Help"
         }
-        ListElement {
-            display: "Dock"
-        }
     }
     function mapModeToImage(mode) {
         switch (mode) {

--- a/lib/top/projectmodel.hpp
+++ b/lib/top/projectmodel.hpp
@@ -27,10 +27,10 @@ public:
   int rowCount(const QModelIndex &parent) const override;
   QVariant data(const QModelIndex &index, int role) const override;
   bool setData(const QModelIndex &index, const QVariant &value, int role) override;
-  Q_INVOKABLE Pep_ISA *pep10ISA(QVariant delegate);
-  Q_INVOKABLE Pep_ISA *pep9ISA(QVariant delegate);
-  Q_INVOKABLE Pep_ASMB *pep10ASMB(QVariant delegate, pepp::Abstraction abstraction);
-  Q_INVOKABLE Pep_ASMB *pep9ASMB(QVariant delegate);
+  Q_INVOKABLE Pep_ISA *pep10ISA();
+  Q_INVOKABLE Pep_ISA *pep9ISA();
+  Q_INVOKABLE Pep_ASMB *pep10ASMB(pepp::Abstraction abstraction);
+  Q_INVOKABLE Pep_ASMB *pep9ASMB();
   bool removeRows(int row, int count, const QModelIndex &parent) override;
   bool moveRows(const QModelIndex &sourceParent, int sourceRow, int count, const QModelIndex &destinationParent,
                 int destinationChild) override;

--- a/test/about/dependencies.cpp
+++ b/test/about/dependencies.cpp
@@ -19,6 +19,6 @@
 
 TEST_CASE("About Dependencies", "[scope:help.about][kind:unit][arch:*]") {
   auto deps = about::dependencies();
-  CHECK(deps.length() == 14);
+  CHECK(deps.length() == 15);
   for (const auto &dep : deps) CHECK(dep.licenseText.size() != 0);
 };


### PR DESCRIPTION
As part of our meeting on 2025-05-15, Stan and I discussed a way of laying out components within the editor and the debugger.

The key complaint was that I had not selected a sufficient set of components to be visible, and did not provide users the ability to show or hide additional components.

For example, as Stan was authoring an ISA3 or ASMB3 program without symbols, he wanted to have the memory pane visible next to the source editor.
For address that he did not yet know the value of, he could assign them a placeholder (`AA AA`, `BB BB` and so on).
After assembling and loading the code, he could use the memory dump to find the actual address that corresponded to the placeholder and substitute that value.

To this end, I've replaced my previous system for dividing the UI (splitters) with [Docking Widgets](https://github.com/KDAB/KDDockWidgets). These docking widgets allow me to provide sane defaults while still allowing users to completely reconfigure a UI as they see fit.