### PR TITLE
Add `microasm` and `microrun` subcommands

### DIFF
--- a/bin/src/commands/microasm.cpp
+++ b/bin/src/commands/microasm.cpp
@@ -1,0 +1,77 @@
+#include "microasm.hpp"
+#include "toolchain/ucode/parser.hpp"
+#include "toolchain/ucode/uarch.hpp"
+
+MicroAsmTask::MicroAsmTask(int ed, std::string in, int busWidth, QObject *parent)
+    : Task(parent), ed(ed), busWidth(busWidth), in(in) {}
+
+void MicroAsmTask::setErrName(std::string fname) { errOut = fname; }
+
+void MicroAsmTask::setOutCPUName(std::string fname) { pepcpuOut = fname; }
+
+void MicroAsmTask::run() {
+  using uarch1 = pepp::ucode::Pep9ByteBus;
+  using uarch2 = pepp::ucode::Pep9WordBus;
+  using regs = pepp::ucode::Pep9Registers;
+  QString source;
+  {
+    QFile sIn(QString::fromStdString(this->in)); // auto-closes
+    if (!sIn.exists()) {
+      std::cerr << "Source file does not exist.\n";
+      emit finished(3);
+    }
+    sIn.open(QIODevice::ReadOnly | QIODevice::Text);
+    source = sIn.readAll();
+    sIn.close();
+  }
+
+  pepp::ucode::Errors errors;
+  QStringList formatted;
+  if (busWidth == 1) {
+    auto result = pepp::ucode::parse<uarch1, regs>(source);
+    if (!result.errors.empty()) errors = result.errors;
+    else
+      for (const auto &line : result.program) formatted.append(pepp::ucode::format<uarch1, regs>(line));
+  } else if (busWidth == 2) {
+    auto result = pepp::ucode::parse<uarch2, regs>(source);
+    if (!result.errors.empty()) errors = result.errors;
+    else
+      for (const auto &line : result.program) formatted.append(pepp::ucode::format<uarch2, regs>(line));
+
+  } else {
+    std::cerr << "Invalid bus width :" << busWidth << std::endl;
+    return emit finished(4);
+  }
+
+  if (!errors.empty()) {
+    std::cerr << "Assembly failed, check error log" << std::endl;
+    QString errFName;
+    if (errOut) {
+      errFName = QString::fromStdString(*errOut);
+    } else {
+      QFileInfo err(QString::fromStdString(this->in));
+      errFName = err.path() + "/" + err.completeBaseName() + ".err.txt";
+    }
+    QFile errF(errFName);
+    if (errF.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+      auto ts = QTextStream(&errF);
+      for (auto const &[line, message] : errors) ts << line << ": " << message.trimmed() << "\n";
+    } else {
+      std::cerr << "Failed to open error log for writing: " << errFName.toStdString() << std::endl;
+      for (auto const &[line, message] : errors) qWarning().noquote().nospace() << line << ": " << message.trimmed();
+    }
+
+    return emit finished(6);
+  }
+
+  QString pepcpuFName;
+  if (pepcpuOut) {
+    pepcpuFName = QString::fromStdString(*pepcpuOut);
+    QFile pepcpuF(pepcpuFName);
+    if (pepcpuF.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+      for (const auto &line : std::as_const(formatted)) QTextStream(&pepcpuF) << line << "\n";
+    } else std::cerr << "Failed to open microcode for writing: " << pepcpuFName.toStdString() << std::endl;
+  }
+
+  return emit finished(0);
+}

