### PR TITLE
Fix background colors on DockTabBar

### DIFF
--- a/lib/top/DockTabBar.qml
+++ b/lib/top/DockTabBar.qml
@@ -117,7 +117,7 @@ KDDW.TabBarBase {
                 required property string title
                 readonly property int tabIndex: index
                 property color error: settings.extPalette.error.background
-                property real flashFactor: warningLogic.flashFactor
+                property alias flashFactor: warningLogic.flashFactor
                 property color flashColor: Qt.rgba(error.r, error.g, error.b, flashFactor)
                 property var dockObj: tabBarCpp.dockWidgetObject(index)
                 text: title


### PR DESCRIPTION
Keep original (Fusion style) background, and overlay error background when needsAttention event fires.

Amended by Matthew to remove refs to Fusion, since I do not expect fusion to work in WASM.