### PR TITLE
Handle non-0 exit codes in installer for MSVC redistributable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ if (ONLY STREQUAL "BUILD")
           DOWNLOAD_NO_EXTRACT TRUE
           DOWNLOAD_NAME "VC_redist.x64.exe"
         )
-        FetchContent_Populate(vcredist_x64)
+        FetchContent_MakeAvailable(vcredist_x64)
         set(VCREDIST14_X64_EXE "${vcredist_x64_SOURCE_DIR}/VC_redist.x64.exe")
         if(NOT EXISTS "${VCREDIST14_X64_EXE}")
             message(FATAL_ERROR "Failed to fetch VC_redist.x64.exe: ${VCREDIST14_X64_EXE}")

--- a/config/installer/vcredist.qs
+++ b/config/installer/vcredist.qs
@@ -7,7 +7,17 @@ Component.prototype.createOperations = function() {
     var base = installer.value("TargetDir") + "/vcredist/";
     var exe = base + "VC_redist.x64.exe";
 
-    console.log("Installing Visual C++ Redistributable from " + exe);
-    // Run quietly and elevated; suppress reboot.
-    component.addElevatedOperation("Execute", exe, "/install", "/quiet", "/norestart");
+    // Treat these as success:
+    // 0    : success
+    // 3010 : success, reboot required
+    // 5100 : vcredist-specific “newer/blocked”
+    try {
+      component.addElevatedOperation(
+          "Execute",
+          "{0,3010,5100}",
+          exe, "/install", "/quiet", "/norestart"
+      );
+    } catch (e) {
+      console.log(e)
+    }
 };


### PR DESCRIPTION
Just eat these errors for now, since Qt IFW is generally a pain to get exit codes out of.