### PR TITLE
Use standard behavior for tree navigation in help

### DIFF
--- a/lib/help/builtins/HelpRoot.qml
+++ b/lib/help/builtins/HelpRoot.qml
@@ -190,8 +190,10 @@ Item {
                     function onNavigateTo(link) {
                         if (link.startsWith("slug:")) {
                             const idx = helpModel.indexFromSlug(link);
-                            if (idx.valid)
+                            if (idx.valid) {
                                 root.selected = Qt.binding(() => idx);
+                                treeView.expandToIndex(root.selected);
+                            }
                         } else
                             Qt.openUrlExternally(link);
                     }

--- a/lib/help/builtins/HelpRoot.qml
+++ b/lib/help/builtins/HelpRoot.qml
@@ -112,6 +112,8 @@ Item {
             delegate: TreeViewDelegate {
                 id: treeDelegate
                 implicitWidth: textMetrics.width
+                font: textMetrics.font
+
                 Component.onCompleted: {
                     contentItem.textFormat = Text.MarkdownText;
                 }
@@ -130,20 +132,11 @@ Item {
                         width: 2
                     }
                 }
-                onCurrentChanged: {
-                    if (current) {
-                        makeActive();
-                    }
-                }
-                onClicked: {
-                    makeActive();
-                    if (treeView.isExpanded(row)) {
-                        treeView.collapseRecursively(row);
-                    } else {
-                        treeView.expandRecursively(row);
-                    }
-                }
-                font: textMetrics.font
+
+                //  Cannot override collapse or expand in onClicked, or it overrides default
+                //  control behavior.
+                onClicked: makeActive();
+
                 function makeActive() {
                     root.selected = treeDelegate.treeView.index(row, column);
                     treeDelegate.treeView.selectionModel.setCurrentIndex(root.selected, ItemSelectionModel.NoUpdate);


### PR DESCRIPTION
- Clicking an item should focus it, not expand it.
- Clicking the arrow next to the item should expand it but not focus it.
- Double click an item should expand/collapse it
- Navigating to an item should recursively expand the item up to the root. Otherwise, the selected item may not be visible in the tree view