### PR TITLE
Rename `CPU Dump` to `CPU`

### DIFF
--- a/lib/project/Pep10ASMB.qml
+++ b/lib/project/Pep10ASMB.qml
@@ -451,7 +451,7 @@ FocusScope {
         KDDW.DockWidget {
             id: dock_cpu
 
-            title: "CPU Dump"
+            title: "CPU"
             uniqueName: `RegisterDump-${dockWidgetArea.uniqueName}`
             property var visibility: {
                 "editor": false,

--- a/lib/project/Pep10ISA.qml
+++ b/lib/project/Pep10ISA.qml
@@ -226,7 +226,7 @@ FocusScope {
         KDDW.DockWidget {
             id: dock_cpu
 
-            title: "CPU Dump"
+            title: "CPU"
             uniqueName: `RegisterDump-${dockWidgetArea.uniqueName}`
             property var visibility: {
                 "editor": false,


### PR DESCRIPTION
#915 renamed `Register Dump` to `CPU Dump`.
This commit removes "Dump" from its name.