### PR TITLE
Reorder abstractions table

### DIFF
--- a/data/help/start/abstractions.html
+++ b/data/help/start/abstractions.html
@@ -31,16 +31,6 @@
           <th>Notes</th>
         </tr>
         <tr>
-          <td><b>Mc2</b></td>
-          <td>Micro Code</td>
-          <td>11</td>
-          <td>
-            Microcode controls the CPU’s datapath; used to implement the
-            fetch–execute cycle and define instruction behavior at the hardware
-            control level.
-          </td>
-        </tr>
-        <tr>
           <td><b>ISA3</b></td>
           <td>Instruction Set Architecture</td>
           <td>4</td>
@@ -59,6 +49,16 @@
           </td>
         </tr>
         <tr>
+          <td><b>Asmb5</b></td>
+          <td>Assembly Language, with full OS</td>
+          <td>6</td>
+          <td>
+            Assembly programs using system calls; may be generated from
+            high-level languages like C, emphasizing translation and runtime
+            services.
+          </td>
+        </tr>
+        <tr>
           <td><b>OS4</b></td>
           <td>Operating System</td>
           <td>8</td>
@@ -68,13 +68,13 @@
           </td>
         </tr>
         <tr>
-          <td><b>Asmb5</b></td>
-          <td>Assembly Language, with full OS</td>
-          <td>6</td>
+          <td><b>Mc2</b></td>
+          <td>Micro Code</td>
+          <td>11</td>
           <td>
-            Assembly programs using system calls; may be generated from
-            high-level languages like C, emphasizing translation and runtime
-            services.
+            Microcode controls the CPU’s datapath; used to implement the
+            fetch–execute cycle and define instruction behavior at the hardware
+            control level.
           </td>
         </tr>
       </table>


### PR DESCRIPTION
Follow the order that they are introduced in the book, not from lowest->highest.