### PR TITLE
Rename level Mc2 to MA2 for 6th edition

### DIFF
--- a/bin/ide/main.qml
+++ b/bin/ide/main.qml
@@ -504,7 +504,7 @@ ApplicationWindow {
                 welcomeForFOpen.filterAbstraction = Qt.binding(() => [Abstraction.ISA3]);
                 welcomeForFOpen.filterEdition = Qt.binding(() => [6, 5, 4]);
             } else if (name.match(/pepcpu$/i)) {
-                welcomeForFOpen.filterAbstraction = Qt.binding(() => [Abstraction.MC2]);
+                welcomeForFOpen.filterAbstraction = Qt.binding(() => [Abstraction.MA2]);
                 welcomeForFOpen.filterEdition = Qt.binding(() => [6, 5, 4]);
             } else if (name.match(/pepm$/i)) {
                 welcomeForFOpen.filterAbstraction = Qt.binding(() => [Abstraction.ASMB3, Abstraction.OS4, Abstraction.ASMB5]);

--- a/bin/term/commands/microrun.hpp
+++ b/bin/term/commands/microrun.hpp
@@ -37,7 +37,7 @@ void registerMicroRun(auto &app, task_factory_t &task, detail::SharedFlags &flag
   // Must initialize,
   static std::string pepcpuIn, testIn, errName;
   static int busWidth = 1;
-  static auto microrunSC = app.add_subcommand("microrun", "Run Mc2 programs");
+  static auto microrunSC = app.add_subcommand("microrun", "Run micrcode programs");
   microrunSC->add_option("-s,microcode", pepcpuIn)->required()->expected(1);
   static const auto testOpt = microrunSC->add_option("-t,test", testIn)->expected(1);
   static auto errOpt =

--- a/data/books/cs4e/ch12/fig1204/manifest.json
+++ b/data/books/cs4e/ch12/fig1204/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:04",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/fig1205/manifest.json
+++ b/data/books/cs4e/ch12/fig1205/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:05",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/fig1205b/manifest.json
+++ b/data/books/cs4e/ch12/fig1205b/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:05b",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/fig1208/manifest.json
+++ b/data/books/cs4e/ch12/fig1208/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:08",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/fig1209/manifest.json
+++ b/data/books/cs4e/ch12/fig1209/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:09",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/fig1210/manifest.json
+++ b/data/books/cs4e/ch12/fig1210/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:10",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/fig1212/manifest.json
+++ b/data/books/cs4e/ch12/fig1212/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:12",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1205/manifest.json
+++ b/data/books/cs4e/ch12/prob1205/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:05",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1206/manifest.json
+++ b/data/books/cs4e/ch12/prob1206/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:06",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207a/manifest.json
+++ b/data/books/cs4e/ch12/prob1207a/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07a",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207b/manifest.json
+++ b/data/books/cs4e/ch12/prob1207b/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07b",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207c/manifest.json
+++ b/data/books/cs4e/ch12/prob1207c/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07c",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207d/manifest.json
+++ b/data/books/cs4e/ch12/prob1207d/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07d",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207e/manifest.json
+++ b/data/books/cs4e/ch12/prob1207e/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07e",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207f/manifest.json
+++ b/data/books/cs4e/ch12/prob1207f/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07f",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207g/manifest.json
+++ b/data/books/cs4e/ch12/prob1207g/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07g",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207h/manifest.json
+++ b/data/books/cs4e/ch12/prob1207h/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07h",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207i/manifest.json
+++ b/data/books/cs4e/ch12/prob1207i/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07i",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207j/manifest.json
+++ b/data/books/cs4e/ch12/prob1207j/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07j",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207k/manifest.json
+++ b/data/books/cs4e/ch12/prob1207k/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07k",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207l/manifest.json
+++ b/data/books/cs4e/ch12/prob1207l/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07l",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207m/manifest.json
+++ b/data/books/cs4e/ch12/prob1207m/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07m",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207n/manifest.json
+++ b/data/books/cs4e/ch12/prob1207n/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07n",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207o/manifest.json
+++ b/data/books/cs4e/ch12/prob1207o/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07o",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207p/manifest.json
+++ b/data/books/cs4e/ch12/prob1207p/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07p",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207q/manifest.json
+++ b/data/books/cs4e/ch12/prob1207q/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07q",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207r/manifest.json
+++ b/data/books/cs4e/ch12/prob1207r/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07r",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207s/manifest.json
+++ b/data/books/cs4e/ch12/prob1207s/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07s",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207t/manifest.json
+++ b/data/books/cs4e/ch12/prob1207t/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07t",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207u/manifest.json
+++ b/data/books/cs4e/ch12/prob1207u/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07u",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207v/manifest.json
+++ b/data/books/cs4e/ch12/prob1207v/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07v",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207w/manifest.json
+++ b/data/books/cs4e/ch12/prob1207w/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07w",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1207x/manifest.json
+++ b/data/books/cs4e/ch12/prob1207x/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:07x",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs4e/ch12/prob1208/manifest.json
+++ b/data/books/cs4e/ch12/prob1208/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:08",
   "arch": "pep8",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "fragments": [
     {
       "name": "pepcpu",

--- a/data/books/cs5e/ch12/fig1205/manifest.json
+++ b/data/books/cs5e/ch12/fig1205/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:05",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/fig1207/manifest.json
+++ b/data/books/cs5e/ch12/fig1207/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:07",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/fig1209/manifest.json
+++ b/data/books/cs5e/ch12/fig1209/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:09",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/fig1210/manifest.json
+++ b/data/books/cs5e/ch12/fig1210/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:10",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/fig1211/manifest.json
+++ b/data/books/cs5e/ch12/fig1211/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:11",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2","test3"
   ],

--- a/data/books/cs5e/ch12/fig1212/manifest.json
+++ b/data/books/cs5e/ch12/fig1212/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:12",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/fig1214/manifest.json
+++ b/data/books/cs5e/ch12/fig1214/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:14",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs5e/ch12/fig1220/manifest.json
+++ b/data/books/cs5e/ch12/fig1220/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:20",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/fig1221/manifest.json
+++ b/data/books/cs5e/ch12/fig1221/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:21",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/fig1223/manifest.json
+++ b/data/books/cs5e/ch12/fig1223/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:23",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/prob1228/manifest.json
+++ b/data/books/cs5e/ch12/prob1228/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:28",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/prob1229a/manifest.json
+++ b/data/books/cs5e/ch12/prob1229a/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:29a",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/prob1229b/manifest.json
+++ b/data/books/cs5e/ch12/prob1229b/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:29b",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/prob1229c/manifest.json
+++ b/data/books/cs5e/ch12/prob1229c/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:29c",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/prob1229d/manifest.json
+++ b/data/books/cs5e/ch12/prob1229d/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:29d",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1229e/manifest.json
+++ b/data/books/cs5e/ch12/prob1229e/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:29e",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2", "test3"
   ],

--- a/data/books/cs5e/ch12/prob1229f/manifest.json
+++ b/data/books/cs5e/ch12/prob1229f/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:29f",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1229g/manifest.json
+++ b/data/books/cs5e/ch12/prob1229g/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:29g",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1230/manifest.json
+++ b/data/books/cs5e/ch12/prob1230/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:30",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs5e/ch12/prob1231a/manifest.json
+++ b/data/books/cs5e/ch12/prob1231a/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:31a",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2", "test3"
   ],

--- a/data/books/cs5e/ch12/prob1231b/manifest.json
+++ b/data/books/cs5e/ch12/prob1231b/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:31b",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1231c/manifest.json
+++ b/data/books/cs5e/ch12/prob1231c/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:31c",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1231d/manifest.json
+++ b/data/books/cs5e/ch12/prob1231d/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:31d",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2", "test3"
   ],

