### PR TITLE
Retry cpack step on failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,7 +220,28 @@ jobs:
         shell: bash
         if: ${{ !contains(inputs.name, 'EMSDK') }}
         working-directory: build
-        run: ls -lah && cpack -c ${{inputs.variant}} && ls -lah
+        env:
+          VARIANT: ${{ inputs.variant }}
+        run: |
+          set -euxo pipefail
+          ls -lah
+          max_attempts=3
+          attempt=1
+          while true; do
+            echo "Running cpack (attempt ${attempt}/${max_attempts})..."
+            if cpack -c "$VARIANT"; then
+              break
+            fi
+
+            if [[ "${attempt}" -ge "${max_attempts}" ]]; then
+              echo "cpack failed after ${max_attempts} attempts."
+              exit 1
+            fi
+            attempt=$((attempt + 1))
+            echo "cpack failed; retrying in 5s..."
+            sleep 5
+          done
+          ls -lah
 
       - name: Codesign Mac OS DMG
         shell: bash


### PR DESCRIPTION
On MacOS, we have flaky CI failures semi-regularly (~10% of commits?) due to a race condition inside cpack:
```bash
CPack Error: Error executing: /usr/bin/hdiutil create -ov -srcfolder "/Users/runner/work/Pepp/Pepp/build/_CPack_Packages/Darwin/DragNDrop/Pepp-0.15.0-mac-arm64" -volname "Pepp-0.15.0-mac-arm64" -fs "HFS+" -format UDZO "/Users/runner/work/Pepp/Pepp/build/_CPack_Packages/Darwin/DragNDrop/temp.dmg"
CPack Error: Error generating temporary disk image.
hdiutil: create failed - Resource busy
```

This error is almost always solved by rerunning step, and hopping hdiutil doesn't hit its race condition.

However, MacOS almost always complete CI first.
With a fail-fast strategy, we kill the pipelines for other targets, and those might take ~30mins to rerun.

As a mitigation, we will retry cpack 3 times before bubbling up the error. True cpack errors are quite rare (and only happen when we change installer params / build env), which is a small fraction of all commits. True errors will be slightly slower to bubble up, but I'm mostly concerned with spurious failures on Mac OS.