### PR TITLE
Give focus to object code editor on creating ISA3 project

### DIFF
--- a/lib/project/Pep10ISA.qml
+++ b/lib/project/Pep10ISA.qml
@@ -126,6 +126,11 @@ FocusScope {
                                      dock_cpu, Qt.size(regmemcol_width,
                                                        memdump_height))
         wrapper.needsDock = Qt.binding(() => false)
+        // Without this workaround the text editor will not receive focus on subsequent key presses.
+        if (PlatformDetector.isWASM)
+            batchInput.forceActiveFocus()
+        // Delay giving focus to editor until the next frame. Any editor that becomes visible without being focused will be incorrectly painted
+        Qt.callLater(() => objEdit.forceActiveFocus())
         modeVisibilityChange()
         for (const x of widgets) {
             x.needsAttention = false

--- a/lib/project/Pep9MA2.qml
+++ b/lib/project/Pep9MA2.qml
@@ -89,6 +89,12 @@ FocusScope {
         dockWidgetArea.addDockWidget(dock_object, KDDW.KDDockWidgets.Location_OnBottom, dock_micro, Qt.size(code_width, microobject_height));
         wrapper.needsDock = Qt.binding(() => false);
         modeVisibilityChange();
+        // WASM version doesn't seem to give focus to editor without giving focus to something else first.
+        // Without this workaround the text editor will not receive focus on subsequent key presses.
+        if (PlatformDetector.isWASM)
+            dock_cpu.forceActiveFocus();
+        // Delay giving focus to editor until the next frame. Any editor that becomes visible without being focused will be incorrectly painted
+        Qt.callLater(() => microEdit.forceEditorFocus())
         for (const x of widgets) {
             x.needsAttention = false;
         }
@@ -97,12 +103,6 @@ FocusScope {
     Component.onCompleted: {
         project.markedClean.connect(wrapper.markClean);
         project.errorsChanged.connect(displayErrors)
-        // WASM version doesn't seem to give focus to editor without giving focus to something else first.
-        // Without this workaround the text editor will not receive focus on subsequent key presses.
-        if (PlatformDetector.isWASM)
-            dock_cpu.forceActiveFocus();
-        // Delay giving focus to editor until the next frame. Any editor that becomes visible without being focused will be incorrectly painted
-        Qt.callLater(() => microEdit.forceEditorFocus())
     }
     function displayErrors() {
         microEdit.addEOLAnnotations(project.microassemblerErrors)


### PR DESCRIPTION
Fixes a bug described by Lesley on 2026-02-20.

Also fix a similar focus issue for MA2 projects.
Assign focus on dock rather than completed, since components may start hidden.