--- a/data/books/cs5e/ch12/prob1231e/manifest.json
+++ b/data/books/cs5e/ch12/prob1231e/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:31e",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs5e/ch12/prob1231f/manifest.json
+++ b/data/books/cs5e/ch12/prob1231f/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:31f",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs5e/ch12/prob1231g/manifest.json
+++ b/data/books/cs5e/ch12/prob1231g/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:31g",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1232a/manifest.json
+++ b/data/books/cs5e/ch12/prob1232a/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32a",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs5e/ch12/prob1232b/manifest.json
+++ b/data/books/cs5e/ch12/prob1232b/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32b",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs5e/ch12/prob1232c/manifest.json
+++ b/data/books/cs5e/ch12/prob1232c/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32c",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs5e/ch12/prob1232d/manifest.json
+++ b/data/books/cs5e/ch12/prob1232d/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32d",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs5e/ch12/prob1232e/manifest.json
+++ b/data/books/cs5e/ch12/prob1232e/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32e",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs5e/ch12/prob1232f/manifest.json
+++ b/data/books/cs5e/ch12/prob1232f/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32f",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs5e/ch12/prob1232g/manifest.json
+++ b/data/books/cs5e/ch12/prob1232g/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32g",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1232h/manifest.json
+++ b/data/books/cs5e/ch12/prob1232h/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32h",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1232i/manifest.json
+++ b/data/books/cs5e/ch12/prob1232i/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32i",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1232j/manifest.json
+++ b/data/books/cs5e/ch12/prob1232j/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32j",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1232k/manifest.json
+++ b/data/books/cs5e/ch12/prob1232k/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32k",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1232l/manifest.json
+++ b/data/books/cs5e/ch12/prob1232l/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32l",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1233a/manifest.json
+++ b/data/books/cs5e/ch12/prob1233a/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:33a",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/prob1233b/manifest.json
+++ b/data/books/cs5e/ch12/prob1233b/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:33b",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1233c/manifest.json
+++ b/data/books/cs5e/ch12/prob1233c/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:33c",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1233d/manifest.json
+++ b/data/books/cs5e/ch12/prob1233d/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:33d",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1233e/manifest.json
+++ b/data/books/cs5e/ch12/prob1233e/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:33e",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/prob1233f/manifest.json
+++ b/data/books/cs5e/ch12/prob1233f/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:33f",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/prob1234a/manifest.json
+++ b/data/books/cs5e/ch12/prob1234a/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:34a",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/prob1234b/manifest.json
+++ b/data/books/cs5e/ch12/prob1234b/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:34b",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/prob1235a/manifest.json
+++ b/data/books/cs5e/ch12/prob1235a/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35a",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1235b/manifest.json
+++ b/data/books/cs5e/ch12/prob1235b/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35b",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs5e/ch12/prob1235c/manifest.json
+++ b/data/books/cs5e/ch12/prob1235c/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35c",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1235d/manifest.json
+++ b/data/books/cs5e/ch12/prob1235d/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35d",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs5e/ch12/prob1235e/manifest.json
+++ b/data/books/cs5e/ch12/prob1235e/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35e",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs5e/ch12/prob1235f/manifest.json
+++ b/data/books/cs5e/ch12/prob1235f/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35f",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs5e/ch12/prob1235g/manifest.json
+++ b/data/books/cs5e/ch12/prob1235g/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35g",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/prob1235h/manifest.json
+++ b/data/books/cs5e/ch12/prob1235h/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35h",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1235i/manifest.json
+++ b/data/books/cs5e/ch12/prob1235i/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35i",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1235j/manifest.json
+++ b/data/books/cs5e/ch12/prob1235j/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35j",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1235k/manifest.json
+++ b/data/books/cs5e/ch12/prob1235k/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35k",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1235l/manifest.json
+++ b/data/books/cs5e/ch12/prob1235l/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35l",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1236a/manifest.json
+++ b/data/books/cs5e/ch12/prob1236a/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:36a",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/prob1236b/manifest.json
+++ b/data/books/cs5e/ch12/prob1236b/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:36b",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs5e/ch12/prob1236c/manifest.json
+++ b/data/books/cs5e/ch12/prob1236c/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:36c",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/prob1236d/manifest.json
+++ b/data/books/cs5e/ch12/prob1236d/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:36d",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/prob1236e/manifest.json
+++ b/data/books/cs5e/ch12/prob1236e/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:36e",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs5e/ch12/prob1236f/manifest.json
+++ b/data/books/cs5e/ch12/prob1236f/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:36f",
   "arch": "pep9",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/fig1205/manifest.json
