### PR TITLE
Upgrade CI to Qt 6.10.1

### DIFF
--- a/.github/actions/install-qt-cmake/action.yml
+++ b/.github/actions/install-qt-cmake/action.yml
@@ -2,7 +2,7 @@ name: 'Install CMake & Qt'
 inputs:
   qt_version:
     required: true
-    default: '6.9.3'
+    default: '6.10.1'
   cache-key-prefix:
     required: false
 runs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/matthew-mcraven/pepp/image-utils:v0.16.1
+      image: ghcr.io/matthew-mcraven/pepp/image-utils:v0.17.0
     steps:
       - uses: actions/checkout@v4
         # LFS defaults to disabled, but accidental LFS bandwidth would be expensive.
@@ -104,7 +104,7 @@ jobs:
     name: Build RISC-V samples
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/matthew-mcraven/pepp/gcc-riscv:v0.16.1
+      image: ghcr.io/matthew-mcraven/pepp/gcc-riscv:v0.17.0
     steps:
       - uses: actions/checkout@v4
         # LFS defaults to disabled, but accidental LFS bandwidth would be expensive.
@@ -131,10 +131,10 @@ jobs:
       # Trying to use `env` or inputs will fail in this context.
       matrix:
         config:
-          - { name: "Ubuntu 22.04; GCC", cache_name: 'ubuntu-gcc', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/gcc:v0.16.1", compiler_launcher: "ccache", compiler_c: "", compiler_cpp: "", cmake_generator: "Ninja", artifact_key: "artifact-linux"}
-          - { name: "Ubuntu 22.04; GCC + CodeQL", cache_name: 'ubuntu-gcc', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/gcc:v0.16.1", compiler_launcher: "ccache", compiler_c: "", compiler_cpp: "", cmake_generator: "Ninja", codeql: True, release_variant: 'debug'}
-          - { name: "Ubuntu 22.04; Clang 17.0", cache_name: 'ubuntu-clang', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/clang:v0.16.1",  compiler_launcher: "", compiler_c: "clang", compiler_cpp: "clang++" , cmake_generator: "Ninja" }
-          - { name: "Ubuntu 22.04; EMSDK 3.1.70", cache_name: 'ubuntu-emsdk', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/wasm:v0.16.1", compiler_launcher: "ccache", cmake_toolchain: '$Qt6_DIR/qt.toolchain.cmake', cmake_xargs: '-D QT_HOST_PATH=/qt/6.9.3/gcc_64', release_variant: 'MinSizeRel', debug_variant: 'MinSizeRel' }
+          - { name: "Ubuntu 24.04; GCC", cache_name: 'ubuntu-gcc', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/gcc:v0.17.0", compiler_launcher: "ccache", compiler_c: "", compiler_cpp: "", cmake_generator: "Ninja", artifact_key: "artifact-linux"}
+          - { name: "Ubuntu 24.04; GCC + CodeQL", cache_name: 'ubuntu-gcc', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/gcc:v0.17.0", compiler_launcher: "ccache", compiler_c: "", compiler_cpp: "", cmake_generator: "Ninja", codeql: True, release_variant: 'debug'}
+          - { name: "Ubuntu 24.04; Clang 17.0", cache_name: 'ubuntu-clang', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/clang:v0.17.0",  compiler_launcher: "", compiler_c: "clang", compiler_cpp: "clang++" , cmake_generator: "Ninja" }
+          - { name: "Ubuntu 24.04; EMSDK 4.1.07", cache_name: 'ubuntu-emsdk', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/wasm:v0.17.0", compiler_launcher: "ccache", cmake_toolchain: '$Qt6_DIR/qt.toolchain.cmake', cmake_xargs: '-D QT_HOST_PATH=/qt/6.10.1/gcc_64', release_variant: 'MinSizeRel', debug_variant: 'MinSizeRel' }
           # See: https://bugreports.qt.io/browse/QTBUG-118086
           - { name: "MacOS-15 ARM64", cache_name: 'macos-clang-arm', runs-on: "macos-15" , compiler_launcher: "ccache", compiler_c: 'clang', compiler_cpp: 'clang++', cmake_generator: "Ninja", artifact_key: "artifact-macos-arm", cmake_xargs: '-D CMAKE_OSX_ARCHITECTURES=arm64' }
           - { name: "MacOS-15 x86-64", cache_name: 'macos-clang-x86', runs-on: "macos-15" , compiler_launcher: "ccache", compiler_c: 'clang', compiler_cpp: 'clang++', cmake_generator: "Ninja", artifact_key: "artifact-macos-x86", cmake_xargs: '-D CMAKE_OSX_ARCHITECTURES=x86_64' }

--- a/config/docker/cpp_build/Dockerfile
+++ b/config/docker/cpp_build/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu:22.04
+ARG BASE_IMAGE=ubuntu:24.04
 # Will be the latest LTS by the time we release the book, which I assume to be ~ 2025.
 FROM ${BASE_IMAGE} AS base-gcc
 # Prevent apt-get from pausing for input in an environment in which it can never
@@ -26,14 +26,14 @@ RUN wget -q -O ninja.zip "https://github.com/ninja-build/ninja/releases/download
 # Need to pick this locale otherwise Qt complains and overrides the locale anyway.
 ENV LANG="C.UTF-8"
 # Must occur after the "FROM" directive, allows choice of Qt version.
-ARG QT_MINOR="9"
-ARG QT_PATCH="3"
+ARG QT_MINOR="10"
+ARG QT_PATCH="1"
 # major/minor
 ARG QT_RELEASE="6.${QT_MINOR}"
 # major/minor/patch
 ARG QT_VERSION="6.${QT_MINOR}.${QT_PATCH}"
 # Depends on major/minor
-ARG EMSDK_VERSION="3.1.70"
+ARG EMSDK_VERSION="4.0.7"
 # Don't cache pip internal files, reduce image size.
 ENV PIP_NO_CACHE_DIR=1
 SHELL ["/bin/bash", "-c"]
@@ -63,16 +63,15 @@ FROM base-gcc AS base-wasm
 # Must install documentation-building tools in WASM image.
 # Otherwise it will be very difficult to build GH pages deployments.
 RUN apt update \
-    && apt install -y --no-install-recommends graphviz imagemagick \
+    && apt install -y --no-install-recommends graphviz imagemagick python3.12-venv \
     && rm -rf /var/lib/apt/lists/*
 RUN git clone https://github.com/emscripten-core/emsdk.git /emsdk
 # Must combine, otherwise a layer is the same in multi-arch builds, breaking everything
 RUN cd /emsdk && git pull && ./emsdk install ${EMSDK_VERSION} && ./emsdk activate ${EMSDK_VERSION} && echo uname -a /emsdk.arch
 # Install shadertools and 3d modules otherwise building from sources will fail.
-RUN pip install aqtinstall \
-    && aqt install-qt linux desktop ${QT_VERSION} -m qtshadertools qtquick3d qt3d --outputdir /qt  \
-    && pip uninstall aqtinstall -y && rm aqtinstall.log
-
+RUN python3 -m venv /venv && source /venv/bin/activate \
+  && pip install aqtinstall &&  aqt install-qt linux desktop ${QT_VERSION} -m qtshadertools qtquick3d qt3d --outputdir /qt \
+  && rm aqtinstall.log && rm -rf /venv
 
 # Use separate step to build Qt to avoid inflating the size of the build image further.
 FROM base-wasm AS build-wasm
@@ -101,7 +100,7 @@ RUN source /emsdk/emsdk_env.sh \
        -no-feature-thread -feature-wasm-exceptions ${QT_WASM_XARGS} \
        -skip qtremoteobjects -skip qtwebengine -skip qtscxml -skip qthttpserver \
        -skip qtwebview -skip qtwebchannel -skip qtsensors -skip qtwebsockets -skip qtlocation \
-       -skip qtpositioning -skip qtactiveqt -skip qt5compat\
+       -skip qtpositioning -skip qtactiveqt -skip qt5compat -skip qtlottie \
        -prefix /qt/${QT_VERSION}/wasm_singlethread
 # Separate build from configure so that I get better logs
 RUN cd /build-qt/${QT_VERSION} \
@@ -120,8 +119,13 @@ ENV PATH=/qt/${QT_VERSION}/wasm_singlethread/bin/:$PATH
 LABEL description="A wasm build container using Qt $QT_VERSION."
 
 FROM base-gcc AS output-gcc
+RUN apt update \
+    && apt install -y --no-install-recommends python3.12-venv \
+    && rm -rf /var/lib/apt/lists/*
 # Install Qt with aqtinstall (see https://github.com/miurahr/aqtinstall), selecting only the modules we need.
-RUN pip install aqtinstall && aqt install-qt linux desktop ${QT_VERSION} --outputdir /qt && pip uninstall aqtinstall -y && rm aqtinstall.log
+RUN python3 -m venv /venv && source /venv/bin/activate \
+  && pip install aqtinstall && aqt install-qt linux desktop ${QT_VERSION} --outputdir /qt \
+  && rm aqtinstall.log && rm -rf /venv
 # Define standard Qt environment variables so that executing cmake directly will work.
 ENV LD_LIBRARY_PATH=/qt/${QT_VERSION}/gcc_64/lib:${LD_LIBRARY_PATH}
 ENV Qt6_DIR=/qt/${QT_VERSION}/gcc_64
@@ -129,7 +133,7 @@ ENV QT_PLUGIN_PATH=/qt/${QT_VERSION}/gcc_64/plugins
 ENV QML2_IMPORT_PATH=/qt/${QT_VERSION}/gcc_64/qml
 ENV PATH=/qt/${QT_VERSION}/gcc_64/bin/:$PATH
 # Install mold, so that we can reduce link times
-ARG MOLD_VERSION="2.3.1"
+ARG MOLD_VERSION="2.40.4"
 RUN --mount=type=tmpfs,target=/mold,size=2G \
     cd mold \
     && wget -q -O mold.tar.gz "https://github.com/rui314/mold/releases/download/v$MOLD_VERSION/mold-$MOLD_VERSION-$(arch)-linux.tar.gz" \

--- a/config/docker/docker-bake.hcl
+++ b/config/docker/docker-bake.hcl
@@ -14,7 +14,7 @@ group "img" {
 
 
 variable "VERSION" {
-  default = "v0.16.1"
+  default = "v0.17.0"
 }
 
 target "gcc-riscv" {

--- a/data/changelog/changes.csv
+++ b/data/changelog/changes.csv
@@ -216,3 +216,4 @@ Changed,Major,0.14.1,1018,"Rename Microcode 2 (Mc2) level of abstraction to Micr
 Fixed,,0.14.1,1019,"Fix CTD for Pep/8 and Pep/9 assembler projects"
 Changed,,0.14.1,968,"Show object code pane by default in Asmb3 and Asmb5 debuggers"
 Changed,,0.14.1,1006,"Add comment to Pep/10 operating system on shutdown behavior"
+Changed,,0.14.2,1021,"Upgrade application to use Qt 6.10.1"

--- a/lib/toolchain2/support/source/location.hpp
+++ b/lib/toolchain2/support/source/location.hpp
@@ -1,6 +1,8 @@
 #pragma once
+#include <stdint.h>
 #include "sim3/api/memory_address.hpp"
 #include "type_traits"
+
 namespace pepp::tc::support {
 // Represent a point (i.e., a single character) within a text file.
 struct Location {


### PR DESCRIPTION
Qt 6.10 has been out for several months now, and I would like to upgrade to it.

While 6.10.2 releases on 2026-01-22, it can take several days for aqt to "catch up" with the latest release. I have time now, so I'll bump from 6.9.3 to 6.10.1.

At the same time, I'd like to upgrade the build environments to use newer OSs / compiler toolchains where possible.