### PR TITLE
Fix copying from listing

### DIFF
--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -129,6 +129,7 @@ FocusScope {
 
     function onSwitchTo(os) {
         sourceSelector.currentIndex = Qt.binding(() => os ? 1 : 0);
+        listingSelector.currentIndex = Qt.binding(() => os ? 1 : 0);
     }
 
     function displayErrors() {

--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -141,14 +141,12 @@ FocusScope {
             const curURO = userList.readOnly;
             userList.readOnly = false;
             userList.text = project.userList ?? "";
-            userList.addListingAnnotations(project.userListAnnotations);
             userList.readOnly = curURO;
         }
         if (osList) {
             const curORO = osList.readOnly;
             osList.readOnly = false;
             osList.text = project.osList ?? "";
-            osList.addListingAnnotations(project.osListAnnotations);
             osList.readOnly = curORO;
         }
     }

--- a/lib/project/pep10.hpp
+++ b/lib/project/pep10.hpp
@@ -161,10 +161,8 @@ class Pep_ASMB final : public Pep_ISA {
   Q_OBJECT
   Q_PROPERTY(QString userAsmText READ userAsmText WRITE setUserAsmText NOTIFY userAsmTextChanged);
   Q_PROPERTY(QString userList READ userList NOTIFY listingChanged);
-  Q_PROPERTY(QList<Error *> userListAnnotations READ userListAnnotations NOTIFY listingChanged);
   Q_PROPERTY(QString osAsmText READ osAsmText WRITE setOSAsmText NOTIFY osAsmTextChanged);
   Q_PROPERTY(QString osList READ osList NOTIFY listingChanged);
-  Q_PROPERTY(QList<Error *> osListAnnotations READ osListAnnotations NOTIFY listingChanged);
   Q_PROPERTY(QList<Error *> assemblerErrors READ errors NOTIFY errorsChanged)
   Q_PROPERTY(StaticSymbolModel *staticSymbolModel READ staticSymbolModel CONSTANT)
   Q_PROPERTY(pepp::debug::WatchExpressionEditor *watchExpressions READ watchExpressions CONSTANT)
@@ -180,11 +178,9 @@ public:
   Q_INVOKABLE QString userAsmText() const;
   Q_INVOKABLE void setUserAsmText(const QString &userAsmText);
   Q_INVOKABLE QString userList() const;
-  Q_INVOKABLE const QList<Error *> userListAnnotations() const;
   Q_INVOKABLE QString osAsmText() const;
   Q_INVOKABLE void setOSAsmText(const QString &osAsmText);
   Q_INVOKABLE QString osList() const;
-  Q_INVOKABLE const QList<Error *> osListAnnotations() const;
   Q_INVOKABLE const QList<Error *> errors() const;
   bool isEmpty() const override;
   Q_INVOKABLE StaticSymbolModel *staticSymbolModel() const;
@@ -224,5 +220,5 @@ protected:
 
   QString _userAsmText = {}, _osAsmText = {};
   QString _userList = {}, _osList = {};
-  QList<QPair<int, QString>> _errors = {}, _userListAnnotations = {}, _osListAnnotations = {};
+  QList<QPair<int, QString>> _errors = {};
 };

--- a/lib/text/editor/ScintillaAsmEdit.qml
+++ b/lib/text/editor/ScintillaAsmEdit.qml
@@ -37,17 +37,6 @@ FocusScope {
             editor.addEOLAnnotation(lst[i].line, lst[i].message);
         }
     }
-    // List has {line:#, message:str}
-    function addListingAnnotations(lst) {
-        editor.clearAllInlineAnnotations();
-        // See styles at: https://scintilla.org/ScintillaDoc.html#EndOfLineAnnotations
-        const len = lst?.length ?? 0;
-        let style = len === 0 ? 0x0 : 0x1;
-        editor.setInlineAnnotationsVisible(style);
-        for (var i = 0; i < len; i++) {
-            editor.addInlineAnnotation(lst[i].line, lst[i].message);
-        }
-    }
 
     property real charHeight: editor.charHeight
 

--- a/lib/toolchain/pas/driver/pep10.cpp
+++ b/lib/toolchain/pas/driver/pep10.cpp
@@ -71,7 +71,14 @@ bool pas::driver::pep10::TransformWholeProgramSanity::operator()(QSharedPointer<
   auto sections = pas::ast::children(*root);
   for (auto &section : sections) {
     auto children = pas::ast::children(*section);
-    for (auto &child : children) child->set(ast::generic::ListingLocation{it++});
+    for (auto &child : children) {
+      child->set(ast::generic::ListingLocation{it});
+      if (child->has<ast::generic::Hide>() &&
+          child->get<ast::generic::Hide>().value.object != ast::generic::Hide::In::Object::Emit) {
+        it += 1;
+      } else if (auto size = ops::pepp::implicitSize<isa::Pep10>(*child); size <= 3) it += 1;
+      else it += (size + 2) / 3;
+    }
   }
   // TODO: tie class variable to OS features.
   return pas::ops::pepp::checkWholeProgramSanity<isa::Pep10>(

--- a/lib/toolchain/pas/driver/pep9.cpp
+++ b/lib/toolchain/pas/driver/pep9.cpp
@@ -55,7 +55,14 @@ bool pas::driver::pep9::TransformWholeProgramSanity::operator()(QSharedPointer<G
   auto sections = pas::ast::children(*root);
   for (auto &section : sections) {
     auto children = pas::ast::children(*section);
-    for (auto &child : children) child->set(ast::generic::ListingLocation{it++});
+    for (auto &child : children) {
+      child->set(ast::generic::ListingLocation{it});
+      if (child->has<ast::generic::Hide>() &&
+          child->get<ast::generic::Hide>().value.object != ast::generic::Hide::In::Object::Emit) {
+        it += 1;
+      } else if (auto size = ops::pepp::implicitSize<isa::Pep9>(*child); size <= 3) it += 1;
+      else it += (size + 2) / 3;
+    }
   }
   // TODO: tie class variable to OS features.
   return pas::ops::pepp::checkWholeProgramSanity<isa::Pep9>(


### PR DESCRIPTION
Listing lines with multiple object-code continuation lines now copy properly.

Progress on #867.