+++ b/data/books/cs6e/ch12/fig1205/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:05",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/fig1207/manifest.json
+++ b/data/books/cs6e/ch12/fig1207/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:07",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/fig1209/manifest.json
+++ b/data/books/cs6e/ch12/fig1209/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:09",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/fig1210/manifest.json
+++ b/data/books/cs6e/ch12/fig1210/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:10",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/fig1211/manifest.json
+++ b/data/books/cs6e/ch12/fig1211/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:11",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2","test3"
   ],

--- a/data/books/cs6e/ch12/fig1212/manifest.json
+++ b/data/books/cs6e/ch12/fig1212/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:12",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/fig1214/manifest.json
+++ b/data/books/cs6e/ch12/fig1214/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:14",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs6e/ch12/fig1220/manifest.json
+++ b/data/books/cs6e/ch12/fig1220/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:20",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/fig1221/manifest.json
+++ b/data/books/cs6e/ch12/fig1221/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:21",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/fig1223/manifest.json
+++ b/data/books/cs6e/ch12/fig1223/manifest.json
@@ -3,7 +3,7 @@
   "type": "figure",
   "name": "12:23",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/prob1228/manifest.json
+++ b/data/books/cs6e/ch12/prob1228/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:28",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/prob1229a/manifest.json
+++ b/data/books/cs6e/ch12/prob1229a/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:29a",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/prob1229b/manifest.json
+++ b/data/books/cs6e/ch12/prob1229b/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:29b",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/prob1229c/manifest.json
+++ b/data/books/cs6e/ch12/prob1229c/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:29c",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/prob1229d/manifest.json
+++ b/data/books/cs6e/ch12/prob1229d/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:29d",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1229e/manifest.json
+++ b/data/books/cs6e/ch12/prob1229e/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:29e",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2", "test3"
   ],