--- a/bin/src/commands/microasm.cpp
+++ b/bin/src/commands/microasm.cpp
@@ -18,7 +18,7 @@ void MicroAsmTask::run() {
     QFile sIn(QString::fromStdString(this->in)); // auto-closes
     if (!sIn.exists()) {
       std::cerr << "Source file does not exist.\n";
-      emit finished(3);
+      return emit finished(3);
     }
     sIn.open(QIODevice::ReadOnly | QIODevice::Text);
     source = sIn.readAll();

--- a/bin/src/commands/microasm.hpp
+++ b/bin/src/commands/microasm.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <CLI11.hpp>
+#include <string>
+#include "../shared.hpp"
+#include "../task.hpp"
+
+class MicroAsmTask : public Task {
+public:
+  MicroAsmTask(int ed, std::string in, int busWidth, QObject *parent = nullptr);
+  void setErrName(std::string fname);
+  void setOutCPUName(std::string fname);
+  void run() override;
+
+private:
+  int ed, busWidth = 1;
+  std::string in;
+  std::optional<std::string> errOut, pepcpuOut;
+};
+
+void registerMicroAsm(auto &app, task_factory_t &task, detail::SharedFlags &flags) {
+  static auto microasmSC = app.add_subcommand("microasm", "Assemble and format microcode");
+  static std::string in, pepcpuOut, errOut;
+  static int busWidth = 1;
+  static auto pepcpuOpt =
+      microasmSC->add_option("-o", pepcpuOut, "File which formatted microcode will be written into.");
+  static auto errOpt =
+      microasmSC->add_option("-e", errOut, "File which errors will be written into. Defaults to <input>.err.txt");
+  static auto busOpt = microasmSC->add_option("-w,--bus-width", busWidth, "Data bus width in bytes. Must be 1 or 2")
+                           ->check(CLI::Bound(1, 2))
+                           ->default_val(1);
+  microasmSC->add_option("-s,source", in, "Microcode input file (pepcpu)")->required()->expected(1);
+  microasmSC->callback([&]() {
+    flags.kind = detail::SharedFlags::Kind::TERM;
+    task = [&](QObject *parent) {
+      auto ret = new MicroAsmTask(flags.edValue, in, busWidth, parent);
+      if (*errOpt) ret->setErrName(errOut);
+      if (*pepcpuOpt) ret->setOutCPUName(pepcpuOut);
+      return ret;
+    };
+  });
+}

--- a/bin/src/commands/microrun.cpp
+++ b/bin/src/commands/microrun.cpp
@@ -1,0 +1,142 @@
+#include "microrun.hpp"
+#include <QtCore>
+#include "sim/api2/device.hpp"
+#include "sim/api2/memory/address.hpp"
+#include "sim/device/dense.hpp"
+#include "targets/pep9/mc2/cpu.hpp"
+
+MicroRunTask::MicroRunTask(int ed, std::string fname, int busWidth, QObject *parent)
+    : Task(parent), _ed(ed), _busWidth(busWidth), _pecpuIn(fname) {}
+
+void MicroRunTask::setUnitTests(std::string fname) { _unitTest = fname; }
+
+void MicroRunTask::setErrName(std::string fname) { _errName = fname; }
+
+void MicroRunTask::run() {
+  using namespace Qt::StringLiterals;
+  using uarch1 = pepp::ucode::Pep9ByteBus;
+  using uarch2 = pepp::ucode::Pep9WordBus;
+  using regs = pepp::ucode::Pep9Registers;
+
+  sim::api2::device::ID id = 0;
+  auto nextID = [&id]() { return id++; };
+  auto desc_mem =
+      sim::api2::device::Descriptor{.id = nextID(), .compatible = nullptr, .baseName = "dev", .fullName = "/dev"};
+  auto span = sim::api2::memory::AddressSpan<quint16>(0, 0xffff);
+  auto desc_cpu =
+      sim::api2::device::Descriptor{.id = nextID(), .compatible = nullptr, .baseName = "cpu", .fullName = "/cpu"};
+  sim::memory::Dense<quint16> mem(desc_mem, span, 0);
+
+  // Load pepcpu source code and unit tests
+  QString source_text, unit_test_text;
+  {
+    QFile f(QString::fromStdString(_pecpuIn)); // auto-closes
+    if (!f.exists()) {
+      std::cerr << "Source file does not exist.\n";
+      return emit finished(3);
+    }
+    f.open(QIODevice::ReadOnly | QIODevice::Text);
+    source_text = f.readAll();
+  }
+
+  if (_unitTest) {
+    QFile f(QString::fromStdString(*_unitTest)); // auto-closes
+    if (!f.exists()) {
+      std::cerr << "Test file does not exist.\n";
+      return emit finished(3);
+    }
+    f.open(QIODevice::ReadOnly | QIODevice::Text);
+    unit_test_text = f.readAll();
+  } else unit_test_text = source_text;
+
+  QStringList errors;
+  if (_busWidth == 1) {
+    auto cpu = targets::pep9::mc2::CPUByteBus(desc_cpu, nextID);
+    cpu.setTarget(&mem, nullptr);
+    cpu.setConstantRegisters();
+    auto code_asm = pepp::ucode::parse<uarch1, regs>(source_text);
+    auto test_asm = pepp::ucode::parse<uarch1, regs>(unit_test_text);
+    if (!code_asm.errors.empty()) {
+      std::cerr << "Assembly failed, check error log" << std::endl;
+      errors.append("Source assembly failed with errors:");
+      for (auto const &[line, message] : code_asm.errors) errors.append(u"%1: %2"_s.arg(line).arg(message.trimmed()));
+    } else if (!test_asm.errors.empty()) {
+      std::cerr << "Assembly failed, check error log" << std::endl;
+      errors.append("Test assembly failed with errors:");
+      for (auto const &[line, message] : test_asm.errors) errors.append(u"%1: %2"_s.arg(line).arg(message.trimmed()));
+    } else {
+      auto mc = pepp::ucode::microcodeFor<uarch1, regs>(code_asm);
+      auto test = pepp::ucode::tests<uarch1, regs>(test_asm);
+      cpu.setMicrocode(std::move(mc));
+      cpu.applyPreconditions(test.pre);
+      for (int cycle = 1; cpu.status() != targets::pep9::mc2::CPUByteBus::Status::Halted;) cpu.clock(cycle++);
+      if (cpu.status() != targets::pep9::mc2::CPUByteBus::Status::Halted) {
+        std::cerr << "CPU did not halt after running unit tests." << std::endl;
+        errors.append("Step failed with error code: " + QString::number((int)cpu.status()));
+      }
+      auto success = cpu.testPostconditions(test.post);
+      auto passed = std::all_of(success.cbegin(), success.cend(), [](const bool &test) { return test; });
+      if (!passed) {
+        std::cerr << "Postconditions violated, check error log" << std::endl;
+        for (int it = 0; it < success.size(); it++)
+          if (!success[it]) errors.append("Failed test: " + toString(test.post[it]));
+      }
+    }
+  } else if (_busWidth == 2) {
+    auto cpu = targets::pep9::mc2::CPUWordBus(desc_cpu, nextID);
+    cpu.setTarget(&mem, nullptr);
+    cpu.setConstantRegisters();
+    auto code_asm = pepp::ucode::parse<uarch2, regs>(source_text);
+    auto test_asm = pepp::ucode::parse<uarch2, regs>(unit_test_text);
+    if (!code_asm.errors.empty()) {
+      std::cerr << "Assembly failed, check error log" << std::endl;
+      errors.append("Source assembly failed with errors:");
+      for (auto const &[line, message] : code_asm.errors) errors.append(u"%1: %2"_s.arg(line).arg(message.trimmed()));
+    } else if (!test_asm.errors.empty()) {
+      std::cerr << "Assembly failed, check error log" << std::endl;
+      errors.append("Test assembly failed with errors:");
+      for (auto const &[line, message] : test_asm.errors) errors.append(u"%1: %2"_s.arg(line).arg(message.trimmed()));
+    } else {
+      auto mc = pepp::ucode::microcodeFor<uarch2, regs>(code_asm);
+      auto test = pepp::ucode::tests<uarch2, regs>(test_asm);
+      cpu.setMicrocode(std::move(mc));
+      cpu.applyPreconditions(test.pre);
+      for (int cycle = 1; cpu.status() != targets::pep9::mc2::CPUWordBus::Status::Halted;) cpu.clock(cycle++);
+      if (cpu.status() != targets::pep9::mc2::CPUWordBus::Status::Halted) {
+        std::cerr << "CPU did not halt after running unit tests." << std::endl;
+        errors.append("Step failed with error code: " + QString::number((int)cpu.status()));
+      }
+      auto success = cpu.testPostconditions(test.post);
+      auto passed = std::all_of(success.cbegin(), success.cend(), [](const bool &test) { return test; });
+      if (!passed) {
+        std::cerr << "Postconditions violated, check error log" << std::endl;
+        for (int it = 0; it < success.size(); it++)
+          if (!success[it]) errors.append("Failed test: " + toString(test.post[it]));
+      }
+    }
+  } else {
+    std::cerr << "Invalid bus width :" << _busWidth << std::endl;
+    return emit finished(4);
+  }
+
+  if (!errors.empty()) {
+    QString errFName;
+    if (_errName) {
+      errFName = QString::fromStdString(*_errName);
+    } else {
+      QFileInfo err(QString::fromStdString(this->_pecpuIn));
+      errFName = err.path() + "/" + err.completeBaseName() + ".err.txt";
+    }
+    QFile errF(errFName);
+    if (errF.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+      auto ts = QTextStream(&errF);
+      for (auto const &message : errors) ts << message.trimmed() << "\n";
+    } else {
+      std::cerr << "Failed to open error log for writing: " << errFName.toStdString() << std::endl;
+      for (auto const &message : errors) qWarning().noquote().nospace() << message.trimmed();
+    }
+    return emit finished(6);
+  }
+
+  return emit finished(0);
+}

--- a/bin/src/commands/microrun.hpp
+++ b/bin/src/commands/microrun.hpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023-2024 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <CLI11.hpp>
+#include "../shared.hpp"
+#include "../task.hpp"
+
+class MicroRunTask : public Task {
+  // Task interface
+public:
+  MicroRunTask(int ed, std::string fname, int busWidth, QObject *parent);
+  void setUnitTests(std::string fname);
+  void setErrName(std::string fname);
+  void run() override;
+
+private:
+  int _ed, _busWidth;
+  std::string _pecpuIn;
+  std::optional<std::string> _unitTest, _errName;
+};
+
+void registerMicroRun(auto &app, task_factory_t &task, detail::SharedFlags &flags) {
+  // Must initialize,
+  static std::string pepcpuIn, testIn, errName;
+  static int busWidth = 1;
+  static auto microrunSC = app.add_subcommand("microrun", "Run Mc2 programs");
+  microrunSC->add_option("-s,microcode", pepcpuIn)->required()->expected(1);
+  static const auto testOpt = microrunSC->add_option("-t,test", testIn)->expected(1);
+  static auto errOpt =
+      microrunSC->add_option("-e", errName, "File which errors will be written into. Defaults to <input>.err.txt");
+  static auto busOpt = microrunSC->add_option("-w,--bus-width", busWidth, "Data bus width in bytes. Must be 1 or 2")
+                           ->check(CLI::Bound(1, 2))
+                           ->default_val(1);
+  microrunSC->callback([&]() {
+    flags.kind = detail::SharedFlags::Kind::TERM;
+    task = [&](QObject *parent) {
+      auto ret = new MicroRunTask(flags.edValue, pepcpuIn, busWidth, parent);
+      if (*testOpt) ret->setUnitTests(testIn);
+      if (*errOpt) ret->setErrName(errName);
+      return ret;
+    };
+  });
+}

--- a/bin/src/main.cpp
+++ b/bin/src/main.cpp
@@ -30,6 +30,7 @@
 #include "commands/license.hpp"
 #include "commands/ls-qrc.hpp"
 #include "commands/ls.hpp"
+#include "commands/microasm.hpp"
 #include "commands/readelf/readelf.hpp"
 #include "commands/run.hpp"
 #include "commands/selftest.hpp"
@@ -79,6 +80,7 @@ int main(int argc, char **argv) {
   registerGet(app, task, shared_flags);
 
   registerAsm(app, task, shared_flags);
+  registerMicroAsm(app, task, shared_flags);
   registerRun(app, task, shared_flags);
   registerReadelf(app, task, shared_flags);
   gui_args args{.argvs = {argv[0]}};

--- a/bin/src/main.cpp
+++ b/bin/src/main.cpp
@@ -31,6 +31,7 @@
 #include "commands/ls-qrc.hpp"
 #include "commands/ls.hpp"
 #include "commands/microasm.hpp"
+#include "commands/microrun.hpp"
 #include "commands/readelf/readelf.hpp"
 #include "commands/run.hpp"
 #include "commands/selftest.hpp"
@@ -82,6 +83,7 @@ int main(int argc, char **argv) {
   registerAsm(app, task, shared_flags);
   registerMicroAsm(app, task, shared_flags);
   registerRun(app, task, shared_flags);
+  registerMicroRun(app, task, shared_flags);
   registerReadelf(app, task, shared_flags);
   gui_args args{.argvs = {argv[0]}};
   registerGUI(app, task, shared_flags, args);

--- a/data/books/cs5e/ch12/fig1220/1220.pepcpu
+++ b/data/books/cs5e/ch12/fig1220/1220.pepcpu
@@ -14,6 +14,3 @@
 // IR <- MDREven, T1 <- MDROdd.
 5. EOMux=0, AMux=0, ALU=0, CMux=1, C=8; LoadCk
 6. EOMux=1, AMux=0, ALU=0, CMux=1, C=11; LoadCk
-
-
-

--- a/lib/toolchain/ucode/parser.hpp
+++ b/lib/toolchain/ucode/parser.hpp
@@ -67,7 +67,6 @@ using Error = std::pair<int, QString>;
 using Errors = std::vector<Error>;
 
 template <typename uarch, typename registers> struct ParseResult {
-
   // Wrap control signals (e.g., our object code) with some assembler IR
   struct Line {
     typename uarch::CodeWithEnables controls;

--- a/lib/toolchain/ucode/parser.hpp
+++ b/lib/toolchain/ucode/parser.hpp
@@ -61,11 +61,13 @@ template <typename registers> QString toString(const Test<registers> &test) {
   else return QString();
 }
 
+// 0-indexed line number and an error message for that line.
+using Error = std::pair<int, QString>;
+// All errors encountered while parsing the source program. May have multiple errors per-line.
+using Errors = std::vector<Error>;
+
 template <typename uarch, typename registers> struct ParseResult {
-  // 0-indexed line number and an error message for that line.
-  using Error = std::pair<int, QString>;
-  // All errors encountered while parsing the source program. May have multiple errors per-line.
-  using Errors = std::vector<Error>;
+
   // Wrap control signals (e.g., our object code) with some assembler IR
   struct Line {
     typename uarch::CodeWithEnables controls;


### PR DESCRIPTION
Adds `microasm` and `microrun` subcommands which allow interaction with Mc2/pepcpu programs.