### PR TITLE
Various Macro Formatting Fixes

### DIFF
--- a/data/books/cs6e/macros/MALLOC/MALLOC.pepm
+++ b/data/books/cs6e/macros/MALLOC/MALLOC.pepm
@@ -1,6 +1,6 @@
 @MALLOC 0
 ;******* malloc()
-;        Precondition: @MALLOC is the last statment before .END
+;        Precondition: @MALLOC is the last statment in the program
 ;        Precondition: A contains number of bytes
 ;        Postcondition: X contains pointer to bytes
 malloc:  LDWX    hpPtr,d     ;returned pointer

--- a/lib/toolchain/pas/operations/generic/include_macros.cpp
+++ b/lib/toolchain/pas/operations/generic/include_macros.cpp
@@ -116,14 +116,30 @@ void pas::ops::generic::IncludeMacros::addExtraChildren(ast::Node &node) {
   auto formattedMacro = detail::formatMacro(node, {.indentMnemonic = -2});
   start->set(ast::generic::Comment{.value = formattedMacro});
 
-  // Use an empty .BLOCK to avoid having to complex line manipulations.
+  // If the macro declares a symbol, find the first addressable line and attempt to move our symbol to that line.
+  // Macros may start with newlines or comment lines, which we must skip over for moving our symbok
+  // If the first addressable line already has a symbol, we will resort to a .BLOCK 0
   if (node.has<ast::generic::SymbolDeclaration>()) {
-    auto sym = QSharedPointer<ast::Node>::create(directiveType);
-    sym->set(node.take<ast::generic::SymbolDeclaration>());
-    sym->set(ast::generic::Directive{.value = "BLOCK"});
-    auto zero = QSharedPointer<ast::value::UnsignedDecimal>::create(0, 2);
-    sym->set(ast::generic::Argument{.value = zero});
-    children.push_front(sym);
+    bool placedSymbol = false;
+    for (const auto &child : std::as_const(children)) {
+      if (child->get<ast::generic::Type>().value == ast::generic::Type::Instruction || isDirectiveAddressed(*child)) {
+        if (child->has<ast::generic::SymbolDeclaration>()) break; // Line already has symbol, opt for .BLOCK 0 instead.
+        else { // No existing symbol, can move macro's symbol to here.
+          child->set(node.get<ast::generic::SymbolDeclaration>());
+          placedSymbol = true;
+          break;
+        }
+      }
+    }
+    // First addressable line already had a symbol, insert .BLOCK 0 at the top of the macro expansion.
+    if (!placedSymbol) {
+      auto sym = QSharedPointer<ast::Node>::create(directiveType);
+      sym->set(ast::generic::Directive{.value = "BLOCK"});
+      sym->set(node.get<ast::generic::SymbolDeclaration>());
+      auto zero = QSharedPointer<ast::value::UnsignedDecimal>::create(0, 2);
+      sym->set(ast::generic::Argument{.value = zero});
+      children.push_front(sym);
+    }
   }
 
   children.push_front(start);

--- a/lib/toolchain/pas/operations/generic/include_macros.cpp
+++ b/lib/toolchain/pas/operations/generic/include_macros.cpp
@@ -151,7 +151,8 @@ void pas::ops::generic::IncludeMacros::addExtraChildren(ast::Node &node) {
   auto spacing = u" "_s.repeated(indents::defaultSymWidth - 1);
   // Align the macro comment as if it were an instruction.
   // Need a -1 indent to accomodate the ; character.
-  end->set(ast::generic::Comment{.value = u"%1End @%2"_s.arg(spacing, node.get<ast::generic::Macro>().value)});
+  end->set(
+      ast::generic::Comment{.value = u"%1End @%2"_s.arg(spacing, node.get<ast::generic::Macro>().value.toUpper())});
   children.push_back(end);
 
   node.set<ast::generic::Children>(ast::generic::Children{.value = children});

--- a/lib/toolchain/pas/operations/generic/string.cpp
+++ b/lib/toolchain/pas/operations/generic/string.cpp
@@ -96,7 +96,7 @@ QString pas::ops::generic::detail::formatMacro(const ast::Node &node, SourceOpti
   }
   auto newOpts = opts;
   newOpts.indentMnemonic = 1 + opts.indentMnemonic;
-  return formatDirectiveOrMacro(node, u"@%1"_s.arg(node.get<ast::generic::Macro>().value), newOpts);
+  return formatDirectiveOrMacro(node, u"@%1"_s.arg(node.get<ast::generic::Macro>().value.toUpper()), newOpts);
 }
 
 QString pas::ops::generic::detail::formatErrorsAsComments(const ast::Node &node) {

--- a/test/asm/pas/operations/pepp/flatten.cpp
+++ b/test/asm/pas/operations/pepp/flatten.cpp
@@ -33,6 +33,7 @@ using namespace Qt::StringLiterals;
 using testFn = void (*)(QSharedPointer<pas::ast::Node>);
 namespace {
 
+auto test = pas::driver::pep10::isDirectiveAddressed;
 void single_test(QSharedPointer<pas::ast::Node> root) {
   // qWarning() << pas::ops::pepp::formatSource<isa::Pep10>(*root).join("\n");
   REQUIRE(root->has<pas::ast::generic::Children>());
@@ -96,7 +97,7 @@ TEST_CASE("Flatten macros", "[scope:asm][kind:unit][arch:pep10]") {
         auto res = parseRoot(input, nullptr);
         REQUIRE(!res.hadError);
         auto ret = pas::ops::generic::includeMacros(
-            *res.root, pas::driver::pepp::createParser<isa::Pep10, pas::driver::ANTLRParserTag>(true), registery);
+            *res.root, pas::driver::pepp::createParser<isa::Pep10, pas::driver::ANTLRParserTag>(true), registery, test);
         root = res.root;
         pas::ops::generic::flattenMacros(*root);
       }

--- a/test/asm/pas/operations/pepp/include_macros.cpp
+++ b/test/asm/pas/operations/pepp/include_macros.cpp
@@ -30,6 +30,7 @@ using namespace Qt::StringLiterals;
 using testFn = void (*)(QSharedPointer<pas::ast::Node>);
 namespace {
 
+auto test = pas::driver::pep10::isDirectiveAddressed;
 void success_test(QSharedPointer<pas::ast::Node> root) {
   REQUIRE(root->has<pas::ast::generic::Children>());
   auto children = root->get<pas::ast::generic::Children>().value;
@@ -91,7 +92,7 @@ void smoke(QSharedPointer<macro::Registry> registry, QString input, testFn valid
     auto res = parseRoot(input, nullptr);
     REQUIRE(!res.hadError);
     auto ret = pas::ops::generic::includeMacros(
-        *res.root, pas::driver::pepp::createParser<isa::Pep10, pas::driver::ANTLRParserTag>(true), registry);
+        *res.root, pas::driver::pepp::createParser<isa::Pep10, pas::driver::ANTLRParserTag>(true), registry, test);
     REQUIRE(ret == !errors);
 
     root = res.root;

--- a/test/asm/pas/operations/pepp/size.cpp
+++ b/test/asm/pas/operations/pepp/size.cpp
@@ -18,6 +18,7 @@
 #include "enums/isa/pep10.hpp"
 #include "toolchain/macro/declaration.hpp"
 #include "toolchain/macro/registry.hpp"
+#include "toolchain/pas/driver/pep10.hpp"
 #include "toolchain/pas/driver/pepp.hpp"
 #include "toolchain/pas/operations/generic/include_macros.hpp"
 #include "utils/bits/strings.hpp"
@@ -26,6 +27,9 @@ using pas::ops::pepp::Direction;
 using pas::ops::pepp::explicitSize;
 using namespace Qt::StringLiterals;
 
+namespace {
+auto test = pas::driver::pep10::isDirectiveAddressed;
+}
 TEST_CASE("Size", "[scope:asm][kind:unit][arch:pep10]") {
   SECTION("Unary") {
     QString body = "rola\nrolx";
@@ -153,7 +157,7 @@ TEST_CASE("Size", "[scope:asm][kind:unit][arch:pep10]") {
 
     REQUIRE_FALSE(res.hadError);
     auto ret = pas::ops::generic::includeMacros(
-        *res.root, pas::driver::pepp::createParser<isa::Pep10, pas::driver::ANTLRParserTag>(true), registry);
+        *res.root, pas::driver::pepp::createParser<isa::Pep10, pas::driver::ANTLRParserTag>(true), registry, test);
     REQUIRE(ret);
     CHECK(explicitSize<isa::Pep10>(*res.root, 0, Direction::Forward) == 3);
     CHECK(explicitSize<isa::Pep10>(*res.root, 0, Direction::Backward) == 3);


### PR DESCRIPTION
- Macro start/end comments use UPPER CASE names rather than the formatting provided by the user.
- Closes #602. Macro invocations that declare symbols do not use my `<sym>: .BLOCK 0` hack when possible