--- a/data/books/cs6e/ch12/prob1229f/manifest.json
+++ b/data/books/cs6e/ch12/prob1229f/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:29f",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1229g/manifest.json
+++ b/data/books/cs6e/ch12/prob1229g/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:29g",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1230/manifest.json
+++ b/data/books/cs6e/ch12/prob1230/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:30",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs6e/ch12/prob1231a/manifest.json
+++ b/data/books/cs6e/ch12/prob1231a/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:31a",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2", "test3"
   ],

--- a/data/books/cs6e/ch12/prob1231b/manifest.json
+++ b/data/books/cs6e/ch12/prob1231b/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:31b",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1231c/manifest.json
+++ b/data/books/cs6e/ch12/prob1231c/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:31c",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1231d/manifest.json
+++ b/data/books/cs6e/ch12/prob1231d/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:31d",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2", "test3"
   ],

--- a/data/books/cs6e/ch12/prob1231e/manifest.json
+++ b/data/books/cs6e/ch12/prob1231e/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:31e",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs6e/ch12/prob1231f/manifest.json
+++ b/data/books/cs6e/ch12/prob1231f/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:31f",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs6e/ch12/prob1231g/manifest.json
+++ b/data/books/cs6e/ch12/prob1231g/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:31g",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1232a/manifest.json
+++ b/data/books/cs6e/ch12/prob1232a/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32a",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs6e/ch12/prob1232b/manifest.json
+++ b/data/books/cs6e/ch12/prob1232b/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32b",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs6e/ch12/prob1232c/manifest.json
+++ b/data/books/cs6e/ch12/prob1232c/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32c",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs6e/ch12/prob1232d/manifest.json
+++ b/data/books/cs6e/ch12/prob1232d/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32d",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs6e/ch12/prob1232e/manifest.json
+++ b/data/books/cs6e/ch12/prob1232e/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32e",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs6e/ch12/prob1232f/manifest.json
+++ b/data/books/cs6e/ch12/prob1232f/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32f",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs6e/ch12/prob1232g/manifest.json
+++ b/data/books/cs6e/ch12/prob1232g/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32g",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1232h/manifest.json
+++ b/data/books/cs6e/ch12/prob1232h/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32h",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1232i/manifest.json
+++ b/data/books/cs6e/ch12/prob1232i/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32i",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1232j/manifest.json
+++ b/data/books/cs6e/ch12/prob1232j/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32j",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1232k/manifest.json
+++ b/data/books/cs6e/ch12/prob1232k/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32k",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1232l/manifest.json
+++ b/data/books/cs6e/ch12/prob1232l/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:32l",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1233a/manifest.json
+++ b/data/books/cs6e/ch12/prob1233a/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:33a",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/prob1233b/manifest.json
+++ b/data/books/cs6e/ch12/prob1233b/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:33b",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1233c/manifest.json
+++ b/data/books/cs6e/ch12/prob1233c/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:33c",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1233d/manifest.json
+++ b/data/books/cs6e/ch12/prob1233d/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:33d",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1233e/manifest.json
+++ b/data/books/cs6e/ch12/prob1233e/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:33e",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/prob1233f/manifest.json
+++ b/data/books/cs6e/ch12/prob1233f/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:33f",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/prob1234a/manifest.json
+++ b/data/books/cs6e/ch12/prob1234a/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:34a",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/prob1234b/manifest.json
+++ b/data/books/cs6e/ch12/prob1234b/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:34b",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/prob1235a/manifest.json
+++ b/data/books/cs6e/ch12/prob1235a/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35a",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1235b/manifest.json
+++ b/data/books/cs6e/ch12/prob1235b/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35b",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs6e/ch12/prob1235c/manifest.json
+++ b/data/books/cs6e/ch12/prob1235c/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35c",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1235d/manifest.json
+++ b/data/books/cs6e/ch12/prob1235d/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35d",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs6e/ch12/prob1235e/manifest.json
+++ b/data/books/cs6e/ch12/prob1235e/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35e",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs6e/ch12/prob1235f/manifest.json
+++ b/data/books/cs6e/ch12/prob1235f/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35f",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1", "test2"
   ],

