### PR TITLE
Use flat style with onHover outlines for

### DIFF
--- a/lib/top/SideBar.qml
+++ b/lib/top/SideBar.qml
@@ -67,19 +67,11 @@ Column {
             display: AbstractButton.TextUnderIcon
 
             background: Rectangle {
-                border.width: del.borderSize
+                border.width: del.hovered ? del.borderSize : 0
                 border.color: palette.shadow
                 anchors.leftMargin: 4
-                gradient: Gradient {
-                    GradientStop {
-                        position: 0
-                        color: del.down ? palette.highlight : (del.checked ? palette.button.darker(1.3) : palette.light.lighter(1.1))
-                    }
-                    GradientStop {
-                        position: 1
-                        color: del.down ? palette.highlight : (del.checked ? palette.button.darker(1.4) : palette.light.darker(1.1))
-                    }
-                }
+                //  Show selected button color first. Show hover box second. Otherwise, use default
+                color: del.checked ? palette.button.lighter(1.2) : (del.hovered ? palette.highlight : palette.button)
             }
             Rectangle {
                 visible: del.checked

--- a/lib/top/SideBar.qml
+++ b/lib/top/SideBar.qml
@@ -53,7 +53,7 @@ Column {
         model: root.modesModel ?? defaultSidebarModel
         delegate: Button {
             id: del
-            property int borderSize: 1
+            property int borderSize: 2
             enabled: root.enabled
             checkable: true
             width: 100
@@ -67,11 +67,11 @@ Column {
             display: AbstractButton.TextUnderIcon
 
             background: Rectangle {
-                border.width: del.hovered ? del.borderSize : 0
-                border.color: palette.shadow
+                border.width: (del.hovered && !del.checked) ? del.borderSize : 0
+                border.color: (del.hovered && !del.checked) ? palette.highlight : palette.shadow
                 anchors.leftMargin: 4
                 //  Show selected button color first. Show hover box second. Otherwise, use default
-                color: del.checked ? palette.button.lighter(1.2) : (del.hovered ? palette.highlight : palette.button)
+                color: del.checked ? palette.button.lighter(1.2) : palette.button
             }
             Rectangle {
                 visible: del.checked
@@ -83,6 +83,7 @@ Column {
                 anchors.bottomMargin: del.borderSize
                 width: 4
                 color: palette.highlight
+                radius: del.borderSize
             }
         }
     }


### PR DESCRIPTION
This roughly mimics existing, flat styles with an indicator for active items (an example from Qt Creator on Mac OS shown below). It remove unnecessary visual clutter in the form of a gradient over a button and the associated button border colors.

<img width="73" height="376" alt="Screenshot 2025-08-08 at 19 02 57" src="https://github.com/user-attachments/assets/3ee50b6c-3e53-4675-8837-c7d91aa8d541" />

These changes are made to make the sidebar less busy while retaining clear indicators of the active mode.