### PR TITLE
build: upgrade deployments to use Qt 6.9.3

### DIFF
--- a/.github/actions/install-qt-cmake/action.yml
+++ b/.github/actions/install-qt-cmake/action.yml
@@ -2,7 +2,7 @@ name: 'Install CMake & Qt'
 inputs:
   qt_version:
     required: true
-    default: '6.9.1'
+    default: '6.9.3'
   cache-key-prefix:
     required: false
 runs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/matthew-mcraven/pepp/image-utils:v0.15.3
+      image: ghcr.io/matthew-mcraven/pepp/image-utils:v0.15.4
     steps:
       - uses: actions/checkout@v4
         # LFS defaults to disabled, but accidental LFS bandwidth would be bad.
@@ -118,10 +118,10 @@ jobs:
       # Trying to use `env` or inputs will fail in this context.
       matrix:
         config:
-          - { name: "Ubuntu 22.04; GCC", cache_name: 'ubuntu-gcc', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/gcc:v0.15.3", compiler_launcher: "ccache", compiler_c: "", compiler_cpp: "", cmake_generator: "Ninja", artifact_key: "artifact-linux"}
-          - { name: "Ubuntu 22.04; GCC + CodeQL", cache_name: 'ubuntu-gcc', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/gcc:v0.15.3", compiler_launcher: "ccache", compiler_c: "", compiler_cpp: "", cmake_generator: "Ninja", codeql: True, release_variant: 'debug'}
-          - { name: "Ubuntu 22.04; Clang 17.0", cache_name: 'ubuntu-clang', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/clang:v0.15.3",  compiler_launcher: "", compiler_c: "clang", compiler_cpp: "clang++" , cmake_generator: "Ninja" }
-          - { name: "Ubuntu 22.04; EMSDK 3.1.70", cache_name: 'ubuntu-emsdk', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/wasm:v0.15.3", compiler_launcher: "ccache", cmake_toolchain: '$Qt6_DIR/qt.toolchain.cmake', cmake_xargs: '-D QT_HOST_PATH=/qt/6.9.1/gcc_64', release_variant: 'MinSizeRel', debug_variant: 'MinSizeRel' }
+          - { name: "Ubuntu 22.04; GCC", cache_name: 'ubuntu-gcc', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/gcc:v0.15.4", compiler_launcher: "ccache", compiler_c: "", compiler_cpp: "", cmake_generator: "Ninja", artifact_key: "artifact-linux"}
+          - { name: "Ubuntu 22.04; GCC + CodeQL", cache_name: 'ubuntu-gcc', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/gcc:v0.15.4", compiler_launcher: "ccache", compiler_c: "", compiler_cpp: "", cmake_generator: "Ninja", codeql: True, release_variant: 'debug'}
+          - { name: "Ubuntu 22.04; Clang 17.0", cache_name: 'ubuntu-clang', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/clang:v0.15.4",  compiler_launcher: "", compiler_c: "clang", compiler_cpp: "clang++" , cmake_generator: "Ninja" }
+          - { name: "Ubuntu 22.04; EMSDK 3.1.70", cache_name: 'ubuntu-emsdk', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/wasm:v0.15.4", compiler_launcher: "ccache", cmake_toolchain: '$Qt6_DIR/qt.toolchain.cmake', cmake_xargs: '-D QT_HOST_PATH=/qt/6.9.3/gcc_64', release_variant: 'MinSizeRel', debug_variant: 'MinSizeRel' }
           # See: https://bugreports.qt.io/browse/QTBUG-118086
           - { name: "MacOS-15 ARM64", cache_name: 'macos-clang-arm', runs-on: "macos-15" , compiler_launcher: "ccache", compiler_c: 'clang', compiler_cpp: 'clang++', cmake_generator: "Ninja", artifact_key: "artifact-macos-arm", cmake_xargs: '-D CMAKE_OSX_ARCHITECTURES=arm64' }
           - { name: "MacOS-15 x86-64", cache_name: 'macos-clang-x86', runs-on: "macos-15" , compiler_launcher: "ccache", compiler_c: 'clang', compiler_cpp: 'clang++', cmake_generator: "Ninja", artifact_key: "artifact-macos-x86", cmake_xargs: '-D CMAKE_OSX_ARCHITECTURES=x86_64' }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endif ()
 if (ONLY STREQUAL "BUILD")
     set(LANGUAGES "CXX")
 endif ()
-project(Pepp VERSION 0.12.2 LANGUAGES ${LANGUAGES})
+project(Pepp VERSION 0.13.0 LANGUAGES ${LANGUAGES})
 # Only overwrite the install prefix if it is the default value.
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/install" CACHE PATH "Installation Directory" FORCE)

--- a/config/docker/cpp_build/Dockerfile
+++ b/config/docker/cpp_build/Dockerfile
@@ -26,7 +26,7 @@ RUN wget -q -O ninja.zip "https://github.com/ninja-build/ninja/releases/download
 ENV LANG="C.UTF-8"
 # Must occur after the "FROM" directive, allows choice of Qt version.
 ARG QT_MINOR="9"
-ARG QT_PATCH="1"
+ARG QT_PATCH="3"
 # major/minor
 ARG QT_RELEASE="6.${QT_MINOR}"
 # major/minor/patch

--- a/config/docker/docker-bake.hcl
+++ b/config/docker/docker-bake.hcl
@@ -11,7 +11,7 @@ group "img" {
 
 
 variable "VERSION" {
-  default = "v0.15.3"
+  default = "v0.15.4"
 }
 
 target "gcc" {
@@ -76,6 +76,6 @@ target "image_utils" {
   context = "./image_utils"
   dockerfile = "Dockerfile"
   tags = ["ghcr.io/matthew-mcraven/pepp/image-utils:${VERSION}"]
-  platforms = ["linux/amd64", "linux/arm64"]
+  platforms = ["linux/amd64"]
   target = "output"
 }

--- a/data/changelog/changes.csv
+++ b/data/changelog/changes.csv
@@ -199,3 +199,4 @@ Fixed,,0.12.1,969,"Avoid flashing ""Messages"" pane when it contains no new mess
 Fixed,,0.12.1,973,"Improve selection contrast in assembler text editors"
 Fixed,,0.12.1,974,"Precent spurious resizes when switching between modes"
 Added,,0.12.2,977,"Enable Asmb5 projects"
+Changed,,0.13.0,979,"Upgrade application to use Qt 6.9.3"

--- a/data/changelog/versions.csv
+++ b/data/changelog/versions.csv
@@ -31,3 +31,4 @@ Number,GitRef,Date,Blurb
 0.12.0,,2025-09-21,"This release contains the necessary subset of features to support the Asmb3 figures in Chapter 5 of Computer Systems, sixth edition"
 0.12.1,,2025-09-28,"This release improves the user experience for editing and debugging Asmb3 programs"
 0.12.2,,2025-10-02,"This release enables the Asmb5 level assembler and simulator"
+0.13.0,,??,"This release improves Asmb5 projects to support Chapter 6 of Computer Systems, sixth edition"


### PR DESCRIPTION
Only Qt 6.10.0+ and 6.9.3+ build on Mac OS 26.
I don't want to commit to upgrading WASM version for Qt 6.10 quite yet. Therefore, I will upgrade to  6.9.3

This change ensures that the builds produced in CI will better match those done on dev machines.