--- a/data/books/cs6e/ch12/prob1235g/manifest.json
+++ b/data/books/cs6e/ch12/prob1235g/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35g",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/prob1235h/manifest.json
+++ b/data/books/cs6e/ch12/prob1235h/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35h",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1235i/manifest.json
+++ b/data/books/cs6e/ch12/prob1235i/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35i",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1235j/manifest.json
+++ b/data/books/cs6e/ch12/prob1235j/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35j",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1235k/manifest.json
+++ b/data/books/cs6e/ch12/prob1235k/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35k",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1235l/manifest.json
+++ b/data/books/cs6e/ch12/prob1235l/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:35l",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1236a/manifest.json
+++ b/data/books/cs6e/ch12/prob1236a/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:36a",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/prob1236b/manifest.json
+++ b/data/books/cs6e/ch12/prob1236b/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:36b",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0", "test1"
   ],

--- a/data/books/cs6e/ch12/prob1236c/manifest.json
+++ b/data/books/cs6e/ch12/prob1236c/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:36c",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/prob1236d/manifest.json
+++ b/data/books/cs6e/ch12/prob1236d/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:36d",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/prob1236e/manifest.json
+++ b/data/books/cs6e/ch12/prob1236e/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:36e",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/books/cs6e/ch12/prob1236f/manifest.json
+++ b/data/books/cs6e/ch12/prob1236f/manifest.json
@@ -3,7 +3,7 @@
   "type": "problem",
   "name": "12:36f",
   "arch": "pep10",
-  "abstraction": "MC2",
+  "abstraction": "MA2",
   "tests": [
     "test0"
   ],

--- a/data/help/ui/index.html
+++ b/data/help/ui/index.html
@@ -43,7 +43,7 @@
 <table border="1" cellspacing="0" cellpadding="4">
   <tr>
     <th rowspan="2">Component</th>
-    <th colspan="2">Mc2</th>
+    <th colspan="2">MA2</th>
     <th colspan="2">ISA3</th>
     <th colspan="2">Asmb3</th>
     <th colspan="2">OS4</th>

--- a/data/help/workflow/autoformat.html
+++ b/data/help/workflow/autoformat.html
@@ -1,7 +1,7 @@
 <h1>Automatic Formatting</h1>
 
 <blockquote>
-<b>Applies to:</b> Mc2, ISA3, Asmb3, OS4, Asmb5
+<b>Applies to:</b> MA2, ISA3, Asmb3, OS4, Asmb5
 </blockquote>
 
 <p>

--- a/data/help/workflow/breakpoints.html
+++ b/data/help/workflow/breakpoints.html
@@ -1,7 +1,7 @@
 <h1>Using Breakpoints</h1>
 
 <blockquote>
-<b>Applies to:</b> Mc2, ISA3, Asmb3, OS4, Asmb5
+<b>Applies to:</b> MA2, ISA3, Asmb3, OS4, Asmb5
 </blockquote>
 
 <h2>Add / Remove Breakpoints</h2>

--- a/data/help/workflow/index.html
+++ b/data/help/workflow/index.html
@@ -35,7 +35,7 @@ these additional programming tools.
   </tr>
   <tr>
     <td><a href="slug://flows/mc2">Microcode</a></td>
