### PR TITLE
CLI improvements for `ls` and `get`

### DIFF
--- a/bin/src/commands/get.hpp
+++ b/bin/src/commands/get.hpp
@@ -17,30 +17,37 @@
 #pragma once
 #include <string>
 #include "../shared.hpp"
+#include "../task.hpp"
 #include "get/fig.hpp"
+#include "get/io.hpp"
 #include "get/macro.hpp"
 
 void registerGet(auto &app, task_factory_t &task, detail::SharedFlags &flags) {
   static auto get = app.add_subcommand("get", "Fetch the body of a figure or macro");
-  static auto get_selector = get->add_option_group("")->required();
+  static auto get_selector = get->add_option_group("figure_or_macro")->required();
   static auto get_figure = get_selector->add_option_group("[--ch]");
   static std::string ch, fig, macro, type, prob;
+  static int inputValue = 0;
   static auto chOpt = get_figure->add_option("--ch", ch, "")->required();
   static auto get_item = get_figure->add_option_group("[--fig, --prob]");
   static auto figOpt = get_item->add_option("--fig", fig, "");
   static auto probOpt = get_item->add_option("--prob", prob, "");
-  static auto typeOpt = get_figure->add_option("--type", type, "")->default_val("pep");
+  static auto get_type = get_figure->add_option_group("[--input, --type]");
+  static auto inputOpt = get_type->add_option("--input", inputValue, "");
+  static auto typeOpt = get_type->add_option("--type", type, "")->default_val("pep");
   static auto macroOpt = get_selector->add_option("--macro", macro, "");
   get_selector->require_option(1);
   get_item->require_option(1);
+  get_type->require_option(1);
   get->callback([&]() {
     flags.kind = detail::SharedFlags::Kind::TERM;
     if (chOpt->count() > 0)
       task = [&](QObject *parent) {
-        if (*figOpt)
-          return new GetFigTask(flags.edValue, ch, fig, type, true, parent);
-        else
-          return new GetFigTask(flags.edValue, ch, fig, type, false, parent);
+        Task *ret = nullptr;
+        if (*inputOpt) ret = new GetIOTask(flags.edValue, ch, fig, true, inputValue, parent);
+        else if (*figOpt) ret = new GetFigTask(flags.edValue, ch, fig, type, true, parent);
+        else if (*probOpt) ret = new GetFigTask(flags.edValue, ch, prob, type, false, parent);
+        return ret;
       };
     else if (macroOpt->count() > 0)
       task = [&](QObject *parent) { return new GetMacroTask(flags.edValue, macro, parent); };

--- a/bin/src/commands/get/io.cpp
+++ b/bin/src/commands/get/io.cpp
@@ -1,0 +1,33 @@
+#include "io.hpp"
+#include <iostream>
+#include "help/builtins/figure.hpp"
+#include "toolchain/helpers/assemblerregistry.hpp"
+
+GetIOTask::GetIOTask(int ed, std::string ch, std::string fig, bool isFigure, int testIdx, QObject *parent)
+    : Task(parent), ed(ed), testIdx(testIdx), isFigure(isFigure), ch(ch), fig(fig) {}
+
+void GetIOTask::run() {
+  using namespace Qt::StringLiterals;
+  static const auto err_noitem = u"%1 %2.%3 does not exist.\n"_s;
+  auto books = helpers::builtins_registry(false);
+  auto book = helpers::book(ed, &*books);
+  if (book.isNull()) return emit finished(1);
+  QSharedPointer<const builtins::Figure> item = nullptr;
+  if (isFigure) item = book->findFigure(QString::fromStdString(ch), QString::fromStdString(fig));
+  else item = book->findProblem(QString::fromStdString(ch), QString::fromStdString(fig));
+  if (item.isNull()) {
+    std::cerr << err_noitem.arg(isFigure ? "Figure" : "Problem")
+                     .arg(QString::fromStdString(ch), QString::fromStdString(fig))
+                     .toStdString();
+    return emit finished(1);
+  }
+  auto tests = item->typesafeTests();
+  if (testIdx < 0 || testIdx >= tests.size()) {
+    std::cerr << "Invalid test index: " << testIdx << ". Valid range is 0 to " << (tests.size() - 1) << ".\n";
+    return emit finished(2);
+  }
+  auto test = tests[testIdx];
+  std::cout << test->input.toString().trimmed().toStdString() << std::endl;
+
+  return emit finished(0);
+}

--- a/bin/src/commands/get/io.hpp
+++ b/bin/src/commands/get/io.hpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023-2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "../../task.hpp"
+
+class GetIOTask : public Task {
+public:
+  GetIOTask(int ed, std::string ch, std::string fig, bool isFigure /*1 is figure, 0 is problem*/, int testIdx,
+            QObject *parent = nullptr);
+  void run() override;
+
+private:
+  int ed, testIdx;
+  bool isFigure;
+  std::string ch, fig;
+};

--- a/bin/src/commands/ls.cpp
+++ b/bin/src/commands/ls.cpp
@@ -27,42 +27,44 @@ void ListTask::run() {
   using namespace Qt::StringLiterals;
   auto books = helpers::builtins_registry(false);
   auto book = helpers::book(ed, &*books);
-  if (book.isNull())
-    return emit finished(1);
+  if (book.isNull()) return emit finished(1);
   auto figures = book->figures();
   auto problems = book->problems();
   auto macros = book->macros();
 
   // Prevent figure name from overlapping with file types. See #305.
   int maxFigWidth = 10;
-  for (auto figure : figures)
+  for (auto &figure : figures)
     maxFigWidth = std::max<int>(figure->chapterName().length() + 1 /*.*/ + figure->figureName().length(), maxFigWidth);
-  for (auto problem : problems)
+  for (auto &problem : problems)
     maxFigWidth =
         std::max<int>(problem->chapterName().length() + 1 /*.*/ + problem->figureName().length(), maxFigWidth);
 
   int maxMacroWidth = 6;
-  for (auto macro : macros)
-    maxMacroWidth = std::max<int>(macro->name().length(), maxMacroWidth);
-  std::cout << "Figures: " << std::endl;
-  for (auto &figure : figures) {
-    std::cout
-        << u"%1.%2"_s.arg(figure->chapterName(), figure->figureName()).leftJustified(maxFigWidth + 2).toStdString();
-    std::cout << figure->typesafeNamedFragments().keys().join(", ").toStdString();
-    std::cout << std::endl;
+  for (auto macro : macros) maxMacroWidth = std::max<int>(macro->name().length(), maxMacroWidth);
+  if (this->showFigs) {
+    std::cout << "Figures: " << std::endl;
+    for (auto &figure : figures) {
+      std::cout
+          << u"%1.%2"_s.arg(figure->chapterName(), figure->figureName()).leftJustified(maxFigWidth + 2).toStdString();
+      if (this->showTestCount) std::cout << u"%1"_s.arg(figure->tests().size(), -4).toStdString();
+      std::cout << figure->typesafeNamedFragments().keys().join(", ").toStdString();
+      std::cout << std::endl;
+    }
   }
 
-  if (problems.size() > 0) {
+  if (problems.size() > 0 && this->showProbs) {
     std::cout << "\nProblems: \n";
     for (auto &problem : problems) {
       std::cout
           << u"%1.%2"_s.arg(problem->chapterName(), problem->figureName()).leftJustified(maxFigWidth + 2).toStdString();
+      if (this->showTestCount) std::cout << u"%1"_s.arg(problem->tests().size(), -4).toStdString();
       std::cout << problem->typesafeNamedFragments().keys().join(", ").toStdString();
       std::cout << std::endl;
     }
   }
 
-  if (macros.size() > 0) {
+  if (macros.size() > 0 && this->showMacros) {
     std::cout << "\nMacros: \n";
     for (auto &macro : macros)
       std::cout << u"%1"_s.arg(macro->name()).leftJustified(maxMacroWidth + 2).toStdString()

--- a/bin/src/commands/ls.hpp
+++ b/bin/src/commands/ls.hpp
@@ -22,6 +22,7 @@ class ListTask : public Task {
 public:
   ListTask(int ed, QObject *parent = nullptr);
   void run() override;
+  bool showFigs = true, showProbs = false, showMacros = false, showTestCount = false;
 
 private:
   int ed;
@@ -29,9 +30,24 @@ private:
 
 void registerList(auto &app, task_factory_t &task, detail::SharedFlags &flags) {
   static auto list = app.add_subcommand("ls", "Produce list of figures and macros");
+  static bool showFigs = true, showProbs = false, showMacros = false, showTestCount = false;
+  static auto optFigs =
+      list->add_flag(" --show-figures,!--no-show-figures", showFigs, "List figures")->default_val(true);
+  static auto optOpt =
+      list->add_flag("--show-problems,!--no-show-problems", showProbs, "List problems")->default_val(false);
+  static auto optMacros =
+      list->add_flag("--show-macros,!--no-show-macros", showMacros, "List macros")->default_val(false);
+  static auto optTestCount =
+      list->add_flag("--show-test-count,!--no-test-count", showTestCount, "List test count")->default_val(false);
   list->callback([&]() {
     flags.kind = detail::SharedFlags::Kind::TERM;
     task = [&](QObject *parent) {
-    return new ListTask(flags.edValue, parent); };
+      auto ret = new ListTask(flags.edValue, parent);
+      ret->showFigs = showFigs;
+      ret->showProbs = showProbs;
+      ret->showMacros = showMacros;
+      ret->showTestCount = showTestCount;
+      return ret;
+    };
   });
 }

--- a/bin/src/main.cpp
+++ b/bin/src/main.cpp
@@ -63,11 +63,11 @@ int main(int argc, char **argv) {
   app.set_help_flag("-h,--help", "Display this help message and exit.");
 
   auto shared_flags = detail::SharedFlags{.kind = detail::SharedFlags::Kind::DEFAULT};
-  auto ed = app.add_flag("-e,--edition", shared_flags.edValue,
-                         "Which edition of Computer Systems to target. "
-                         "Possible values are 4, 5, and 6.")
+  auto ed = app.add_option("-e,--edition", shared_flags.edValue,
+                           "Which edition of Computer Systems to target. "
+                           "Possible values are 4, 5, and 6.")
                 ->default_val(6)
-                ->expected(4, 6);
+                ->check(CLI::Bound(4, 6));
   task_factory_t task = nullptr;
 
   registerLicense(app, task, shared_flags);


### PR DESCRIPTION
- `ls` now optionally outputs # of tests
- `ls` allow figures/problems/macros to be individually enabled for listing
- `get` now allows extracting the input for a figure/problem's test case
- `-e,--edition` flag properly validates edition being in [4,6]