### PR TITLE
Reorganize `about` and `changelog` information

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -15,7 +15,10 @@ else ()
     # Future platform-specific logic for icons.
 endif ()
 
-qt6_add_executable(pepp ${sources} ${guis} ${CMAKE_SOURCE_DIR}/data/icons/icons.qrc)
+qt6_add_executable(pepp ${sources} ${guis}
+    ${CMAKE_SOURCE_DIR}/data/icons/icons.qrc
+    ${CMAKE_SOURCE_DIR}/data/app_icon/app_icon.qrc
+)
 
 
 target_link_libraries(pepp PRIVATE cli catch Qt6::Core Qt6::Gui
@@ -58,7 +61,10 @@ endif ()
 
 # Skip term target on platforms where it is not needed.
 if(NOT (EMSCRIPTEN OR IOS) )
-    qt6_add_executable(pepp-term ${sources} ${CMAKE_SOURCE_DIR}/data/icons/icons.qrc)
+    qt6_add_executable(pepp-term ${sources}
+        ${CMAKE_SOURCE_DIR}/data/icons/icons.qrc
+        ${CMAKE_SOURCE_DIR}/data/app_icon/app_icon.qrc
+    )
     target_link_libraries(pepp-term PRIVATE cli Qt6::Core catch test-lib-all pepp-lib catch)
     set_target_properties(pepp-term PROPERTIES FOLDER "qtc_runnable")
     target_compile_definitions(pepp-term PRIVATE "INCLUDE_GUI=0")

--- a/data/app_icon/.gitignore
+++ b/data/app_icon/.gitignore
@@ -1,3 +1,4 @@
+# Should we delete this .gitignore file?
 *
 !*.svg
 !.gitignore
@@ -6,3 +7,4 @@
 !*.png
 !*.ico
 !*.icns
+!*.qrc

--- a/data/app_icon/app_icon.qrc
+++ b/data/app_icon/app_icon.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/app_icon">
+        <file>icon.png</file>
+        <file>icon.svg</file>
+    </qresource>
+</RCC>

--- a/lib/help/about/About.qml
+++ b/lib/help/about/About.qml
@@ -51,12 +51,16 @@ Item {
             width: implicitButtonWidth
         }
         TabButton {
+            text: "System Info"
+            width: implicitButtonWidth
+        }
+        TabButton {
             text: "Dependencies"
             width: implicitButtonWidth
         }
     }
 
-    //  Figure contents
+    //  All Screens, selection based on current index
     StackLayout {
         currentIndex: helpBar.currentIndex
         anchors {
@@ -65,6 +69,7 @@ Item {
             right: parent.right
             bottom: parent.bottom
         }
+        //  Pep About screen
         Item {
             id: pepAbout
             Layout.fillHeight: true
@@ -77,27 +82,44 @@ Item {
                 ColumnLayout {
                     anchors.fill: parent
                     spacing: 0
-                    Text {
-                        id: title
-                        color: palette.windowText
-                        Layout.margins: root.sideMargin
-                        onLinkActivated: link => {
-                            Qt.openUrlExternally(link)
+                    RowLayout {
+                        Rectangle {
+                            // Rectangle is only for testing. When image works, remove this control
+                            color: "yellow"
+                            width: logo.width
+                            height: logo.height
+
+                            Image {
+                                id: logo
+                                source: "file:///E:\Projects\QTProjects\Pepp\lib\help\about\icon.png"
+                                fillMode: Image.PreserveAspectFit
+                                width: 75
+                                height: logo.width
+                            }
                         }
-                        // Too much text to assign in binding, so build it inline instead.
-                        Component.onCompleted: {
-                            let line0 = "<h2>Pepp version %1</h2> <a href=\"https://github.com/Matthew-McRaven/Pepp/releases\">Check for updates</a>.  ".arg(
-                                Version.version_str_full)
-                            let url = "https://github.com/Matthew-McRaven/Pepp/commit/"
-                            + Version.git_sha
-                            let line1 = "Based on <a href=\"" + url + "\">"
-                            line1 += Version.git_tag
-                            !== "unknown" ? Version.git_tag : Version.git_sha.substring(
-                                                0, 7)
-                            line1 += "</a>."
-                            text = line0 + line1
+                        Text {
+                            id: title
+                            color: palette.windowText
+                            Layout.margins: root.sideMargin
+                            onLinkActivated: link => {
+                                Qt.openUrlExternally(link)
+                            }
+                            // Too much text to assign in binding, so build it inline instead.
+                            Component.onCompleted: {
+                                let line0 = "<h2>Pepp version %1</h2> <a href=\"https://github.com/Matthew-McRaven/Pepp/releases\">Check for updates</a>.  ".arg(
+                                    Version.version_str_full)
+                                let url = "https://github.com/Matthew-McRaven/Pepp/commit/"
+                                + Version.git_sha
+                                let line1 = "Based on <a href=\"" + url + "\">"
+                                line1 += Version.git_tag
+                                !== "unknown" ? Version.git_tag : Version.git_sha.substring(
+                                                    0, 7)
+                                line1 += "</a>."
+                                text = line0 + line1
+                            }
                         }
-                    }
+                    } //  RowLayout-logo
+
                     Label {
                         Layout.fillWidth: true
                         Layout.topMargin: root.paragraphSpace
@@ -188,13 +210,16 @@ Item {
                             TextArea {
                                 id: license
                                 readOnly: true
-                                text: "qrc:/LICENSE_FULL" //"qrc:/qt/qml/Pepp/LICENSE" //"qrc:/LICENSE_FULL"
+                                text: FileReader.readFile(
+                                          ":/about/LICENSE_FULL")
                             }
+                            ScrollBar.vertical.policy: ScrollBar.AlwaysOn
                         } //  ScrollView
                     }
                 } //ColumnLayout
             } //  Rectangle
         } //  Item - pepAbout
+        //  Change Log screen
         Item {
             id: changeLog
             Layout.fillHeight: true
@@ -209,7 +234,24 @@ Item {
                     text: "Change Log"
                 } //  End of replacement
             }
-        }
+        } //  Item - changeLog
+        //  System Info screen
+        Item {
+            id: systemInfo
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            Rectangle {
+                anchors.fill: parent
+                color: palette.base
+                border.width: 1
+                border.color: palette.shadow
+                Text {
+                    // Replace this control with system info screen
+                    text: "System info"
+                } //  End of replacement
+            }
+        } //  Item - systemInfo
+        //  Third party license screen
         Item {
             id: thirdParty
             Layout.fillHeight: true
@@ -243,7 +285,9 @@ Item {
                                     projectCombo.onCurrentIndexChanged)
                             }
 
-                            Layout.fillWidth: true
+                            Layout.preferredWidth: 160
+                            Layout.minimumWidth: 160
+                            Layout.maximumWidth: 160
                             model: Dependencies
                             currentIndex: 0
                             textRole: "name"
@@ -254,6 +298,10 @@ Item {
                                 let url = model.data(index, DependencyRoles.URL)
                                 projectUrl.text = "<a href=\"" + url + "\">" + url + "</a>"
                             }
+                        }
+                        Item {
+                            id: spacer
+                            Layout.fillWidth: true
                         }
                     } //Row
                     RowLayout {
@@ -281,7 +329,6 @@ Item {
                         TextArea {
                             id: projectLicense
                             readOnly: true
-                            //wrapMode: Text.WordWrap
                         }
                     } //  ScrollView
                 } //ColumnLayout

