### PR TITLE
fix: catch illegal opcode exceptions in Pepp IDE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endif ()
 if (ONLY STREQUAL "BUILD")
     set(LANGUAGES "CXX")
 endif ()
-project(Pepp VERSION 0.13.0 LANGUAGES ${LANGUAGES})
+project(Pepp VERSION 0.13.1 LANGUAGES ${LANGUAGES})
 # Only overwrite the install prefix if it is the default value.
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/install" CACHE PATH "Installation Directory" FORCE)

--- a/data/changelog/changes.csv
+++ b/data/changelog/changes.csv
@@ -207,3 +207,4 @@ Changed,,0.13.0,989,"Temporarily hide globals and heap rendering to prioritize s
 Added,Major,0.13.0,992,"Enable stack trace for Asmb5 projects"
 Fixed,,0.13.0,985,"In terminal application, output error and warning messages to both console and log file"
 Fixed,,0.13.0,984,"In terminal application, fix a CTD when executing illegal opcodes"
+Fixed,,0.13.1,994,"Fix CTD when executing illegal opcodes in GUI application, introduced in #984"

--- a/data/changelog/versions.csv
+++ b/data/changelog/versions.csv
@@ -32,3 +32,4 @@ Number,GitRef,Date,Blurb
 0.12.1,,2025-09-28,"This release improves the user experience for editing and debugging Asmb3 programs"
 0.12.2,,2025-10-02,"This release enables the Asmb5 level assembler and simulator"
 0.13.0,,2025-10-13,"This release improves Asmb5 projects to support Chapter 6 of Computer Systems, sixth edition"
+0.13.1,,2025-10-20,"This release prevents a crash-to-desktop on malformed user programs"

--- a/lib/project/pep10.cpp
+++ b/lib/project/pep10.cpp
@@ -741,7 +741,11 @@ void Pep_ISA::onDeferredExecution(std::function<bool()> step) {
   } catch (const std::logic_error &e) {
     err = true;
     emit message(e.what());
+  } catch (const ::targets::isa::IllegalOpcode &e) {
+    err = true;
+    emit message(e.what());
   }
+
   // Only terminates if something written to endpoint or there was an error
   if (endpoint->next_value().has_value() || err) {
     switch (_state) {


### PR DESCRIPTION
Changed the base type of illegal opcode exception in 5297e27316ad177cdce6c0c540951d91da5fbfb8. At the time, I did not update the appropriate catch statements in the GUI projects.

Closes #994.