### PR TITLE
Enable OS file opening integrations on Mac OS

### DIFF
--- a/bin/Info.plist
+++ b/bin/Info.plist
@@ -28,79 +28,88 @@
 	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
-	<key>NSHumanReadableCopyright</key>
-	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
-	<key>CFBundleTypeExtensions</key>
-	<array>
-		<string>pep</string>
-		<string>pepo</string>
-		<string>pepcpu</string>
-		<string>pepm</string>
-	</array>
 	<key>NSHighResolutionCapable</key>
 	<string>True</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>pepo</string>
-			</array>
-			<key>CFBundleTypeName</key>
-			<string>Pep Microcode File</string>
-			<key>LSHandlerRank</key>
-			<string>Owner</string>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>LSTypeIsPackage</key>
-			<false/>
-		</dict>
-		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>pep</string>
-			</array>
-			<key>CFBundleTypeName</key>
-			<string>Pep Object Code File</string>
-			<key>LSHandlerRank</key>
-			<string>Owner</string>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>LSTypeIsPackage</key>
-			<false/>
-		</dict>
-		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>pep</string>
-			</array>
 			<key>CFBundleTypeName</key>
 			<string>Pep Assembly Source File</string>
-			<key>LSHandlerRank</key>
-			<string>Owner</string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
 			<key>LSTypeIsPackage</key>
 			<false/>
+			<key>CFBundleTypeIconFile</key>
+			<string>${MACOSX_BUNDLE_ICON_FILE}</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>edu.cslab.pepperdine.pep</string>
+			</array>
 		</dict>
 		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>pepm</string>
-			</array>
 			<key>CFBundleTypeName</key>
-			<string>Pep Macro Declaration File</string>
-			<key>LSHandlerRank</key>
-			<string>Owner</string>
+			<string>Pep Object Code File</string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
 			<key>LSTypeIsPackage</key>
 			<false/>
+			<key>CFBundleTypeIconFile</key>
+			<string>${MACOSX_BUNDLE_ICON_FILE}</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>edu.cslab.pepperdine.pepo</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Pep Microcode File</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+			<key>CFBundleTypeIconFile</key>
+			<string>${MACOSX_BUNDLE_ICON_FILE}</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>edu.cslab.pepperdine.pepcpu</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Pep Macro Declaration File</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+			<key>CFBundleTypeIconFile</key>
+			<string>${MACOSX_BUNDLE_ICON_FILE}</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>edu.cslab.pepperdine.pepm</string>
+			</array>
 		</dict>
 	</array>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>edu.cslab.pepperdine.pep</string>
+			<key>UTTypeDescription</key>
+			<string>Pep Assembly Source File</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.text</string>
+			</array>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
@@ -108,16 +117,16 @@
 					<string>pep</string>
 				</array>
 			</dict>
-			<key>UTTypeIdentifier</key>
-			<string>edu.cslab.pepperdine.pep</string>
-			<key>UTTypeConformsTo</key>
-			<array>
-				<string>public.data</string>
-			</array>
-			<key>UTTypeDescription</key>
-			<string>Pep Assembly Source File</string>
 		</dict>
 		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>edu.cslab.pepperdine.pepo</string>
+			<key>UTTypeDescription</key>
+			<string>Pep Object Code File</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.text</string>
+			</array>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
@@ -125,16 +134,16 @@
 					<string>pepo</string>
 				</array>
 			</dict>
-			<key>UTTypeIdentifier</key>
-			<string>edu.cslab.pepperdine.pepo</string>
-			<key>UTTypeConformsTo</key>
-			<array>
-				<string>public.data</string>
-			</array>
-			<key>UTTypeDescription</key>
-			<string>Pep Object Code File</string>
 		</dict>
 		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>edu.cslab.pepperdine.pepcpu</string>
+			<key>UTTypeDescription</key>
+			<string>Pep Microcode File</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.text</string>
+			</array>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
@@ -142,16 +151,16 @@
 					<string>pepcpu</string>
 				</array>
 			</dict>
-			<key>UTTypeIdentifier</key>
-			<string>edu.cslab.pepperdine.pepcpu</string>
-			<key>UTTypeConformsTo</key>
-			<array>
-				<string>public.data</string>
-			</array>
-			<key>UTTypeDescription</key>
-			<string>Pep Microcode File</string>
 		</dict>
 		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>edu.cslab.pepperdine.pepm</string>
+			<key>UTTypeDescription</key>
+			<string>Pep Macro Declaration File</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.text</string>
+			</array>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
@@ -159,14 +168,6 @@
 					<string>pepm</string>
 				</array>
 			</dict>
-			<key>UTTypeIdentifier</key>
-			<string>edu.cslab.pepperdine.pepm</string>
-			<key>UTTypeConformsTo</key>
-			<array>
-				<string>public.data</string>
-			</array>
-			<key>UTTypeDescription</key>
-			<string>Pep Macro Declaration File</string>
 		</dict>
 	</array>
 </dict>

--- a/bin/Info.plist
+++ b/bin/Info.plist
@@ -108,7 +108,7 @@
 			<string>Pep Assembly Source File</string>
 			<key>UTTypeConformsTo</key>
 			<array>
-				<string>public.text</string>
+			        <string>public.plain-text</string>
 			</array>
 			<key>UTTypeTagSpecification</key>
 			<dict>
@@ -125,7 +125,7 @@
 			<string>Pep Object Code File</string>
 			<key>UTTypeConformsTo</key>
 			<array>
-				<string>public.text</string>
+			        <string>public.plain-text</string>
 			</array>
 			<key>UTTypeTagSpecification</key>
 			<dict>