-    <td>Mc2</td>
+    <td>MA2</td>
     <td>10, 11</td>
     <td>One- vs two-byte data bus</td>
   </tr>

--- a/docs/dev/readme/revamp-ch12.md
+++ b/docs/dev/readme/revamp-ch12.md
@@ -51,8 +51,8 @@ Keep the two-byte bus
 > Reduces the amount of new material to write in CS6E.
 > Does not requiring writing a RISC-V simulator.
 
-Remove two-byte bus, teach RISC-V MC2 emulation of Pep/10 CPU
-> Need to determine mapping of RISC-V:Pep/10 registers at the MC2 level.
+Remove two-byte bus, teach RISC-V MA2 emulation of Pep/10 CPU
+> Need to determine mapping of RISC-V:Pep/10 registers at the MA2 level.
 > Students would be taught to implement Pep/10 CPU using RISC-V instructions as a form of microcode.
 > This establishes continuity between the two halves of chapter 12.
 > This would require some kind of graphical data & control path to maintain parity to Pep10CPU within the application.

--- a/lib/bts/levels.cpp
+++ b/lib/bts/levels.cpp
@@ -7,7 +7,7 @@ QString pepp::AbstractionHelper::string(Abstraction abstraction) const {
 }
 QString pepp::abstractionAsPrettyString(AbstractionHelper::Abstraction abstraction) {
   switch (abstraction) {
-  case AbstractionHelper::Abstraction::MC2: return "Mc2";
+  case AbstractionHelper::Abstraction::MA2: return "MA2";
   case AbstractionHelper::Abstraction::ISA3: return "ISA3";
   case AbstractionHelper::Abstraction::ASMB3: return "Asmb3";
   case AbstractionHelper::Abstraction::OS4: return "OS4";

--- a/lib/bts/levels.hpp
+++ b/lib/bts/levels.hpp
@@ -35,7 +35,7 @@ public:
   enum class Abstraction {
     NO_ABS = -1,
     // LG1 = 1,
-    MC2 = 20,
+    MA2 = 20,
     ISA3 = 30,
     ASMB3 = 31,
     OS4 = 40,

--- a/lib/help/builtins/helpdata.cpp
+++ b/lib/help/builtins/helpdata.cpp
@@ -134,7 +134,7 @@ QSharedPointer<HelpEntry> ui_root() {
 QSharedPointer<HelpEntry> workflows_root() {
   using enum pepp::Architecture;
   using enum pepp::Abstraction;
-  int mc10 = bitmask(PEP10, MC2);
+  int mc10 = bitmask(PEP10, MA2);
   int oc10 = bitmask(PEP10, ISA3);
   int as10 = bitmask(PEP10, ASMB5);
   int p10 = mc10 | oc10 | as10;
@@ -540,7 +540,7 @@ int bitmask(pepp::Abstraction level) {
   using enum pepp::Abstraction;
   switch (level) {
   case NO_ABS: return 0;
-  case MC2: return 1 << 0;
+  case MA2: return 1 << 0;
   case ISA3: return 1 << 1;
   case ASMB3: return 1 << 2;
   case OS4: return 1 << 3;

--- a/lib/settings/GeneralCategoryDelegate.qml
+++ b/lib/settings/GeneralCategoryDelegate.qml
@@ -198,8 +198,8 @@ Item {
             "value": Abstraction.ISA3
         })
         abstractionModel.append({
-            "key": "MC2",
-            "value": Abstraction.MC2
+            "key": "MA2",
+            "value": Abstraction.MA2
         })
         abstractionModel.append({
             "key": "OS4",

--- a/lib/sim3/cores/pep/traced_pep10_isa3.cpp
+++ b/lib/sim3/cores/pep/traced_pep10_isa3.cpp
@@ -399,7 +399,7 @@ sim::api2::tick::Result targets::pep10::isa::CPU::unaryDispatch(quint8 is, quint
     bits::memcpy(ctxSpan.subspan(1, 2), tmpSpan);
     tmp = swap ? bits::byteswap(x) : x;
     bits::memcpy(ctxSpan.subspan(3, 2), tmpSpan);
-    // Must increment PC by 2 since we are ISA3 dyadic but MC2 monadic
+    // Must increment PC by 2 since we are ISA3 dyadic but MA2 monadic
     tmp = pc + 2;
     tmp = swap ? bits::byteswap(tmp) : tmp;
     bits::memcpy(ctxSpan.subspan(5, 2), tmpSpan);

--- a/lib/top/RecentFiles.qml
+++ b/lib/top/RecentFiles.qml
@@ -126,8 +126,8 @@ Item {
 
                 function abstractText(value) {
                     switch (value) {
-                    case Abstraction.MC2:
-                        return "MC2";
+                    case Abstraction.MA2:
+                        return "MA2";
                     case Abstraction.ISA3:
                         return "ISA3";
                     case Abstraction.ASMB3:

--- a/lib/top/projectmodel.cpp
+++ b/lib/top/projectmodel.cpp
@@ -426,21 +426,21 @@ void init_pep10(QList<ProjectType> &vec) {
               .state = CompletionState::PARTIAL,
               .edition = 6});
   vec.append({.name = "Pep/10",
-              .levelText = "Mc2",
+              .levelText = "MA2",
               .details = "1-Byte Bus",
               .chapter = "11",
               .description = "Missing",
               .arch = a,
-              .level = Abstraction::MC2,
+              .level = Abstraction::MA2,
               .state = CompletionState::INCOMPLETE,
               .edition = 6});
   vec.append({.name = "Pep/10",
-              .levelText = "Mc2",
+              .levelText = "MA2",
               .details = "2-Byte Bus",
               .chapter = "11",
               .description = "Missing",
               .arch = a,
-              .level = Abstraction::MC2,
+              .level = Abstraction::MA2,
               .state = CompletionState::INCOMPLETE,
               .edition = 6});
 }
@@ -481,7 +481,7 @@ void init_pep9(QList<ProjectType> &vec) {
               .chapter = "12",
               .description = "Missing",
               .arch = a,
-              .level = Abstraction::MC2,
+              .level = Abstraction::MA2,
               .state = CompletionState::INCOMPLETE,
               .edition = 5});
   vec.append({.name = "Pep/9",
@@ -490,7 +490,7 @@ void init_pep9(QList<ProjectType> &vec) {
               .chapter = "12",
               .description = "Missing",
               .arch = a,
-              .level = Abstraction::MC2,
+              .level = Abstraction::MA2,
               .state = CompletionState::INCOMPLETE,
               .edition = 5});
 }
@@ -531,7 +531,7 @@ void init_pep8(QList<ProjectType> &vec) {
               .chapter = "12",
               .description = "Missing",
               .arch = a,
-              .level = Abstraction::MC2,
+              .level = Abstraction::MA2,
               .state = CompletionState::INCOMPLETE,
               .edition = 4});
 }

--- a/scripts/migrate_manifest_1to2.py
+++ b/scripts/migrate_manifest_1to2.py
@@ -11,7 +11,7 @@ def migrate_figure(type: str, path: str):
         "arch": figure.get("arch"),
     }
     if "abstraction" in figure: out["abstraction"] = figure["abstraction"]
-    elif "ch12" in path: out["abstraction"] = "MC2"
+    elif "ch12" in path: out["abstraction"] = "MA2"
     elif "os" in path: out["abstraction"] = "OS4"
     elif "cs4e" in path and "ch04" in path: out["abstraction"] = "ISA3"
     elif "cs4e" in path and "ch05" in path: out["abstraction"] = "ASMB5"
@@ -58,11 +58,11 @@ def migrate_figure(type: str, path: str):
           pepl, pepo = make_item("pepl", name="pepl"), make_item("pepo", name="pepo")
           add_from_element(pepl, "pep"), add_from_element(pepo, "pep")
           out["items"].extend([pepl, pepo])
-    elif out["abstraction"] == "MC2":
+    elif out["abstraction"] == "MA2":
         out["items"]=[]
         for format in figure.get("items", []):
             el = make_item(format, name=format)
-            if format == "MC2": el["copy"] ="microcode"
+            if format == "MA2": el["copy"] ="microcode"
             add_from_file(el, figure["items"][format])
             out["items"].append(el)
     else:


### PR DESCRIPTION
As per my discussion with Stan on 2026-01-16, Mc2 does not apply to RISC computers. However, the more general topic of "microarchitecture" applies to both RISC and CISC. By rebranding the 2nd level to Microarchitecture 2 (MA2), we make the prose of Chapter 12 easier to write.

This change has already been applied to the CS6E text, and is being mirrored here.