--- a/lib/help/about/About.qml
+++ b/lib/help/about/About.qml
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2024 J. Stanley Warford, Matthew McRaven
  * This program is free software: you can redistribute it and/or modify
@@ -22,6 +21,7 @@ import QtQuick.Controls
 import QtQuick.Window
 import edu.pepp 1.0
 import "../about" as About
+import "qrc:/qt/qml/edu/pepp/help/builtins" as Builtins
 
 Item {
     id: root
@@ -103,20 +103,16 @@ Item {
                             color: palette.windowText
                             Layout.margins: root.sideMargin
                             onLinkActivated: link => {
-                                Qt.openUrlExternally(link)
+                                Qt.openUrlExternally(link);
                             }
                             // Too much text to assign in binding, so build it inline instead.
                             Component.onCompleted: {
-                                let line0 = "<h2>Pepp version %1</h2> <a href=\"https://github.com/Matthew-McRaven/Pepp/releases\">Check for updates</a>.  ".arg(
-                                    Version.version_str_full)
-                                let url = "https://github.com/Matthew-McRaven/Pepp/commit/"
-                                + Version.git_sha
-                                let line1 = "Based on <a href=\"" + url + "\">"
-                                line1 += Version.git_tag
-                                !== "unknown" ? Version.git_tag : Version.git_sha.substring(
-                                                    0, 7)
-                                line1 += "</a>."
-                                text = line0 + line1
+                                let line0 = "<h2>Pepp version %1</h2> <a href=\"https://github.com/Matthew-McRaven/Pepp/releases\">Check for updates</a>.  ".arg(Version.version_str_full);
+                                let url = "https://github.com/Matthew-McRaven/Pepp/commit/" + Version.git_sha;
+                                let line1 = "Based on <a href=\"" + url + "\">";
+                                line1 += Version.git_tag !== "unknown" ? Version.git_tag : Version.git_sha.substring(0, 7);
+                                line1 += "</a>.";
+                                text = line0 + line1;
                             }
                         }
                     } //  RowLayout-logo
@@ -211,8 +207,7 @@ Item {
                             TextArea {
                                 id: license
                                 readOnly: true
-                                text: FileReader.readFile(
-                                          ":/about/LICENSE_FULL")
+                                text: FileReader.readFile(":/about/LICENSE_FULL")
                             }
                             ScrollBar.vertical.policy: ScrollBar.AlwaysOn
                         } //  ScrollView
@@ -230,10 +225,10 @@ Item {
                 color: palette.base
                 border.width: 1
                 border.color: palette.shadow
-                Text {
-                    // Replace this control with Change control screen
-                    text: "Change Log"
-                } //  End of replacement
+                Builtins.ChangelogViewer {
+                    focus: true
+                    anchors.fill: parent
+                }
             }
         } //  Item - changeLog
         //  System Info screen
