### PR TITLE
Re-enable assembler mnemonic & directive highlighting

### DIFF
--- a/data/changelog/changes.csv
+++ b/data/changelog/changes.csv
@@ -221,4 +221,5 @@ Changed,,0.14.2,1030,"Fix register clocking bug in Pep/9 and Pep/10 microcode si
 Added,,0.14.2,1025,"Begin work on python bindings for assembler and simulator"
 Added,,0.14.2,1032,"Begin implementation of logic-gate (LG1) simulator and editor"
 Fixed,,0.14.2,,"Fix bug where not all shared objects/DLLs are found at runtime"
-Fixed,,0.15.0,1034,"Add a top-level microcode project for one- and two-byte data buses"
+Added,,0.15.0,1034,"Add a top-level microcode project for one- and two-byte data buses"
+Fixed,,0.15.0,1040,"Re-enable assembler mnemonic and directive highlighting"

--- a/lib/text/editor/scintillaasmeditbase.cpp
+++ b/lib/text/editor/scintillaasmeditbase.cpp
@@ -15,12 +15,14 @@
  */
 #include "scintillaasmeditbase.hpp"
 #include <QQmlEngine>
-#include "../../../core/core/arch/pep/isa/pep10.hpp"
-#include "../../../core/core/arch/pep/isa/pep9.hpp"
 #include "Geometry.h"
 #include "LexillaAccess.h"
 #include "SciLexer.h"
 #include "ScintillaEditBase/PlatQt.h"
+#include "core/arch/pep/isa/pep10.hpp"
+#include "core/arch/pep/isa/pep9.hpp"
+#include "core/math/bitmanip/strings.hpp"
+#include "fmt/ranges.h"
 #include "settings/palette.hpp"
 #include "settings/paletteitem.hpp"
 
@@ -134,24 +136,30 @@ void ScintillaAsmEditBase::addInlineAnnotation(int line, const QString &annotati
 }
 
 std::string pep9_mnemonics() {
-  QStringList mnemonics_list;
-  for (const auto &mn : isa::Pep9::mnemonics()) mnemonics_list.append(QString::fromStdString(mn));
-  return mnemonics_list.join(" ").toStdString();
+  auto ret = fmt::format("{}", fmt::join(isa::Pep9::mnemonics(), " "));
+  // lexer seems to lower-case before comparison, so our word list needs to be lower too.
+  bits::to_lower_inplace(ret);
+  return ret;
 }
 std::string pep9_directives() {
   std::string dirs;
   for (const auto &dir : isa::Pep9::legalDirectives()) dirs += "." + dir + " ";
+  // lexer seems to lower-case before comparison, so our word list needs to be lower too.
+  bits::to_lower_inplace(dirs);
   return dirs;
 }
 
 std::string pep10_mnemonics() {
-  QStringList mnemonics_list;
-  for (const auto &mn : isa::Pep10::mnemonics()) mnemonics_list.append(QString::fromStdString(mn));
-  return mnemonics_list.join(" ").toStdString();
+  auto ret = fmt::format("{}", fmt::join(isa::Pep10::mnemonics(), " "));
+  // lexer seems to lower-case before comparison, so our word list needs to be lower too.
+  bits::to_lower_inplace(ret);
+  return ret;
 }
 std::string pep10_directives() {
   std::string dirs;
   for (const auto &dir : isa::Pep10::legalDirectives()) dirs += "." + dir + " ";
+  // lexer seems to lower-case before comparison, so our word list needs to be lower too.
+  bits::to_lower_inplace(dirs);
   return dirs;
 }
 


### PR DESCRIPTION
Seems I need to lowercase word lists before using them. Also, fmt::join does the same thing that my loop does, so prefer the functional style.

Broke this in a5356309509d08ed00431696d14cbefb77c31897, prior to v0.14.2 release.