### PR TITLE
Restyle `Help` mode content item

### DIFF
--- a/lib/help/builtins/Figure2.qml
+++ b/lib/help/builtins/Figure2.qml
@@ -53,7 +53,7 @@ Item {
 
     ColumnLayout {
         id: figureLayout
-        spacing: 10
+        spacing: 0
         anchors.fill: parent
         ComboBox {
             id: fragmentSelector
@@ -141,20 +141,26 @@ Item {
                 textArea.readOnly = true;
             }
         }
-        Row {
+        RowLayout {
             id: copyRow
-            Layout.alignment: Qt.AlignBottom
-            Layout.preferredHeight: 20
-            Layout.maximumHeight: 30
+
+            Layout.preferredHeight: button.height
+            Layout.minimumHeight: Layout.preferredHeight
+            Layout.maximumHeight: helpText.contentHeight
             Layout.fillWidth: true
-            spacing: 10
+            spacing: 0
             //  Copy button logic
             Button {
                 id: button
                 visible: enabled
                 enabled: wrapper.payload.defaultFragmentName.length > 0
                 text: "Copy to New Project"
-                anchors.horizontalCenter: copyRow.center
+                topPadding: 5
+                bottomPadding: 5
+
+                Layout.alignment: Qt.AlignVCenter
+                Layout.fillHeight: true
+
                 onClicked: {
                     const pl = wrapper.payload;
                     const name = pl.defaultFragmentName;
@@ -165,9 +171,14 @@ Item {
             }
             //  Figure title
             Text {
-                width: copyRow.width - button.width - copyRow.spacing
+                id: helpText
+                Layout.leftMargin: 10
+                Layout.fillHeight: true
+                Layout.fillWidth: true
+
                 textFormat: Text.RichText
                 text: "<b>" + wrapper.title + ":</b> " + wrapper.payload.description
+                color: palette.windowText
                 wrapMode: Text.WordWrap
             }
         }

--- a/lib/help/builtins/Figure2.qml
+++ b/lib/help/builtins/Figure2.qml
@@ -55,79 +55,101 @@ Item {
         id: figureLayout
         spacing: 0
         anchors.fill: parent
-        ComboBox {
-            id: fragmentSelector
+        RowLayout {
             Layout.alignment: Qt.AlignTop
             Layout.preferredHeight: Math.max(35, fragmentSelectorFM.height)
+            Layout.minimumHeight: Layout.preferredHeight
+            Layout.maximumHeight: Layout.preferredHeight
             Layout.preferredWidth: parent.width
             Layout.fillWidth: true
-            textRole: "key"
-            valueRole: "value"
-            font: fragmentSelectorFM.font
-            FontMetrics {
-                id: fragmentSelectorFM
-                font.pointSize: 25
-            }
-
-            model: ListModel {
-                id: fragmentModel
-            }
-            delegate: ItemDelegate {
-                id: delegate
-                required property var model
-                required property int index
-                width: fragmentSelector.width
-                contentItem: Text {
-                    text: delegate.model[fragmentSelector.textRole]
-                    //  Text color in dropdown
-                    color: fragmentSelector.highlightedIndex === index ? palette.window : palette.dark
-                    font.pointSize: 12
-                    elide: Text.ElideRight
-                    verticalAlignment: Text.AlignVCenter
+            spacing: 0
+            ComboBox {
+                id: fragmentSelector
+                Layout.fillHeight: true
+                textRole: "key"
+                valueRole: "value"
+                font: fragmentSelectorFM.font
+                FontMetrics {
+                    id: fragmentSelectorFM
+                    font.pointSize: 25
                 }
-                highlighted: fragmentSelector.highlightedIndex === index
-            }
-            indicator: Canvas {
-                id: canvas
-                x: fragmentSelector.width - width - fragmentSelector.rightPadding
-                y: fragmentSelector.topPadding + (fragmentSelector.availableHeight - height) / 2
-                width: 12
-                height: 8
-                contextType: "2d"
 
-                Connections {
-                    target: fragmentSelector
-                    function onPressedChanged() {
-                        canvas.requestPaint();
+                model: ListModel {
+                    id: fragmentModel
+                }
+                delegate: ItemDelegate {
+                    id: delegate
+                    required property var model
+                    required property int index
+                    width: fragmentSelector.width
+                    contentItem: Text {
+                        text: delegate.model[fragmentSelector.textRole]
+                        //  Text color in dropdown
+                        color: fragmentSelector.highlightedIndex === index ? palette.window : palette.dark
+                        font.pointSize: 12
+                        elide: Text.ElideRight
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    highlighted: fragmentSelector.highlightedIndex === index
+                }
+                indicator: Canvas {
+                    id: canvas
+                    x: fragmentSelector.width - width - fragmentSelector.rightPadding
+                    y: fragmentSelector.topPadding + (fragmentSelector.availableHeight - height) / 2
+                    width: 12
+                    height: 8
+                    contextType: "2d"
+
+                    Connections {
+                        target: fragmentSelector
+                        function onPressedChanged() {
+                            canvas.requestPaint();
+                        }
+                    }
+
+                    onPaint: {
+                        context.reset();
+                        context.moveTo(0, 0);
+                        context.lineTo(width, 0);
+                        context.lineTo(width / 2, height);
+                        context.closePath();
+                        context.fillStyle = fragmentSelector.pressed ? Qt.black : "#ff7d33";
+                        context.fill();
                     }
                 }
-
-                onPaint: {
-                    context.reset();
-                    context.moveTo(0, 0);
-                    context.lineTo(width, 0);
-                    context.lineTo(width / 2, height);
-                    context.closePath();
-                    context.fillStyle = fragmentSelector.pressed ? Qt.black : "#ff7d33";
-                    context.fill();
+                contentItem: Text {
+                    leftPadding: 0
+                    rightPadding: fragmentSelector.indicator.width + fragmentSelector.spacing
+                    text: fragmentSelector.displayText
+                    font: fragmentSelector.font
+                    color: palette.text
+                    verticalAlignment: Text.AlignVCenter
+                    elide: Text.ElideRight
                 }
+                onActivated: textArea.updateText(currentValue)
+            }   //  ComboBox
+            Rectangle {
+                color: palette.window
+                //  Hide all but top line
+                Layout.leftMargin: -1
+                Layout.rightMargin: -1
+                Layout.topMargin: -1
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                border {
+                    width: 1
+                    color: palette.shadow
+                }
+                z: -1
+
             }
-            contentItem: Text {
-                leftPadding: 0
-                rightPadding: fragmentSelector.indicator.width + fragmentSelector.spacing
-                text: fragmentSelector.displayText
-                font: fragmentSelector.font
-                color: palette.text
-                verticalAlignment: Text.AlignVCenter
-                elide: Text.ElideRight
-            }
-            onActivated: textArea.updateText(currentValue)
-        }
+        }   //  RowLayout
         Editor.ScintillaAsmEdit {
             id: textArea
             Layout.alignment: Qt.AlignCenter
             Layout.fillHeight: true
             Layout.fillWidth: true
+            Layout.rightMargin: 1
             editorFont: editorFM.font
             language: wrapper.lexerLang
             readOnly: false
@@ -141,47 +163,56 @@ Item {
                 textArea.readOnly = true;
             }
         }
-        RowLayout {
-            id: copyRow
-
+        Rectangle {
             Layout.preferredHeight: button.height
             Layout.minimumHeight: Layout.preferredHeight
-            Layout.maximumHeight: helpText.contentHeight
+            Layout.maximumHeight: Math.max(button.height, helpText.contentHeight)
             Layout.fillWidth: true
-            spacing: 0
-            //  Copy button logic
-            Button {
-                id: button
-                visible: enabled
-                enabled: wrapper.payload.defaultFragmentName.length > 0
-                text: "Copy to New Project"
-                topPadding: 5
-                bottomPadding: 5
-
-                Layout.alignment: Qt.AlignVCenter
-                Layout.fillHeight: true
-
-                onClicked: {
-                    const pl = wrapper.payload;
-                    const name = pl.defaultFragmentName;
-                    const text = pl.fragments[name].content;
-                    wrapper.addProject("", text, "Editor", pl?.defaultOS?.fragments["pep"]?.content, pl?.tests);
-                    wrapper.renameCurrentProject(wrapper.title);
-                }
+            color: palette.window
+            border {
+                width: 1
+                color: palette.shadow
             }
-            //  Figure title
-            Text {
-                id: helpText
-                Layout.leftMargin: 10
-                Layout.fillHeight: true
-                Layout.fillWidth: true
 
-                textFormat: Text.RichText
-                text: "<b>" + wrapper.title + ":</b> " + wrapper.payload.description
-                color: palette.windowText
-                wrapMode: Text.WordWrap
-            }
-        }
+             //  Copy button logic
+            RowLayout {
+                spacing: 0
+                anchors.left: parent.left
+                anchors.right: parent.right
+                Button {
+                    id: button
+                    visible: enabled
+                    enabled: wrapper.payload.defaultFragmentName.length > 0
+                    text: "Copy to New Project"
+                    padding: 5
+
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.fillHeight: true
+                    Layout.minimumWidth: 50//button.width
+
+                    onClicked: {
+                        const pl = wrapper.payload;
+                        const name = pl.defaultFragmentName;
+                        const text = pl.fragments[name].content;
+                        wrapper.addProject("", text, "Editor", pl?.defaultOS?.fragments["pep"]?.content, pl?.tests);
+                        wrapper.renameCurrentProject(wrapper.title);
+                    }
+                }   //  Button
+
+                //  Figure title
+                Text {
+                    id: helpText
+
+                    Layout.leftMargin: 10
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    textFormat: Text.RichText
+                    text: "<b>" + wrapper.title + ":</b> " + wrapper.payload.description
+                    color: palette.windowText
+                    wrapMode: Text.WordWrap
+                }   //  Text - figure title
+            }   //  RowLayout
+        }   //  Rectangle - figure backgound
     }
     FontMetrics {
         id: editorFM

--- a/lib/help/builtins/HelpRoot.qml
+++ b/lib/help/builtins/HelpRoot.qml
@@ -207,7 +207,7 @@ Item {
         }
         color: palette.base
         border {
-            color: palette.windowText
+            color: palette.shadow
             width: 1
         }
 
@@ -217,7 +217,7 @@ Item {
             clip: true
             anchors {
                 fill: parent
-                margins: 1
+                margins: 0
             }
             Loader {
                 id: contentLoader
@@ -242,7 +242,7 @@ Item {
                 }
                 onLoaded: {
                     // Offset by some small amount to disappear scrollbar when content is not large enough.
-                    const height = Math.max(contentFlickable.height - 1, contentLoader?.item?.implicitHeight ?? 0);
+                    const height = Math.max(contentFlickable.height /*- 1*/, contentLoader?.item?.implicitHeight ?? 0);
                     contentFlickable.contentHeight = Qt.binding(() => height);
                 }
             }   //  Loader

--- a/lib/help/builtins/HelpRoot.qml
+++ b/lib/help/builtins/HelpRoot.qml
@@ -194,48 +194,60 @@ Item {
             }
         }
     }
-    Flickable {
-        id: contentFlickable
+    //  Background
+    Rectangle {
         anchors {
             left: controlPanel.right
             top: parent.top
             right: parent.right
             bottom: parent.bottom
             topMargin: 0
-            leftMargin: 20
+            leftMargin: 10
             rightMargin: 20
-            bottomMargin: 20
         }
-        ScrollBar.vertical: ScrollBar {}
-        clip: true
-        Loader {
-            id: contentLoader
-            anchors.fill: parent
-            Connections {
-                target: contentLoader.item
-
-                function onAddProject(feats, texts, mode, os, tests) {
-                    const abs = filterModel.get(filterCombo.currentIndex).value.abstraction;
-                    const arch = filterModel.get(filterCombo.currentIndex).value.architecture;
-                    root.addProject(arch, abs, feats, texts, true);
-                    if (tests && tests[0])
-                        root.setCharIn(tests[0].input);
-                    root.switchToMode(mode ?? "Editor");
-                }
-
-                function onRenameCurrentProject(name) {
-                    root.renameCurrentProject(name);
-                }
-
-                ignoreUnknownSignals: true
-            }
-            onLoaded: {
-                // Offset by some small amount to disappear scrollbar when content is not large enough.
-                const height = Math.max(contentFlickable.height - 1, contentLoader?.item?.implicitHeight ?? 0);
-                contentFlickable.contentHeight = Qt.binding(() => height);
-            }
+        color: palette.base
+        border {
+            color: palette.windowText
+            width: 1
         }
-    }
+
+        Flickable {
+            id: contentFlickable
+            ScrollBar.vertical: ScrollBar {}
+            clip: true
+            anchors {
+                fill: parent
+                margins: 1
+            }
+            Loader {
+                id: contentLoader
+                anchors.fill: parent
+                Connections {
+                    target: contentLoader.item
+
+                    function onAddProject(feats, texts, mode, os, tests) {
+                        const abs = filterModel.get(filterCombo.currentIndex).value.abstraction;
+                        const arch = filterModel.get(filterCombo.currentIndex).value.architecture;
+                        root.addProject(arch, abs, feats, texts, true);
+                        if (tests && tests[0])
+                            root.setCharIn(tests[0].input);
+                        root.switchToMode(mode ?? "Editor");
+                    }
+
+                    function onRenameCurrentProject(name) {
+                        root.renameCurrentProject(name);
+                    }
+
+                    ignoreUnknownSignals: true
+                }
+                onLoaded: {
+                    // Offset by some small amount to disappear scrollbar when content is not large enough.
+                    const height = Math.max(contentFlickable.height - 1, contentLoader?.item?.implicitHeight ?? 0);
+                    contentFlickable.contentHeight = Qt.binding(() => height);
+                }
+            }   //  Loader
+        }   //  Flickable
+    }   //  Rectangle - background
 
     signal addProject(int level, int abstraction, string feats, var text, bool reuse)
 


### PR DESCRIPTION
Central help content item should have a background color of white (depending on the current palette) and a border that matches the tree view. This should appear more modern than black text on a grey background.