@@ -286,10 +281,9 @@ Item {
                             id: projectCombo
                             Component.onCompleted: {
                                 // Force the correct license to be selected on load.
-                                projectCombo.onCurrentIndexChanged()
+                                projectCombo.onCurrentIndexChanged();
                                 // onCurrentIndexChanged not called automatically, so we must connect to the appropriate signal.
-                                projectCombo.currentIndexChanged.connect(
-                                    projectCombo.onCurrentIndexChanged)
+                                projectCombo.currentIndexChanged.connect(projectCombo.onCurrentIndexChanged);
                             }
 
                             Layout.preferredWidth: 160
@@ -299,11 +293,10 @@ Item {
                             currentIndex: 0
                             textRole: "name"
                             function onCurrentIndexChanged() {
-                                let index = model.index(currentIndex, 0)
-                                projectLicense.text = model.data(
-                                            index, DependencyRoles.LicenseText)
-                                let url = model.data(index, DependencyRoles.URL)
-                                projectUrl.text = "<a href=\"" + url + "\">" + url + "</a>"
+                                let index = model.index(currentIndex, 0);
+                                projectLicense.text = model.data(index, DependencyRoles.LicenseText);
+                                let url = model.data(index, DependencyRoles.URL);
+                                projectUrl.text = "<a href=\"" + url + "\">" + url + "</a>";
                             }
                         }
                         Item {
@@ -324,7 +317,7 @@ Item {
                             Layout.fillWidth: true
                             color: palette.windowText
                             onLinkActivated: link => {
-                                Qt.openUrlExternally(link)
+                                Qt.openUrlExternally(link);
                             }
                         }
                     }

--- a/lib/help/about/About.qml
+++ b/lib/help/about/About.qml
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2024 J. Stanley Warford, Matthew McRaven
  * This program is free software: you can redistribute it and/or modify
@@ -21,6 +20,7 @@ import QtQuick.Layouts
 import QtQuick.Controls
 import QtQuick.Window
 import edu.pepp 1.0
+import "../about" as About
 
 Item {
     id: root
@@ -102,20 +102,16 @@ Item {
                             color: palette.windowText
                             Layout.margins: root.sideMargin
                             onLinkActivated: link => {
-                                Qt.openUrlExternally(link)
+                                Qt.openUrlExternally(link);
                             }
                             // Too much text to assign in binding, so build it inline instead.
                             Component.onCompleted: {
-                                let line0 = "<h2>Pepp version %1</h2> <a href=\"https://github.com/Matthew-McRaven/Pepp/releases\">Check for updates</a>.  ".arg(
-                                    Version.version_str_full)
-                                let url = "https://github.com/Matthew-McRaven/Pepp/commit/"
-                                + Version.git_sha
-                                let line1 = "Based on <a href=\"" + url + "\">"
-                                line1 += Version.git_tag
-                                !== "unknown" ? Version.git_tag : Version.git_sha.substring(
-                                                    0, 7)
-                                line1 += "</a>."
-                                text = line0 + line1
+                                let line0 = "<h2>Pepp version %1</h2> <a href=\"https://github.com/Matthew-McRaven/Pepp/releases\">Check for updates</a>.  ".arg(Version.version_str_full);
+                                let url = "https://github.com/Matthew-McRaven/Pepp/commit/" + Version.git_sha;
+                                let line1 = "Based on <a href=\"" + url + "\">";
+                                line1 += Version.git_tag !== "unknown" ? Version.git_tag : Version.git_sha.substring(0, 7);
+                                line1 += "</a>.";
+                                text = line0 + line1;
                             }
                         }
                     } //  RowLayout-logo
@@ -210,8 +206,7 @@ Item {
                             TextArea {
                                 id: license
                                 readOnly: true
-                                text: FileReader.readFile(
-                                          ":/about/LICENSE_FULL")
+                                text: FileReader.readFile(":/about/LICENSE_FULL")
                             }
                             ScrollBar.vertical.policy: ScrollBar.AlwaysOn
                         } //  ScrollView
@@ -241,14 +236,20 @@ Item {
             Layout.fillHeight: true
             Layout.fillWidth: true
             Rectangle {
+
                 anchors.fill: parent
                 color: palette.base
                 border.width: 1
                 border.color: palette.shadow
-                Text {
-                    // Replace this control with system info screen
-                    text: "System info"
-                } //  End of replacement
+                ColumnLayout {
+                    anchors.fill: parent
+                    spacing: 0
+                    About.Diagnostics {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        Layout.margins: root.sideMargin
+                    } //  Diagnostics
+                }
             }
         } //  Item - systemInfo
         //  Third party license screen
@@ -279,10 +280,9 @@ Item {
                             id: projectCombo
                             Component.onCompleted: {
                                 // Force the correct license to be selected on load.
-                                projectCombo.onCurrentIndexChanged()
+                                projectCombo.onCurrentIndexChanged();
                                 // onCurrentIndexChanged not called automatically, so we must connect to the appropriate signal.
-                                projectCombo.currentIndexChanged.connect(
-                                    projectCombo.onCurrentIndexChanged)
+                                projectCombo.currentIndexChanged.connect(projectCombo.onCurrentIndexChanged);
                             }
 
                             Layout.preferredWidth: 160
@@ -292,11 +292,10 @@ Item {
                             currentIndex: 0
                             textRole: "name"
                             function onCurrentIndexChanged() {
-                                let index = model.index(currentIndex, 0)
-                                projectLicense.text = model.data(
-                                            index, DependencyRoles.LicenseText)
-                                let url = model.data(index, DependencyRoles.URL)
-                                projectUrl.text = "<a href=\"" + url + "\">" + url + "</a>"
+                                let index = model.index(currentIndex, 0);
+                                projectLicense.text = model.data(index, DependencyRoles.LicenseText);
+                                let url = model.data(index, DependencyRoles.URL);
+                                projectUrl.text = "<a href=\"" + url + "\">" + url + "</a>";
                             }
                         }
                         Item {
@@ -317,7 +316,7 @@ Item {
                             Layout.fillWidth: true
                             color: palette.windowText
                             onLinkActivated: link => {
-                                Qt.openUrlExternally(link)
+                                Qt.openUrlExternally(link);
                             }
                         }
                     }

--- a/lib/help/about/About.qml
+++ b/lib/help/about/About.qml
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2024 J. Stanley Warford, Matthew McRaven
  * This program is free software: you can redistribute it and/or modify
@@ -83,17 +84,17 @@ Item {
                     anchors.fill: parent
                     spacing: 0
                     RowLayout {
-                        Rectangle {
+                        Item {
                             // Rectangle is only for testing. When image works, remove this control
-                            color: "yellow"
-                            width: logo.width
-                            height: logo.height
+                            width: logo.width + 10
+                            height: logo.height + 10
 
                             Image {
                                 id: logo
-                                source: "file:///E:\Projects\QTProjects\Pepp\lib\help\about\icon.png"
+                                source: "qrc:/app_icon/icon.svg"
+                                anchors.centerIn: parent
                                 fillMode: Image.PreserveAspectFit
-                                width: 75
+                                width: 50
                                 height: logo.width
                             }
                         }
@@ -102,16 +103,20 @@ Item {
                             color: palette.windowText
                             Layout.margins: root.sideMargin
                             onLinkActivated: link => {
-                                Qt.openUrlExternally(link);
+                                Qt.openUrlExternally(link)
                             }
                             // Too much text to assign in binding, so build it inline instead.
                             Component.onCompleted: {
-                                let line0 = "<h2>Pepp version %1</h2> <a href=\"https://github.com/Matthew-McRaven/Pepp/releases\">Check for updates</a>.  ".arg(Version.version_str_full);
-                                let url = "https://github.com/Matthew-McRaven/Pepp/commit/" + Version.git_sha;
-                                let line1 = "Based on <a href=\"" + url + "\">";
-                                line1 += Version.git_tag !== "unknown" ? Version.git_tag : Version.git_sha.substring(0, 7);
-                                line1 += "</a>.";
-                                text = line0 + line1;
+                                let line0 = "<h2>Pepp version %1</h2> <a href=\"https://github.com/Matthew-McRaven/Pepp/releases\">Check for updates</a>.  ".arg(
+                                    Version.version_str_full)
+                                let url = "https://github.com/Matthew-McRaven/Pepp/commit/"
+                                + Version.git_sha
+                                let line1 = "Based on <a href=\"" + url + "\">"
+                                line1 += Version.git_tag
+                                !== "unknown" ? Version.git_tag : Version.git_sha.substring(
+                                                    0, 7)
+                                line1 += "</a>."
+                                text = line0 + line1
                             }
                         }
                     } //  RowLayout-logo
@@ -206,7 +211,8 @@ Item {
                             TextArea {
                                 id: license
                                 readOnly: true
-                                text: FileReader.readFile(":/about/LICENSE_FULL")
+                                text: FileReader.readFile(
+                                          ":/about/LICENSE_FULL")
                             }
                             ScrollBar.vertical.policy: ScrollBar.AlwaysOn
                         } //  ScrollView
@@ -280,9 +286,10 @@ Item {
                             id: projectCombo
                             Component.onCompleted: {
                                 // Force the correct license to be selected on load.
-                                projectCombo.onCurrentIndexChanged();
+                                projectCombo.onCurrentIndexChanged()
                                 // onCurrentIndexChanged not called automatically, so we must connect to the appropriate signal.
-                                projectCombo.currentIndexChanged.connect(projectCombo.onCurrentIndexChanged);
+                                projectCombo.currentIndexChanged.connect(
+                                    projectCombo.onCurrentIndexChanged)
                             }
 
                             Layout.preferredWidth: 160
@@ -292,10 +299,11 @@ Item {
                             currentIndex: 0
                             textRole: "name"
                             function onCurrentIndexChanged() {
-                                let index = model.index(currentIndex, 0);
-                                projectLicense.text = model.data(index, DependencyRoles.LicenseText);
-                                let url = model.data(index, DependencyRoles.URL);
-                                projectUrl.text = "<a href=\"" + url + "\">" + url + "</a>";
+                                let index = model.index(currentIndex, 0)
+                                projectLicense.text = model.data(
+                                            index, DependencyRoles.LicenseText)
+                                let url = model.data(index, DependencyRoles.URL)
+                                projectUrl.text = "<a href=\"" + url + "\">" + url + "</a>"
                             }
                         }
                         Item {
@@ -316,7 +324,7 @@ Item {
                             Layout.fillWidth: true
                             color: palette.windowText
                             onLinkActivated: link => {
-                                Qt.openUrlExternally(link);
+                                Qt.openUrlExternally(link)
                             }
                         }
                     }

--- a/lib/help/about/About.qml
+++ b/lib/help/about/About.qml
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2024 J. Stanley Warford, Matthew McRaven
  * This program is free software: you can redistribute it and/or modify
@@ -14,6 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
@@ -26,6 +28,9 @@ Item {
 
     implicitWidth: 500
     implicitHeight: 800
+    property int implicitButtonWidth: 100
+    property int paragraphSpace: 8
+    property int sideMargin: 5
 
     width: Math.min(implicitWidth * 1.1, parent.width * .5)
     height: Math.min(implicitHeight, parent.height * .75)
@@ -33,132 +38,254 @@ Item {
     FontMetrics {
         id: fontMetrics
     }
+
+    TabBar {
+        id: helpBar
+        width: parent.width
+        TabButton {
+            text: "Pepp"
+            width: implicitButtonWidth
+        }
+        TabButton {
+            text: "Change Log"
+            width: implicitButtonWidth
+        }
+        TabButton {
+            text: "Dependencies"
+            width: implicitButtonWidth
+        }
+    }
+
     //  Figure contents
-    ScrollView {
-        anchors.fill: parent
-        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-        contentWidth: parent.width
-        ColumnLayout {
-            anchors.fill: parent
-            Text {
-                id: title
-                color: palette.windowText
-                onLinkActivated: link => {
-                    Qt.openUrlExternally(link);
-                }
-                // Too much text to assign in binding, so build it inline instead.
-                Component.onCompleted: {
-                    let line0 = "<h2>Pepp version %1</h2> <a href=\"https://github.com/Matthew-McRaven/Pepp/releases\">Check for updates</a>.  ".arg(Version.version_str_full);
-                    let url = "https://github.com/Matthew-McRaven/Pepp/commit/" + Version.git_sha;
-                    let line1 = "Based on <a href=\"" + url + "\">";
-                    line1 += Version.git_tag !== "unknown" ? Version.git_tag : Version.git_sha.substring(0, 7);
-                    line1 += "</a>.";
-                    text = line0 + line1;
-                }
-            }
-            Label {
-                Layout.fillWidth: true
-                text: qsTr("Programmed By:")
-                font.bold: true
-            }
-            Column {
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                Repeater {
-                    model: MaintainerList {}
+    StackLayout {
+        currentIndex: helpBar.currentIndex
+        anchors {
+            top: helpBar.bottom
+            left: parent.left
+            right: parent.right
+            bottom: parent.bottom
+        }
+        Item {
+            id: pepAbout
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            Rectangle {
+                anchors.fill: parent
+                color: palette.base
+                border.width: 1
+                border.color: palette.shadow
+                ColumnLayout {
+                    anchors.fill: parent
+                    spacing: 0
+                    Text {
+                        id: title
+                        color: palette.windowText
+                        Layout.margins: root.sideMargin
+                        onLinkActivated: link => {
+                            Qt.openUrlExternally(link)
+                        }
+                        // Too much text to assign in binding, so build it inline instead.
+                        Component.onCompleted: {
+                            let line0 = "<h2>Pepp version %1</h2> <a href=\"https://github.com/Matthew-McRaven/Pepp/releases\">Check for updates</a>.  ".arg(
+                                Version.version_str_full)
+                            let url = "https://github.com/Matthew-McRaven/Pepp/commit/"
+                            + Version.git_sha
+                            let line1 = "Based on <a href=\"" + url + "\">"
+                            line1 += Version.git_tag
+                            !== "unknown" ? Version.git_tag : Version.git_sha.substring(
+                                                0, 7)
+                            line1 += "</a>."
+                            text = line0 + line1
+                        }
+                    }
+                    Label {
+                        Layout.fillWidth: true
+                        Layout.topMargin: root.paragraphSpace
+                        Layout.leftMargin: root.sideMargin
+                        Layout.rightMargin: root.sideMargin
+                        text: qsTr("Programmed By:")
+                        font.bold: true
+                    }
+                    Column {
+                        Layout.fillWidth: true
+                        Layout.topMargin: 0
+                        Layout.margins: root.sideMargin
+                        Repeater {
+                            model: MaintainerList {}
+
+                            Label {
+                                width: parent.width
+                                height: fontMetrics.height
+                                required property var item
+                                text: item.name + "  <" + item.email + ">"
+                            }
+                            height: model.rowCount() * fontMetrics.height
+                        }
+                    }
+                    Label {
+                        Layout.fillWidth: true
+                        Layout.topMargin: root.paragraphSpace
+                        Layout.leftMargin: root.sideMargin
+                        Layout.rightMargin: root.sideMargin
+                        text: qsTr("Previous Contributions By:")
+                        font.bold: true
+                    }
 
                     Label {
-                        width: parent.width
-                        height: fontMetrics.height
-                        required property var item
-                        text: item.name + "  <" + item.email + ">"
+                        Layout.fillWidth: true
+                        Layout.topMargin: 0
+                        Layout.margins: root.sideMargin
+                        wrapMode: Text.WordWrap
+                        text: Contributors.text
                     }
-                    height: model.rowCount() * fontMetrics.height
-                }
-            }
-            Label {
-                Layout.fillWidth: true
-                text: qsTr("Previous Contributions By:")
-                font.bold: true
-            }
 
-            Label {
-                Layout.fillWidth: true
-                wrapMode: Text.WordWrap
-                text: Contributors.text
-            }
+                    Label {
+                        Layout.fillWidth: true
+                        Layout.topMargin: root.paragraphSpace
+                        Layout.leftMargin: root.sideMargin
+                        Layout.rightMargin: root.sideMargin
+                        text: qsTr("Legal:")
+                        font.bold: true
+                        wrapMode: Text.WordWrap
+                    }
+                    Label {
+                        Layout.fillWidth: true
+                        Layout.leftMargin: root.sideMargin
+                        Layout.rightMargin: root.sideMargin
+                        text: qsTr("Copyright © 2016 - 2025, J. Stanley Warford, Matthew McRaven, Pepperdine University")
+                        wrapMode: Text.WordWrap
+                    }
+                    Label {
+                        Layout.fillWidth: true
+                        Layout.margins: root.sideMargin
+                        wrapMode: Text.WordWrap
+                        text: qsTr("This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.")
+                    }
+                    Label {
+                        Layout.fillWidth: true
+                        Layout.margins: root.sideMargin
+                        text: qsTr("<html>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.\n\nYou should have received a copy of the GNU General Public License along with this program. If not, see <a href=\"https://www.gnu.org/licenses/.\">https://www.gnu.org/licenses/</a></html>")
 
-            Label {
-                Layout.fillWidth: true
-                text: qsTr("Legal:")
-                font.bold: true
-                wrapMode: Text.WordWrap
-            }
-            Label {
-                Layout.fillWidth: true
-                text: qsTr("Copyright © 2016 - 2025, J. Stanley Warford, Matthew McRaven, Pepperdine University\n")
-                wrapMode: Text.WordWrap
-            }
-            Label {
-                Layout.fillWidth: true
-                Layout.preferredWidth: parent.width
-                wrapMode: Text.WordWrap
-                text: qsTr("This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.\n\n")
-            }
+                        //Layout.preferredWidth: parent.width
+                        wrapMode: Text.WordWrap
+                        onLinkActivated: link => Qt.openUrlExternally(link)
+                        MouseArea {
+                            anchors.fill: parent
+                            acceptedButtons: Qt.NoButton // Don't eat the mouse clicks
+                            cursorShape: Qt.PointingHandCursor
+                        }
+                    }
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        Layout.margins: root.sideMargin
 
-            Label {
-                Layout.fillWidth: true
-                text: qsTr("<html>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.\n\nYou should have received a copy of the GNU General Public License along with this program. If not, see <a href=\"https://www.gnu.org/licenses/.\">https://www.gnu.org/licenses/</a><br/></html>")
+                        border.width: 1
+                        border.color: palette.shadow
 
-                Layout.preferredWidth: parent.width
-                wrapMode: Text.WordWrap
-                onLinkActivated: link => Qt.openUrlExternally(link)
-                MouseArea {
-                    anchors.fill: parent
-                    acceptedButtons: Qt.NoButton // Don't eat the mouse clicks
-                    cursorShape: Qt.PointingHandCursor
-                }
-            }
-            Label {
-                Layout.fillWidth: true
-                text: qsTr("Dependencies:")
-                font.bold: true
-                wrapMode: Text.WordWrap
-            }
-            ComboBox {
-                id: projectCombo
-                Component.onCompleted: {
-                    // Force the correct license to be selected on load.
-                    projectCombo.onCurrentIndexChanged();
-                    // onCurrentIndexChanged not called automatically, so we must connect to the appropriate signal.
-                    projectCombo.currentIndexChanged.connect(projectCombo.onCurrentIndexChanged);
-                }
-
-                Layout.fillWidth: true
-                model: Dependencies
-                currentIndex: 0
-                textRole: "name"
-                function onCurrentIndexChanged() {
-                    let index = model.index(currentIndex, 0);
-                    projectLicense.text = model.data(index, DependencyRoles.LicenseText);
-                    let url = model.data(index, DependencyRoles.URL);
-                    projectUrl.text = "<a href=\"" + url + "\">" + url + "</a>";
-                }
-            }
-            Text {
-                id: projectUrl
-                Layout.fillWidth: true
-                color: palette.windowText
-                onLinkActivated: link => {
-                    Qt.openUrlExternally(link);
-                }
-            }
-            TextArea {
-                id: projectLicense
-                Layout.fillWidth: true
-                readOnly: true
-                wrapMode: Text.WordWrap
+                        ScrollView {
+                            anchors.fill: parent
+                            TextArea {
+                                id: license
+                                readOnly: true
+                                text: "qrc:/LICENSE_FULL" //"qrc:/qt/qml/Pepp/LICENSE" //"qrc:/LICENSE_FULL"
+                            }
+                        } //  ScrollView
+                    }
+                } //ColumnLayout
+            } //  Rectangle
+        } //  Item - pepAbout
+        Item {
+            id: changeLog
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            Rectangle {
+                anchors.fill: parent
+                color: palette.base
+                border.width: 1
+                border.color: palette.shadow
+                Text {
+                    // Replace this control with Change control screen
+                    text: "Change Log"
+                } //  End of replacement
             }
         }
-    } //  ScrollView
+        Item {
+            id: thirdParty
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+
+            Rectangle {
+                anchors.fill: parent
+                color: palette.base
+                border.width: 1
+                border.color: palette.shadow
+
+                //  Dependencies
+                ColumnLayout {
+                    anchors.fill: parent
+                    spacing: 0
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.margins: root.sideMargin
+                        Label {
+                            text: qsTr("Third Party Licenses:")
+                            font.bold: true
+                            wrapMode: Text.WordWrap
+                        }
+                        ComboBox {
+                            id: projectCombo
+                            Component.onCompleted: {
+                                // Force the correct license to be selected on load.
+                                projectCombo.onCurrentIndexChanged()
+                                // onCurrentIndexChanged not called automatically, so we must connect to the appropriate signal.
+                                projectCombo.currentIndexChanged.connect(
+                                    projectCombo.onCurrentIndexChanged)
+                            }
+
+                            Layout.fillWidth: true
+                            model: Dependencies
+                            currentIndex: 0
+                            textRole: "name"
+                            function onCurrentIndexChanged() {
+                                let index = model.index(currentIndex, 0)
+                                projectLicense.text = model.data(
+                                            index, DependencyRoles.LicenseText)
+                                let url = model.data(index, DependencyRoles.URL)
+                                projectUrl.text = "<a href=\"" + url + "\">" + url + "</a>"
+                            }
+                        }
+                    } //Row
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.margins: root.sideMargin
+                        Label {
+                            text: qsTr("Link:")
+                            font.bold: true
+                            wrapMode: Text.WordWrap
+                        }
+                        Text {
+                            id: projectUrl
+                            Layout.fillWidth: true
+                            color: palette.windowText
+                            onLinkActivated: link => {
+                                Qt.openUrlExternally(link)
+                            }
+                        }
+                    }
+
+                    ScrollView {
+                        id: sv
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        TextArea {
+                            id: projectLicense
+                            readOnly: true
+                            //wrapMode: Text.WordWrap
+                        }
+                    } //  ScrollView
+                } //ColumnLayout
+            } //  Rectangle
+        } //  Item - third party
+    } //  StackLayout
 }

--- a/lib/help/about/Diagnostics.qml
+++ b/lib/help/about/Diagnostics.qml
@@ -11,18 +11,51 @@ ColumnLayout {
             Qt.openUrlExternally(link);
         }
         Component.onCompleted: {
+            const url = "https://github.com/Matthew-McRaven/Pepp/issues";
+            const l1 = `Report any issues to our <a href=\"${url}\">issue tracker</a>`;
+            const l2 = "Please include a copy of the diagnositc information on this page.";
+
+            text = `${l1}<br/>${l2}`;
+        }
+    }
+
+    Item {
+        implicitHeight: 30
+    }
+
+    Text {
+        onLinkActivated: link => {
+            Qt.openUrlExternally(link);
+        }
+        Component.onCompleted: {
             let url = "https://github.com/Matthew-McRaven/Pepp/commit/" + Version.git_sha;
             text = `Pepp build: <a href=\"${url}\">${Version.git_sha.substring(0, 7)}</a>`;
         }
     }
     Text {
         Component.onCompleted: {
-            text = `Built on: ${Version.build_timestamp}`;
+            text = `Qt Version: ${Version.qt_version},debug=${Version.qt_debug},shared=${Version.qt_shared}`;
         }
     }
     Text {
         Component.onCompleted: {
-            text = `Build OS ID: ${Version.build_system}`;
+            text = `Machine OS: ${Version.target_platform}`;
+        }
+    }
+    Text {
+        Component.onCompleted: {
+            text = `Machine ABI: ${Version.target_abi}`;
+        }
+    }
+
+    Text {
+        Component.onCompleted: {
+            text = `Build date: ${Version.build_timestamp}`;
+        }
+    }
+    Text {
+        Component.onCompleted: {
+            text = `Build OS: ${Version.build_system}`;
         }
     }
     Text {
@@ -34,14 +67,9 @@ ColumnLayout {
         Layout.fillHeight: true
     }
 
-    // Want to know
     // Link to our issue reporting thing. Add a template which tells you to submit a screenshot of this information.
+    // Want to know
     /* OS info;
-     *   Name, version, architecture
      *   Window manager
-     *
-     * Build information:
-     *   Qt build # with URL
-     *   Qt debug/shared/static
      */
 }

--- a/lib/help/about/Diagnostics.qml
+++ b/lib/help/about/Diagnostics.qml
@@ -1,0 +1,47 @@
+pragma ComponentBehavior: Bound
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+import QtQuick.Window
+import edu.pepp 1.0
+
+ColumnLayout {
+    Text {
+        onLinkActivated: link => {
+            Qt.openUrlExternally(link);
+        }
+        Component.onCompleted: {
+            let url = "https://github.com/Matthew-McRaven/Pepp/commit/" + Version.git_sha;
+            text = `Pepp build: <a href=\"${url}\">${Version.git_sha.substring(0, 7)}</a>`;
+        }
+    }
+    Text {
+        Component.onCompleted: {
+            text = `Built on: ${Version.build_timestamp}`;
+        }
+    }
+    Text {
+        Component.onCompleted: {
+            text = `Build OS ID: ${Version.build_system}`;
+        }
+    }
+    Text {
+        Component.onCompleted: {
+            text = `Compiler ID: ${Version.cxx_compiler}`;
+        }
+    }
+    Item {
+        Layout.fillHeight: true
+    }
+
+    // Want to know
+    // Link to our issue reporting thing. Add a template which tells you to submit a screenshot of this information.
+    /* OS info;
+     *   Name, version, architecture
+     *   Window manager
+     *
+     * Build information:
+     *   Qt build # with URL
+     *   Qt debug/shared/static
+     */
+}

--- a/lib/help/about/Diagnostics.qml
+++ b/lib/help/about/Diagnostics.qml
@@ -13,7 +13,7 @@ ColumnLayout {
         Component.onCompleted: {
             const url = "https://github.com/Matthew-McRaven/Pepp/issues";
             const l1 = `Report any issues to our <a href=\"${url}\">issue tracker</a>`;
-            const l2 = "Please include a copy of the diagnositc information on this page.";
+            const l2 = "Please include a copy of the diagnostic information on this page.";
 
             text = `${l1}<br/>${l2}`;
         }

--- a/lib/help/about/git.cmake
+++ b/lib/help/about/git.cmake
@@ -283,3 +283,5 @@ function(git_local_changes _var)
             PARENT_SCOPE)
     endif()
 endfunction()
+
+string(TIMESTAMP BUILD_TIMESTAMP "%b %d %Y %H:%M:%S")

--- a/lib/help/about/version.cpp
+++ b/lib/help/about/version.cpp
@@ -33,6 +33,9 @@ QString about::Version::build_timestamp() {
 }
 
 QString about::Version::qt_version() { return QLibraryInfo::version().toString(); }
+QString about::Version::qt_debug() { return QLibraryInfo::isDebugBuild() ? "true" : "false"; }
+QString about::Version::qt_shared() { return QLibraryInfo::isSharedBuild() ? "true" : "false"; }
+
 QString about::Version::cxx_compiler() {
   static const auto ret = QStringLiteral("%1 %2").arg(about::g_CXX_COMPILER_ID()).arg(about::g_CXX_COMPILER_VERSION());
   return ret;
@@ -43,5 +46,15 @@ QString about::Version::build_system() {
                               .arg(about::g_BUILD_SYSTEM_NAME())
                               .arg(about::g_BUILD_SYSTEM_VERSION())
                               .arg(about::g_BUILD_SYSTEM_PROCESSOR());
+  return ret;
+}
+
+QString about::Version::target_platform() {
+  static const auto ret = QStringLiteral("%1").arg(QSysInfo::prettyProductName());
+  return ret;
+}
+
+QString about::Version::target_abi() {
+  static const auto ret = QStringLiteral("%1").arg(QSysInfo::buildAbi());
   return ret;
 }

--- a/lib/help/about/version.cpp
+++ b/lib/help/about/version.cpp
@@ -26,3 +26,22 @@ QString about::Version::version_str_full() {
   using namespace Qt::StringLiterals;
   return u"%1.%2.%3"_s.arg(version_major()).arg(version_minor()).arg(version_patch());
 }
+
+QString about::Version::build_timestamp() {
+  using namespace Qt::StringLiterals;
+  return u"%1"_s.arg(about::g_BUILD_TIMESTAMP());
+}
+
+QString about::Version::qt_version() { return QLibraryInfo::version().toString(); }
+QString about::Version::cxx_compiler() {
+  static const auto ret = QStringLiteral("%1 %2").arg(about::g_CXX_COMPILER_ID()).arg(about::g_CXX_COMPILER_VERSION());
+  return ret;
+}
+
+QString about::Version::build_system() {
+  static const auto ret = QStringLiteral("%1 %2 %3")
+                              .arg(about::g_BUILD_SYSTEM_NAME())
+                              .arg(about::g_BUILD_SYSTEM_VERSION())
+                              .arg(about::g_BUILD_SYSTEM_PROCESSOR());
+  return ret;
+}

--- a/lib/help/about/version.hpp
+++ b/lib/help/about/version.hpp
@@ -21,6 +21,12 @@
 namespace about {
 const char *const g_GIT_SHA1();
 const char *const g_GIT_TAG();
+const char *g_CXX_COMPILER_ID();
+const char *g_CXX_COMPILER_VERSION();
+const char *g_BUILD_SYSTEM_NAME();
+const char *g_BUILD_SYSTEM_VERSION();
+const char *g_BUILD_SYSTEM_PROCESSOR();
+const char *g_BUILD_TIMESTAMP();
 int g_MAJOR_VERSION();
 int g_MINOR_VERSION();
 int g_PATCH_VERSION();
@@ -28,6 +34,7 @@ bool g_GIT_LOCAL_CHANGES();
 
 class Version : public QObject {
   Q_OBJECT
+  // Properties of pepp
   Q_PROPERTY(QString git_sha READ git_sha CONSTANT)
   Q_PROPERTY(QString git_tag READ git_tag CONSTANT)
   Q_PROPERTY(bool git_dirty READ git_dirty CONSTANT)
@@ -35,6 +42,12 @@ class Version : public QObject {
   Q_PROPERTY(int version_minor READ version_minor CONSTANT)
   Q_PROPERTY(int version_patch READ version_patch CONSTANT)
   Q_PROPERTY(QString version_str_full READ version_str_full CONSTANT)
+  Q_PROPERTY(QString build_timestamp READ build_timestamp CONSTANT)
+  // Properties of our dependencies
+  Q_PROPERTY(QString qt_version READ qt_version CONSTANT)
+  // Properties of our build system
+  Q_PROPERTY(QString cxx_compiler READ cxx_compiler CONSTANT)
+  Q_PROPERTY(QString build_system READ build_system CONSTANT)
   QML_ELEMENT
   QML_SINGLETON
 
@@ -48,6 +61,12 @@ public:
   static int version_minor();
   static int version_patch();
   static QString version_str_full();
+  static QString build_timestamp();
+
+  static QString qt_version();
+
+  static QString cxx_compiler();
+  static QString build_system();
 };
 
 } // namespace about

--- a/lib/help/about/version.hpp
+++ b/lib/help/about/version.hpp
@@ -43,8 +43,13 @@ class Version : public QObject {
   Q_PROPERTY(int version_patch READ version_patch CONSTANT)
   Q_PROPERTY(QString version_str_full READ version_str_full CONSTANT)
   Q_PROPERTY(QString build_timestamp READ build_timestamp CONSTANT)
+  // Properties of the machine running the application
+  Q_PROPERTY(QString target_platform READ target_platform CONSTANT)
+  Q_PROPERTY(QString target_abi READ target_abi CONSTANT)
   // Properties of our dependencies
   Q_PROPERTY(QString qt_version READ qt_version CONSTANT)
+  Q_PROPERTY(QString qt_debug READ qt_debug CONSTANT)
+  Q_PROPERTY(QString qt_shared READ qt_shared CONSTANT)
   // Properties of our build system
   Q_PROPERTY(QString cxx_compiler READ cxx_compiler CONSTANT)
   Q_PROPERTY(QString build_system READ build_system CONSTANT)
@@ -62,8 +67,12 @@ public:
   static int version_patch();
   static QString version_str_full();
   static QString build_timestamp();
+  static QString target_platform();
+  static QString target_abi();
 
   static QString qt_version();
+  static QString qt_debug();
+  static QString qt_shared();
 
   static QString cxx_compiler();
   static QString build_system();

--- a/lib/help/about/version_gen.cpp.in
+++ b/lib/help/about/version_gen.cpp.in
@@ -29,9 +29,36 @@ const char *const about::g_GIT_TAG() { return GIT_TAG_tmp; }
 #define VERSION_MINOR @Pepp_VERSION_MINOR@
 #define VERSION_PATCH @Pepp_VERSION_PATCH@
 #define CLEAN @GIT_CLEAN@
+#define CXX_COMPILER_ID "@CMAKE_CXX_COMPILER_ID@"
+#define CXX_COMPILER_VERSION "@CMAKE_CXX_COMPILER_VERSION@"
+#define BUILD_SYSTEM_NAME "@CMAKE_HOST_SYSTEM_NAME@"
+#define BUILD_SYSTEM_VERSION "@CMAKE_HOST_SYSTEM_VERSION@"
+#define BUILD_SYSTEM_PROCESSOR "@CMAKE_HOST_SYSTEM_PROCESSOR@"
+#define BUILD_TIMESTAMP "@BUILD_TIMESTAMP@"
 // clang-format on
 
 int about::g_MAJOR_VERSION() { return VERSION_MAJOR; }
 int about::g_MINOR_VERSION() { return VERSION_MINOR; }
 int about::g_PATCH_VERSION() { return VERSION_PATCH; }
 bool about::g_GIT_LOCAL_CHANGES() { return CLEAN; }
+const char* about::g_CXX_COMPILER_ID() {
+    return CXX_COMPILER_ID;
+}
+
+const char* about::g_CXX_COMPILER_VERSION() {
+    return CXX_COMPILER_VERSION;
+}
+
+const char* about::g_BUILD_SYSTEM_NAME() {
+    return BUILD_SYSTEM_NAME;
+}
+const char* about::g_BUILD_SYSTEM_VERSION() {
+    return BUILD_SYSTEM_VERSION;
+}
+const char* about::g_BUILD_SYSTEM_PROCESSOR() {
+    return BUILD_SYSTEM_PROCESSOR;
+}
+const char* about::g_BUILD_TIMESTAMP() {
+    return BUILD_TIMESTAMP;
+}
+

--- a/lib/help/builtins/helpdata.cpp
+++ b/lib/help/builtins/helpdata.cpp
@@ -6,18 +6,6 @@
 using namespace Qt::StringLiterals;
 constexpr int shift = 16;
 
-QSharedPointer<HelpEntry> about_root() {
-  // relative to this the directroy in which HelpRoot.qml is located.
-  auto ret = QSharedPointer<HelpEntry>::create(HelpCategory::Category::About, -1, "About", "../about/About.qml");
-  QList<QSharedPointer<HelpEntry>> children;
-  if (auto changedb = QFileInfo(":/changelog/changelog.db"); changedb.exists()) {
-    children.append(
-        QSharedPointer<HelpEntry>::create(HelpCategory::Category::About, -1, "Changelog", "ChangelogViewer.qml"));
-  }
-  if (children.size() != 0) ret->addChildren(children);
-  return ret;
-}
-
 QSharedPointer<HelpEntry> writing_root() {
   using enum pepp::Architecture;
   using enum pepp::Abstraction;
@@ -112,7 +100,7 @@ QString removeLeading0(const QString &str) {
 QSharedPointer<HelpEntry> examples_root(const builtins::Registry &reg) {
   auto books = reg.books();
   QList<QSharedPointer<HelpEntry>> children;
-  for (const auto &book : books) {
+  for (const auto &book : std::as_const(books)) {
     for (const auto &figure : book->figures()) {
       // Skip explicitly hidden figures (like the assembler).
       if (figure->isHidden()) continue;

--- a/lib/help/builtins/helpdata.hpp
+++ b/lib/help/builtins/helpdata.hpp
@@ -6,7 +6,6 @@ namespace builtins {
 class Registry;
 }
 class HelpEntry;
-QSharedPointer<HelpEntry> about_root();
 QSharedPointer<HelpEntry> writing_root();
 QSharedPointer<HelpEntry> debugging_root();
 QSharedPointer<HelpEntry> systemcalls_root();

--- a/lib/help/builtins/helpmodel.cpp
+++ b/lib/help/builtins/helpmodel.cpp
@@ -22,8 +22,8 @@ HelpModel::HelpModel(QObject *parent) : QAbstractItemModel{parent} {
 
   // If you update the following array, YOU MUST UPDATE THE INDEX OF VARIABLE TOO!!!
   _roots = {
-      writing_root(),       debugging_root(),   systemcalls_root(), greencard10_root(),
-      examples_root(*_reg), macros_root(*_reg), about_root(),
+      writing_root(),     debugging_root(),     systemcalls_root(),
+      greencard10_root(), examples_root(*_reg), macros_root(*_reg),
   };
   _indexOfFigs = 4;
   _indexOfMacros = 5;

--- a/lib/menu/NativeMainMenu.qml
+++ b/lib/menu/NativeMainMenu.qml
@@ -236,11 +236,6 @@ Labs.MenuBar {
             icon.source: fixSuffix(actions.build.execute.icon.source, wrapper.darkMode)
             shortcut: actions.build.execute.shortcut
         }
-        Labs.MenuSeparator {}
-        Labs.MenuItem {
-            text: actions.help.about.text
-            onTriggered: actions.help.about.trigger()
-        }
     }
     Labs.Menu {
         title: qsTr("&Debug")
@@ -314,6 +309,13 @@ Labs.MenuBar {
         Labs.MenuItem {
             text: actions.view.fullscreen.text
             onTriggered: actions.view.fullscreen.trigger()
+        }
+    }
+    Labs.Menu {
+        title: qsTr("&Help")
+        Labs.MenuItem {
+            text: actions.help.about.text
+            onTriggered: actions.help.about.trigger()
         }
     }
     // Only meant for testing the app, not meant for deployment to users!


### PR DESCRIPTION
- Split _our_ licensing information from that of our dependencies. While I want a prominent list of dependencies, licenses, and links, it takes up too much space on the page.
- Move help's change log to about. With this change, we can remove all of the `about` info from our help system.
- Add a diagnostic information tab, which users can screenshot and place in issues that they open. This should make it easier to exactly identify broke builds & environment issues.