@@ -142,7 +142,7 @@
 			<string>Pep Microcode File</string>
 			<key>UTTypeConformsTo</key>
 			<array>
-				<string>public.text</string>
+			        <string>public.plain-text</string>
 			</array>
 			<key>UTTypeTagSpecification</key>
 			<dict>
@@ -159,7 +159,7 @@
 			<string>Pep Macro Declaration File</string>
 			<key>UTTypeConformsTo</key>
 			<array>
-				<string>public.text</string>
+			        <string>public.plain-text</string>
 			</array>
 			<key>UTTypeTagSpecification</key>
 			<dict>

--- a/bin/src/main.qml
+++ b/bin/src/main.qml
@@ -364,6 +364,7 @@ ApplicationWindow {
     }
 
     Connections {
+        id: welcomeConnections
         target: welcome
         function onAddProject() {
             sidebar.enabled = true;
@@ -371,32 +372,47 @@ ApplicationWindow {
             welcome.loadingFileName = Qt.binding(() => "");
             welcome.loadingFileContent = Qt.binding(() => "");
             welcome.filterAbstraction = Qt.binding(() => []);
-            welcome.filterEdition = Qt.binding(() => 0);
+            welcome.filterEdition = Qt.binding(() => []);
+            enabled = false;
         }
+        enabled: false
     }
     FileIO {
         id: fileio
         onCodeLoaded: function (name, content, arch, abs) {
             if (!name || !content)
                 return;
-            console.log(`Will load ${name}`);
-            console.log(`(arch, abs)=(${arch},${abs})`);
+            if (arch !== 0 && abs !== 0) {
+                root.pm.onAddProject(arch, abs, "", content, true);
+                return;
+            } else if (name.match(/pep$/i)) {
+                welcome.filterAbstraction = Qt.binding(() => [Abstraction.ASMB3, Abstraction.OS4, Abstraction.ASMB5]);
+                welcome.filterEdition = Qt.binding(() => [6, 5, 4]);
+            } else if (name.match(/pepo$/i)) {
+                welcome.filterAbstraction = Qt.binding(() => [Abstraction.ISA3]);
+                welcome.filterEdition = Qt.binding(() => [6, 5, 4]);
+            } else if (name.match(/pepcpu$/i)) {
+                welcome.filterAbstraction = Qt.binding(() => [Abstraction.MC2]);
+                welcome.filterEdition = Qt.binding(() => [6, 5, 4]);
+            } else if (name.match(/pepm$/i)) {
+                welcome.filterAbstraction = Qt.binding(() => [Abstraction.ASMB3, Abstraction.OS4, Abstraction.ASMB5]);
+                welcome.filterEdition = Qt.binding(() => [6]);
+            } else {
+                welcome.filterAbstraction = Qt.binding(() => []);
+                welcome.filterEdition = Qt.binding(() => []);
+            }
+
+            welcomeConnections.enabled = true;
             sidebar.switchToMode("Welcome");
             welcome.loadingFileName = Qt.binding(() => name);
             welcome.loadingFileContent = Qt.binding(() => content);
             sidebar.enabled = false;
             sidebar.visible = false;
-            if (arch != 0 && abs != 0) {
-                welcome.addProject(arch, abs, "", content, true);
-            } else {
-                welcome.filterAbstraction = Qt.binding(() => [Abstraction.ASMB5, Abstraction.ASMB3, Abstraction.OS4]);
-                welcome.filterEdition = Qt.binding(() => 6);
-            }
         }
     }
 
     function onNew() {
-        pm.onAddProject(Architecture.PEP10, Abstraction.ASMB5, "", false);
+        pm.onAddProject(Architecture.PEP10, Abstraction.ASMB5, "", "", false);
     }
     function onOpenDialog() {
         fileio.loadCodeViaDialog("");

--- a/bin/src/main.qml
+++ b/bin/src/main.qml
@@ -109,6 +109,7 @@ ApplicationWindow {
         message.connect(() => messageTimer.restart());
         messageTimer.restart();
         sidebar.switchToMode("Welcome");
+        pm.rowCountChanged.connect(noOpenProjectCheck);
     }
 
     // Provide a default font for menu items.
@@ -119,6 +120,10 @@ ApplicationWindow {
         const loader = delegateRepeater.itemAt(innerLayout.currentIndex);
         if (loader.item)
             loader.item.syncEditors();
+    }
+    function noOpenProjectCheck() {
+        if (pm.rowCount() === 0)
+            sidebar.switchToMode("Welcome");
     }
 
     Menu.Actions {

--- a/bin/src/main.qml
+++ b/bin/src/main.qml
@@ -370,7 +370,7 @@ ApplicationWindow {
             sidebar.visible = true;
             welcome.loadingFileName = Qt.binding(() => "");
             welcome.loadingFileContent = Qt.binding(() => "");
-            welcome.filterAbstraction = Qt.binding(() => 0);
+            welcome.filterAbstraction = Qt.binding(() => []);
             welcome.filterEdition = Qt.binding(() => 0);
         }
     }
@@ -389,8 +389,8 @@ ApplicationWindow {
             if (arch != 0 && abs != 0) {
                 welcome.addProject(arch, abs, "", content, true);
             } else {
-                welcome.filterAbstraction = Qt.binding(() => 0);
-                welcome.filterEdition = Qt.binding(() => 5);
+                welcome.filterAbstraction = Qt.binding(() => [Abstraction.ASMB5, Abstraction.ASMB3, Abstraction.OS4]);
+                welcome.filterEdition = Qt.binding(() => 6);
             }
         }
     }

--- a/bin/src/main.qml
+++ b/bin/src/main.qml
@@ -427,7 +427,8 @@ ApplicationWindow {
     }
 
     function onNew() {
-        pm.onAddProject(Architecture.PEP10, Abstraction.ASMB5, "", "", false);
+        pm.onAddProject(settings.general.defaultArch, settings.general.defaultAbstraction, "", "", true);
+        sidebar.switchToMode("Editor");
     }
     function onOpenDialog() {
         fileio.loadCodeViaDialog("");

--- a/bin/src/main.qml
+++ b/bin/src/main.qml
@@ -376,6 +376,13 @@ ApplicationWindow {
     function onOpenDialog() {
         fileio.load("");
     }
+    // must be named onOpenFile, or `gui.cpp` must be updated!
+    function onOpenFile(filename) {
+        console.log(`QML loading file ${filename}`);
+        // Changes the window coloring
+        window.palette.window = Qt.binding(() => Qt.rgba(1, 0, 0, 1));
+        window.palette.windowText = Qt.binding(() => Qt.rgba(0, 1, 0, 1));
+    }
     function onCloseAllProjects(excludeCurrent: bool) {
     }
     function onQuit() {

--- a/bin/src/main.qml
+++ b/bin/src/main.qml
@@ -362,11 +362,36 @@ ApplicationWindow {
         onAccepted: prefs.closed()
         onClosed: prefs.closed()
     }
+
+    Connections {
+        target: welcome
+        function onAddProject() {
+            sidebar.enabled = true;
+            sidebar.visible = true;
+            welcome.loadingFileName = Qt.binding(() => "");
+            welcome.loadingFileContent = Qt.binding(() => "");
+            welcome.filterAbstraction = Qt.binding(() => 0);
+            welcome.filterEdition = Qt.binding(() => 0);
+        }
+    }
     FileIO {
         id: fileio
-        onFileLoaded: function (name, content, arch, abs) {
+        onCodeLoaded: function (name, content, arch, abs) {
+            if (!name || !content)
+                return;
             console.log(`Will load ${name}`);
             console.log(`(arch, abs)=(${arch},${abs})`);
+            sidebar.switchToMode("Welcome");
+            welcome.loadingFileName = Qt.binding(() => name);
+            welcome.loadingFileContent = Qt.binding(() => content);
+            sidebar.enabled = false;
+            sidebar.visible = false;
+            if (arch != 0 && abs != 0) {
+                welcome.addProject(arch, abs, "", content, true);
+            } else {
+                welcome.filterAbstraction = Qt.binding(() => 0);
+                welcome.filterEdition = Qt.binding(() => 5);
+            }
         }
     }
 

--- a/bin/src/main.qml
+++ b/bin/src/main.qml
@@ -362,10 +362,19 @@ ApplicationWindow {
         onAccepted: prefs.closed()
         onClosed: prefs.closed()
     }
+    FileIO {
+        id: fileio
+        onFileLoaded: function (name, content, arch, abs) {
+            console.log(`Will load ${name}`);
+            console.log(`(arch, abs)=(${arch},${abs})`);
+        }
+    }
+
     function onNew() {
-        pm.onAddProject(Architecture.PEP9, Abstraction.ASMB5, "", false);
+        pm.onAddProject(Architecture.PEP10, Abstraction.ASMB5, "", false);
     }
     function onOpenDialog() {
+        fileio.load("");
     }
     function onCloseAllProjects(excludeCurrent: bool) {
     }

--- a/bin/src/main.qml
+++ b/bin/src/main.qml
@@ -362,52 +362,62 @@ ApplicationWindow {
         onAccepted: prefs.closed()
         onClosed: prefs.closed()
     }
-
-    Connections {
-        id: welcomeConnections
-        target: welcome
-        function onAddProject() {
-            sidebar.enabled = true;
-            sidebar.visible = true;
-            welcome.loadingFileName = Qt.binding(() => "");
-            welcome.loadingFileContent = Qt.binding(() => "");
-            welcome.filterAbstraction = Qt.binding(() => []);
-            welcome.filterEdition = Qt.binding(() => []);
-            enabled = false;
+    Dialog {
+        id: fileDisambiguateDialog
+        title: qsTr("Determine file type")
+        parent: Overlay.overlay
+        anchors.centerIn: parent
+        modal: true
+        height: parent.height
+        width: parent.width
+        contentItem: Top.Welcome {
+            id: welcomeForFOpen
+            focus: true
+            Keys.onEscapePressed: {
+                fileDisambiguateDialog.close();
+            }
+            onAddProject: function (arch, abs, feats, content, reuse) {
+                window.pm.onAddProject(arch, abs, feats, content, reuse);
+                sidebar.switchToMode("Editor");
+                welcomeForFOpen.loadingFileName = Qt.binding(() => "");
+                welcomeForFOpen.loadingFileContent = Qt.binding(() => "");
+                welcomeForFOpen.filterAbstraction = Qt.binding(() => []);
+                welcomeForFOpen.filterEdition = Qt.binding(() => []);
+                fileDisambiguateDialog.accept();
+            }
         }
-        enabled: false
+        standardButtons: Dialog.Close
     }
+
     FileIO {
         id: fileio
         onCodeLoaded: function (name, content, arch, abs) {
             if (!name || !content)
                 return;
             if (arch !== 0 && abs !== 0) {
-                root.pm.onAddProject(arch, abs, "", content, true);
+                window.pm.onAddProject(arch, abs, "", content, true);
                 return;
             } else if (name.match(/pep$/i)) {
-                welcome.filterAbstraction = Qt.binding(() => [Abstraction.ASMB3, Abstraction.OS4, Abstraction.ASMB5]);
-                welcome.filterEdition = Qt.binding(() => [6, 5, 4]);
+                welcomeForFOpen.filterAbstraction = Qt.binding(() => [Abstraction.ASMB3, Abstraction.OS4, Abstraction.ASMB5]);
+                welcomeForFOpen.filterEdition = Qt.binding(() => [6, 5, 4]);
             } else if (name.match(/pepo$/i)) {
-                welcome.filterAbstraction = Qt.binding(() => [Abstraction.ISA3]);
-                welcome.filterEdition = Qt.binding(() => [6, 5, 4]);
+                welcomeForFOpen.filterAbstraction = Qt.binding(() => [Abstraction.ISA3]);
+                welcomeForFOpen.filterEdition = Qt.binding(() => [6, 5, 4]);
             } else if (name.match(/pepcpu$/i)) {
-                welcome.filterAbstraction = Qt.binding(() => [Abstraction.MC2]);
-                welcome.filterEdition = Qt.binding(() => [6, 5, 4]);
+                welcomeForFOpen.filterAbstraction = Qt.binding(() => [Abstraction.MC2]);
+                welcomeForFOpen.filterEdition = Qt.binding(() => [6, 5, 4]);
             } else if (name.match(/pepm$/i)) {
-                welcome.filterAbstraction = Qt.binding(() => [Abstraction.ASMB3, Abstraction.OS4, Abstraction.ASMB5]);
-                welcome.filterEdition = Qt.binding(() => [6]);
+                welcomeForFOpen.filterAbstraction = Qt.binding(() => [Abstraction.ASMB3, Abstraction.OS4, Abstraction.ASMB5]);
+                welcomeForFOpen.filterEdition = Qt.binding(() => [6]);
             } else {
-                welcome.filterAbstraction = Qt.binding(() => []);
-                welcome.filterEdition = Qt.binding(() => []);
+                welcomeForFOpen.filterAbstraction = Qt.binding(() => []);
+                welcomeForFOpen.filterEdition = Qt.binding(() => []);
             }
 
-            welcomeConnections.enabled = true;
             sidebar.switchToMode("Welcome");
-            welcome.loadingFileName = Qt.binding(() => name);
-            welcome.loadingFileContent = Qt.binding(() => content);
-            sidebar.enabled = false;
-            sidebar.visible = false;
+            welcomeForFOpen.loadingFileName = Qt.binding(() => name);
+            welcomeForFOpen.loadingFileContent = Qt.binding(() => content);
+            fileDisambiguateDialog.open();
         }
     }
 

--- a/bin/src/main.qml
+++ b/bin/src/main.qml
@@ -399,14 +399,11 @@ ApplicationWindow {
         pm.onAddProject(Architecture.PEP10, Abstraction.ASMB5, "", false);
     }
     function onOpenDialog() {
-        fileio.load("");
+        fileio.loadCodeViaDialog("");
     }
     // must be named onOpenFile, or `gui.cpp` must be updated!
     function onOpenFile(filename) {
-        console.log(`QML loading file ${filename}`);
-        // Changes the window coloring
-        window.palette.window = Qt.binding(() => Qt.rgba(1, 0, 0, 1));
-        window.palette.windowText = Qt.binding(() => Qt.rgba(0, 1, 0, 1));
+        fileio.loadCodeFromFile(filename);
     }
     function onCloseAllProjects(excludeCurrent: bool) {
     }

--- a/lib/settings/ThemeCategoryDelegate.qml
+++ b/lib/settings/ThemeCategoryDelegate.qml
@@ -14,6 +14,9 @@ Item {
     NuAppSettings {
         id: settings
     }
+    FileIO {
+        id: fileio
+    }
 
     PaletteFilterModel {
         id: paletteModel
@@ -117,7 +120,7 @@ Item {
                                 requestRename();
                             }
                         } else {
-                            FileIO.save(comboBox.currentValue, settings.extPalette.jsonString());
+                            fileio.save(comboBox.currentValue, settings.extPalette.jsonString());
                         }
                     }
                     signal requestRename
@@ -232,7 +235,7 @@ Item {
             target: exportLoader.item
             function onAccepted() {
                 const path = decodeURIComponent(exportLoader.item.selectedFile);
-                FileIO.save(path, settings.extPalette.jsonString());
+                fileio.save(path, settings.extPalette.jsonString());
             }
         }
     }

--- a/lib/settings/ThemeCategoryDelegate.qml
+++ b/lib/settings/ThemeCategoryDelegate.qml
@@ -5,10 +5,10 @@ import QtQuick.Controls
 import edu.pepp
 
 Item {
+    id: root
     property var category: undefined
     property int activeCategory: 0
     property int buttonWidth: 50
-    id: root
     implicitHeight: childrenRect.height
     implicitWidth: childrenRect.width
     NuAppSettings {
@@ -42,10 +42,8 @@ Item {
             leftMargin: 4 * anchors.margins
             topMargin: anchors.leftMargin
         }
-        ScrollBar.vertical.policy: flickable.contentHeight
-                                   > flickable.height ? ScrollBar.AlwaysOn : ScrollBar.AsNeeded
-        ScrollBar.horizontal.policy: flickable.contentWidth
-                                     > flickable.width ? ScrollBar.AlwaysOn : ScrollBar.AsNeeded
+        ScrollBar.vertical.policy: flickable.contentHeight > flickable.height ? ScrollBar.AlwaysOn : ScrollBar.AsNeeded
+        ScrollBar.horizontal.policy: flickable.contentWidth > flickable.width ? ScrollBar.AlwaysOn : ScrollBar.AsNeeded
         ColumnLayout {
             id: layout
             anchors.fill: parent
@@ -61,19 +59,19 @@ Item {
                         id: onDisk
                     }
                     Component.onCompleted: {
-                        const startTheme = settings.theme.themePath
+                        const startTheme = settings.theme.themePath;
                         for (var row = 0; row < onDisk.rowCount(); row++) {
-                            const index = onDisk.index(row, 0)
-                            const rowPath = onDisk.data(index, onDisk.path)
+                            const index = onDisk.index(row, 0);
+                            const rowPath = onDisk.data(index, onDisk.path);
                             // As a side-effect, will reload from disk
                             if (rowPath === startTheme) {
-                                currentIndex = row
-                                break
+                                currentIndex = row;
+                                break;
                             }
                         }
                         // Reset to default theme if previously selected theme does not exist.
                         if (currentIndex === -1)
-                            currentIndex = 0
+                            currentIndex = 0;
                     }
 
                     textRole: "display"
@@ -86,11 +84,9 @@ Item {
                     currentIndex: -1
                     onCurrentValueChanged: settings.loadPalette(currentValue)
                     onCurrentIndexChanged: {
-                        const idx = onDisk.index(currentIndex, 0)
-                        isSystemTheme = Qt.binding(() => onDisk.data(
-                                                       idx, onDisk.isSystem))
-                        isMonoFont = Qt.binding(() => onDisk.data(
-                                                    idx, onDisk.isMonoFont))
+                        const idx = onDisk.index(currentIndex, 0);
+                        isSystemTheme = Qt.binding(() => onDisk.data(idx, onDisk.isSystem));
+                        isMonoFont = Qt.binding(() => onDisk.data(idx, onDisk.isMonoFont));
                     }
                 }
                 Button {
@@ -101,7 +97,7 @@ Item {
                         buttonText: comboBox.isSystemTheme ? root.palette.placeholderText : root.palette.buttonText
                     }
                     onPressed: {
-                        renameDialog.open()
+                        renameDialog.open();
                     }
                 }
                 Item {}
@@ -113,16 +109,15 @@ Item {
                     Layout.minimumWidth: root.buttonWidth
                     onPressed: {
                         if (comboBox.isSystemTheme) {
-                            const curIdx = comboBox.currentIndex
+                            const curIdx = comboBox.currentIndex;
                             // Copy also creates the duplicate item for us!
-                            const index = onDisk.copy(comboBox.currentIndex)
+                            const index = onDisk.copy(comboBox.currentIndex);
                             if (index != -1) {
-                                comboBox.currentIndex = index
-                                requestRename()
+                                comboBox.currentIndex = index;
+                                requestRename();
                             }
                         } else {
-                            FileIO.save(comboBox.currentValue,
-                                        settings.extPalette.jsonString())
+                            FileIO.save(comboBox.currentValue, settings.extPalette.jsonString());
                         }
                     }
                     signal requestRename
@@ -133,11 +128,10 @@ Item {
                     Layout.minimumWidth: root.buttonWidth
                     enabled: !comboBox.isSystemTheme
                     onClicked: {
-                        const index = comboBox.currentIndex
+                        const index = comboBox.currentIndex;
                         if (index != -1) {
-                            onDisk.deleteTheme(index)
-                            comboBox.currentIndex = Math.min(index,
-                                                             comboBox.count - 1)
+                            onDisk.deleteTheme(index);
+                            comboBox.currentIndex = Math.min(index, comboBox.count - 1);
                         }
                     }
                     palette {
@@ -169,7 +163,7 @@ Item {
                         required property variant model
                         text: model.display
                         onClicked: {
-                            root.activeCategory = Qt.binding(() => model.value)
+                            root.activeCategory = Qt.binding(() => model.value);
                         }
                     }
                 }
@@ -182,19 +176,12 @@ Item {
                     id: listView
                     clip: true
                     Layout.fillHeight: true
-                    Layout.minimumHeight: Math.max(100,
-                                                   modifyArea.implicitHeight)
-                    Layout.minimumWidth: Math.max(
-                                             100,
-                                             contentItem.childrenRect.width + 5,
-                                             childrenRect.width)
+                    Layout.minimumHeight: Math.max(100, modifyArea.implicitHeight)
+                    Layout.minimumWidth: Math.max(100, contentItem.childrenRect.width + 5, childrenRect.width)
                     focus: true
                     focusPolicy: Qt.StrongFocus
-                    Keys.onUpPressed: listView.currentIndex = Math.max(
-                                          0, listView.currentIndex - 1)
-                    Keys.onDownPressed: listView.currentIndex = Math.min(
-                                            listView.count - 1,
-                                            listView.currentIndex + 1)
+                    Keys.onUpPressed: listView.currentIndex = Math.max(0, listView.currentIndex - 1)
+                    Keys.onDownPressed: listView.currentIndex = Math.min(listView.count - 1, listView.currentIndex + 1)
                     model: paletteModel
                     delegate: BoxedText {
                         required property string display
@@ -203,8 +190,7 @@ Item {
                         name: display
                         bgColor: paletteItem?.background ?? "transparent"
                         fgColor: paletteItem?.foreground ?? "black"
-                        font: paletteItem?.font
-                              ?? settings.extPalette.baseMono.font
+                        font: paletteItem?.font ?? settings.extPalette.baseMono.font
                     }
                 }
                 PaletteDetails {
@@ -221,7 +207,7 @@ Item {
         }
     }
     Component.onCompleted: {
-        copyButton.requestRename.connect(renameDialog.open)
+        copyButton.requestRename.connect(renameDialog.open);
     }
     Loader {
         id: exportLoader
@@ -233,20 +219,20 @@ Item {
                 "selectedNameFilter_index": 0,
                 "defaultSuffix": "theme",
                 "selectedFile": "default.theme"
-            }
+            };
 
             if (PlatformDetector.isWASM) {
-                setSource("qrc:/qt/qml/edu/pepp/settings/QMLFileDialog.qml", props)
+                setSource("qrc:/qt/qml/edu/pepp/settings/QMLFileDialog.qml", props);
             } else {
-                setSource("qrc:/qt/qml/edu/pepp/settings/NativeFileDialog.qml", props)
+                setSource("qrc:/qt/qml/edu/pepp/settings/NativeFileDialog.qml", props);
             }
         }
         asynchronous: false
         Connections {
             target: exportLoader.item
             function onAccepted() {
-                const path = decodeURIComponent(exportLoader.item.selectedFile)
-                FileIO.save(path, settings.extPalette.jsonString())
+                const path = decodeURIComponent(exportLoader.item.selectedFile);
+                FileIO.save(path, settings.extPalette.jsonString());
             }
         }
     }
@@ -259,24 +245,24 @@ Item {
                 "nameFilters": ["Pep Theme files (*.theme)"],
                 "selectedNameFilter_index": 0,
                 "defaultSuffix": "theme"
-            }
+            };
 
             if (PlatformDetector.isWASM) {
-                setSource("qrc:/qt/qml/edu/pepp/settings/QMLFileDialog.qml", props)
+                setSource("qrc:/qt/qml/edu/pepp/settings/QMLFileDialog.qml", props);
             } else {
-                setSource("qrc:/qt/qml/edu/pepp/settings/NativeFileDialog.qml", props)
+                setSource("qrc:/qt/qml/edu/pepp/settings/NativeFileDialog.qml", props);
             }
         }
         asynchronous: false
         Connections {
             target: importLoader.item
             function onAccepted() {
-                const model = comboBox.model
-                const uri = decodeURIComponent(importLoader.item.selectedFile)
-                const file = uri.replace("file:///", "")
-                const index = model.importTheme(file)
+                const model = comboBox.model;
+                const uri = decodeURIComponent(importLoader.item.selectedFile);
+                const file = uri.replace("file:///", "");
+                const index = model.importTheme(file);
                 if (index != -1)
-                    comboBox.currentIndex = index
+                    comboBox.currentIndex = index;
             }
         }
     }
@@ -305,9 +291,9 @@ Item {
         }
 
         onAccepted: {
-            const model = comboBox.model
-            const index = model.index(comboBox.currentIndex, 0)
-            model.setData(index, name.text, model.display)
+            const model = comboBox.model;
+            const index = model.index(comboBox.currentIndex, 0);
+            model.setData(index, name.text, model.display);
         }
     }
 }

--- a/lib/top/ProjectSelectBar.qml
+++ b/lib/top/ProjectSelectBar.qml
@@ -63,7 +63,7 @@ Flickable {
                 break;
             }
 
-            if (optTexts === undefined || optTexts === null)
+            if (optTexts === undefined || optTexts === null || optTexts === "")
                 return onMarkActiveDirty(false);
             else if (typeof (optTexts) === "string")
                 proj.set(level, optTexts);

--- a/lib/top/ProjectSelectBar.qml
+++ b/lib/top/ProjectSelectBar.qml
@@ -16,11 +16,16 @@ Flickable {
     contentWidth: projectBar.width + addProjectButton.width
     contentHeight: projectBar.height
     height: contentHeight
+    NuAppSettings {
+        id: settings
+    }
     ProjectModel {
         id: pm
         function onAddProject(arch, level, feats, optTexts, reuse) {
             var proj = null;
             var cur = currentProject;
+            settings.general.defaultArch = Number(arch);
+            settings.general.defaultAbstraction = Number(level);
             // Attach a delegate to the project which can render its edit/debug modes. Since it is a C++ property,
             // binding changes propogate automatically.
             switch (Number(arch)) {

--- a/lib/top/SideBar.qml
+++ b/lib/top/SideBar.qml
@@ -7,6 +7,10 @@ Column {
     id: root
     property var modesModel: undefined
     function switchToMode(mode) {
+        if (!root.enabled) {
+            console.warn("Cannot switch modes when sidebar is disabled.");
+            return;
+        }
         // Match the button, case insensitive.
         const re = new RegExp(mode, "i");
         // Children of sidebar are the repeater's delegates
@@ -49,6 +53,7 @@ Column {
         // If there is no current project, display a Welcome mode.
         model: root.modesModel ?? defaultSidebarModel
         delegate: Button {
+            enabled: root.enabled
             checkable: true
             width: 100
             height: 65

--- a/lib/top/Welcome.qml
+++ b/lib/top/Welcome.qml
@@ -10,9 +10,8 @@ Item {
     property string loadingFileName: ""
     property var loadingFileContent: ""
     property int filterEdition: 0
-
-    property int filterAbstraction: 0
-    readonly property bool filtering: filterEdition !== 0 && filterAbstraction !== 0
+    property list<int> filterAbstraction: []
+    readonly property bool filtering: filterEdition !== 0 && filterAbstraction.length !== 0
     NuAppSettings {
         id: settings
     }
@@ -180,7 +179,7 @@ Item {
                         visible: !model.placeholder
                         text: model.text
                         onReleased: root.addProject(model.architecture, model.abstraction, "", root.loadingFileContent, false)
-                        enabled: model.complete || model.partiallyComplete
+                        enabled: (model.complete || model.partiallyComplete) && (root.filterAbstraction.length === 0 || root.filterAbstraction.includes(model.abstraction))
                         palette.disabled.button: parent.palette.shadow
                         hoverEnabled: true
                         ToolTip.visible: (hovered || down) && model.description

--- a/lib/top/Welcome.qml
+++ b/lib/top/Welcome.qml
@@ -7,6 +7,12 @@ import edu.pepp 1.0
 Item {
     id: root
     property real topOffset: 0
+    property string loadingFileName: ""
+    property var loadingFileContent: ""
+    property int filterEdition: 0
+
+    property int filterAbstraction: 0
+    readonly property bool filtering: filterEdition !== 0 && filterAbstraction !== 0
     NuAppSettings {
         id: settings
     }
@@ -25,26 +31,33 @@ Item {
             pointSize: 3 * fm.font.pointSize / 4
         }
     }
+    FontMetrics {
+        id: fnameFM
+        font {
+            family: fm.font.family
+            pointSize: 3 * fm.font.pointSize / 4
+        }
+    }
     TextMetrics {
         id: projectTM
         font: projectFM.font
         text: "Level Asmb5"
     }
 
-    signal addProject(int arch, int abstraction, string features, bool reuse)
+    signal addProject(int arch, int abstraction, string features, string optText, bool reuse)
 
     component EditionButton: Button {
         id: control
         required property int edition
         property real leftRadius: 0
         property real rightRadius: 0
-
+        readonly property var p: enabled ? root.palette : root.palette.disabled
         down: settings.general.defaultEdition == control.edition
+        enabled: root.filterEdition === 0 || control.edition === root.filterEdition
         font: fm.font
-
         background: Rectangle {
             id: background
-            color: control.down ? palette.highlight : (control.hovered ? palette.light : palette.button)
+            color: control.enabled ? (control.down ? palette.highlight : (control.hovered ? palette.light : palette.button)) : palette.shadow
             topLeftRadius: control.leftRadius
             topRightRadius: control.rightRadius
             bottomLeftRadius: control.leftRadius
@@ -67,22 +80,49 @@ Item {
         }
     }
 
-    Flow {
-        id: header
+    RowLayout {
+        id: filenameHeader
         spacing: fm.averageCharacterWidth
+        visible: !!root.loadingFileName
         anchors {
             top: parent.top
             left: parent.left
             leftMargin: 10
             right: parent.right
-            topMargin: -root.topOffset
+            topMargin: visible ? -root.topOffset : 0
+        }
+        Label {
+            text: `Loading from file:`
+            font: fm.font
+            Layout.alignment: Qt.AlignVCenter
+        }
+        Text {
+            text: root.loadingFileName
+            font: fnameFM.font
+            Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
+        }
+        Item {
+            Layout.fillWidth: true
+        }
+
+        height: visible ? implicitHeight : 0
+    }
+
+    Flow {
+        id: header
+        spacing: fm.averageCharacterWidth
+        anchors {
+            top: filenameHeader.bottom
+            left: parent.left
+            leftMargin: 10
+            right: parent.right
+            topMargin: filenameHeader.visible ? 0 : -root.topOffset
         }
         Label {
             text: `Computer Systems`
             font: fm.font
         }
         Row {
-
             spacing: -1 // -border.width
             EditionButton {
                 text: "Sixth"
@@ -139,7 +179,7 @@ Item {
                         font: projectFM.font
                         visible: !model.placeholder
                         text: model.text
-                        onReleased: root.addProject(model.architecture, model.abstraction, "", false)
+                        onReleased: root.addProject(model.architecture, model.abstraction, "", root.loadingFileContent, false)
                         enabled: model.complete || model.partiallyComplete
                         palette.disabled.button: parent.palette.shadow
                         hoverEnabled: true
@@ -169,5 +209,11 @@ Item {
         showIncomplete: settings.general.showDebugComponents
         showPartiallyComplete: settings.general.showDebugComponents
         sourceModel: ProjectTypeModel {}
+    }
+
+    onFilterEditionChanged: {
+        if (filterEdition === 0) {} else if (4 <= filterEdition && filterEdition <= 6) {
+            settings.general.defaultEdition = filterEdition;
+        }
     }
 }

--- a/lib/top/Welcome.qml
+++ b/lib/top/Welcome.qml
@@ -9,9 +9,9 @@ Item {
     property real topOffset: 0
     property string loadingFileName: ""
     property var loadingFileContent: ""
-    property int filterEdition: 0
+    property list<int> filterEdition: []
     property list<int> filterAbstraction: []
-    readonly property bool filtering: filterEdition !== 0 && filterAbstraction.length !== 0
+    readonly property bool filtering: filterEdition.length !== 0 && filterAbstraction.length !== 0
     NuAppSettings {
         id: settings
     }
@@ -52,7 +52,7 @@ Item {
         property real rightRadius: 0
         readonly property var p: enabled ? root.palette : root.palette.disabled
         down: settings.general.defaultEdition == control.edition
-        enabled: root.filterEdition === 0 || control.edition === root.filterEdition
+        enabled: root.filterEdition.length === 0 || root.filterEdition.includes(control.edition)
         font: fm.font
         background: Rectangle {
             id: background

--- a/lib/utils/fileio.cpp
+++ b/lib/utils/fileio.cpp
@@ -57,8 +57,9 @@ void FileIO::loadCodeFromFile(const QString &name) {
 QByteArray FileIO::load(const QString &fileName) {
   QFile file(fileName);
   QByteArray ret;
-  if (file.size() > 1'000'000) qWarning() << "File size exceeds 1MB. Will not load.";
-  if (file.open(QIODevice::ReadOnly)) {
+  if (file.size() > 1'000'000) {
+    qWarning() << "File size exceeds 1MB. Will not load.";
+  } else if (file.open(QIODevice::ReadOnly)) {
     ret = file.readAll();
     file.close();
   } else qWarning() << "Could not open file for reading";

--- a/lib/utils/fileio.cpp
+++ b/lib/utils/fileio.cpp
@@ -1,4 +1,6 @@
 #include "fileio.hpp"
+#include <QtWidgets/qfiledialog.h>
+#include "constants.hpp"
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
@@ -16,5 +18,38 @@ void FileIO::save(const QString &filename, const QString &data) {
   } else qWarning() << "Could not open file for writing";
 #ifdef __EMSCRIPTEN__
   EM_ASM(FS.syncfs(function(){}););
+#endif
+}
+
+void FileIO::load(const QString &filters) {
+  // arch, abstraction
+  using enum pepp::Architecture;
+  using enum pepp::Abstraction;
+  using M = QMap<QString, std::pair<int, int>>; // Type alias to make formatting more legible.
+  static const M filters3 = {{"Pep/10, ISA3 (*.pepo)", {(int)PEP10, (int)ISA3}},
+                             {"Pep/9, ISA3 (*.pepo)", {(int)PEP9, (int)ISA3}},
+                             {"Pep/10, ASMB3 (*.pep)", {(int)PEP10, (int)ASMB3}},
+                             {"Pep/10, ASMB5 (*.pep)", {(int)PEP10, (int)ASMB5}},
+                             {"Pep/9, ASMB5 (*.pep)", {(int)PEP9, (int)ASMB5}},
+                             {"Text files (*.txt)", {0, 0}},
+                             {"Any files (*.*)", {0, 0}}};
+  static const QStringList filters2 = filters3.keys();
+#ifdef __EMSCRIPTEN__
+  auto ready = [this](const QString &fileName, const QByteArray &fileContent) {
+    emit fileLoaded(fileName, fileContent, 0, 0);
+  };
+  QFileDialog::getOpenFileContent(filters2.join(";;"), ready);
+#else
+  QString selectedFilter;
+  auto fileName = QFileDialog::getOpenFileName(nullptr, "Need a caption", "", filters2.join(";;"), &selectedFilter);
+  QFile file(fileName);
+  QByteArray ret;
+  if (file.size() > 1'000'000) qWarning() << "File size exceeds 1MB. Will not load.";
+  if (file.open(QIODevice::ReadOnly)) {
+    ret = file.readAll();
+    file.close();
+  } else qWarning() << "Could not open file for reading";
+  auto [arch, abs] = filters3.value(selectedFilter, {0, 0});
+  emit fileLoaded(fileName, ret, arch, abs);
 #endif
 }

--- a/lib/utils/fileio.cpp
+++ b/lib/utils/fileio.cpp
@@ -41,7 +41,7 @@ void FileIO::loadCodeViaDialog(const QString &filters) {
   QFileDialog::getOpenFileContent(filters2.join(";;"), ready);
 #else
   QString selectedFilter;
-  auto fileName = QFileDialog::getOpenFileName(nullptr, "Need a caption", "", filters2.join(";;"), &selectedFilter);
+  auto fileName = QFileDialog::getOpenFileName(nullptr, "Open Source Code", "", filters2.join(";;"), &selectedFilter);
   if (fileName.isEmpty()) return;
   QByteArray ret = load(fileName);
   auto [arch, abs] = filters3.value(selectedFilter, {0, 0});

--- a/lib/utils/fileio.hpp
+++ b/lib/utils/fileio.hpp
@@ -12,5 +12,5 @@ public:
   Q_INVOKABLE void save(const QString &filename, const QString &data);
   Q_INVOKABLE void load(const QString &filters);
 signals:
-  Q_INVOKABLE void fileLoaded(const QString &fileName, const QByteArray &fileContent, int arch, int abstraction);
+  Q_INVOKABLE void codeLoaded(const QString &fileName, const QString &fileContent, int arch, int abstraction);
 };

--- a/lib/utils/fileio.hpp
+++ b/lib/utils/fileio.hpp
@@ -10,7 +10,14 @@ class FileIO : public QObject {
 public:
   FileIO(QObject *parent = nullptr);
   Q_INVOKABLE void save(const QString &filename, const QString &data);
-  Q_INVOKABLE void load(const QString &filters);
+  Q_INVOKABLE void loadCodeViaDialog(const QString &filters);
+#ifndef __EMSCRIPTEN__
+  Q_INVOKABLE void loadCodeFromFile(const QString &name);
+
+private:
+  QByteArray load(const QString &fileName);
+#endif
+
 signals:
   Q_INVOKABLE void codeLoaded(const QString &fileName, const QString &fileContent, int arch, int abstraction);
 };

--- a/lib/utils/fileio.hpp
+++ b/lib/utils/fileio.hpp
@@ -6,9 +6,11 @@
 class FileIO : public QObject {
   Q_OBJECT
   QML_NAMED_ELEMENT(FileIO)
-  QML_SINGLETON
 
 public:
   FileIO(QObject *parent = nullptr);
   Q_INVOKABLE void save(const QString &filename, const QString &data);
+  Q_INVOKABLE void load(const QString &filters);
+signals:
+  Q_INVOKABLE void fileLoaded(const QString &fileName, const QByteArray &fileContent, int arch, int abstraction);
 };


### PR DESCRIPTION
- Double clicking on a file opens Pepp
- Right click "Open with" opens Pepp
- Files open to an existing instance when possible
- If the file extension is ambiguous, then a dialog can be disable to select between editions / abstractions

This covers some features from #596 and #779.
I still need to complete WASM file open and native save/as to close those issues.