### PR TITLE
Reduce size of Qt builds for WASM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     name: Build RISC-V samples
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/matthew-mcraven/pepp/gcc-riscv:v0.18.0
+      image: ghcr.io/matthew-mcraven/pepp/gcc-riscv:v0.18.1
     steps:
       - uses: actions/checkout@v4
         # LFS defaults to disabled, but accidental LFS bandwidth would be expensive.
@@ -152,12 +152,12 @@ jobs:
       # Trying to use `env` or inputs will fail in this context.
       matrix:
         config:
-          - { name: "Ubuntu 24.04; GCC", cache_name: 'ubuntu-gcc', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/gcc:v0.18.0", compiler_launcher: "ccache", compiler_c: "", compiler_cpp: "", cmake_generator: "Ninja", artifact_key: "artifact-linux"}
+          - { name: "Ubuntu 24.04; GCC", cache_name: 'ubuntu-gcc', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/gcc:v0.18.1", compiler_launcher: "ccache", compiler_c: "", compiler_cpp: "", cmake_generator: "Ninja", artifact_key: "artifact-linux"}
           # Disable CodeQL runs, because they fail on main (and only main) due to disk space exhaustion. We still perform static analsysis (Sonar) on all commits.
-          #- { name: "Ubuntu 24.04; GCC + CodeQL", cache_name: 'ubuntu-gcc', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/gcc:v0.18.0", compiler_launcher: "ccache", compiler_c: "", compiler_cpp: "", cmake_generator: "Ninja", codeql: True, release_variant: 'debug'}
-          - { name: "Ubuntu 24.04; Clang 17.0", cache_name: 'ubuntu-clang', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/clang:v0.18.0",  compiler_launcher: "ccache", compiler_c: "clang", compiler_cpp: "clang++" , cmake_generator: "Ninja" }
-          - { name: "Ubuntu 24.04; Clang 17.0 + SonarQube", cache_name: 'ubuntu-clang-codecov', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/clang:v0.18.0",  compiler_launcher: "ccache", compiler_c: "clang", compiler_cpp: "clang++" , cmake_generator: "Ninja", cmake_xargs: '-D CODECOV=TRUE', codecov: True }
-          - { name: "Ubuntu 24.04; EMSDK 4.1.07", cache_name: 'ubuntu-emsdk', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/wasm:v0.18.0", cmake_generator: "Ninja", compiler_launcher: "ccache", cmake_toolchain: '$Qt6_DIR/qt.toolchain.cmake', cmake_xargs: '-D QT_HOST_PATH=/qt/6.11.0/gcc_64', release_variant: 'MinSizeRel', debug_variant: 'MinSizeRel' }
+          #- { name: "Ubuntu 24.04; GCC + CodeQL", cache_name: 'ubuntu-gcc', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/gcc:v0.18.1", compiler_launcher: "ccache", compiler_c: "", compiler_cpp: "", cmake_generator: "Ninja", codeql: True, release_variant: 'debug'}
+          - { name: "Ubuntu 24.04; Clang 17.0", cache_name: 'ubuntu-clang', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/clang:v0.18.1",  compiler_launcher: "ccache", compiler_c: "clang", compiler_cpp: "clang++" , cmake_generator: "Ninja" }
+          - { name: "Ubuntu 24.04; Clang 17.0 + SonarQube", cache_name: 'ubuntu-clang-codecov', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/clang:v0.18.1",  compiler_launcher: "ccache", compiler_c: "clang", compiler_cpp: "clang++" , cmake_generator: "Ninja", cmake_xargs: '-D CODECOV=TRUE', codecov: True }
+          - { name: "Ubuntu 24.04; EMSDK 4.1.07", cache_name: 'ubuntu-emsdk', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/wasm:v0.18.1", cmake_generator: "Ninja", compiler_launcher: "ccache", cmake_toolchain: '$Qt6_DIR/qt.toolchain.cmake', cmake_xargs: '-D QT_HOST_PATH=/qt/6.11.0/gcc_64', release_variant: 'MinSizeRel', debug_variant: 'MinSizeRel' }
           # See: https://bugreports.qt.io/browse/QTBUG-118086
           - { name: "MacOS-15 ARM64", cache_name: 'macos-clang-arm', runs-on: "macos-15" , compiler_launcher: "ccache", compiler_c: 'clang', compiler_cpp: 'clang++', cmake_generator: "Ninja", artifact_key: "artifact-macos-arm", cmake_xargs: '-D CMAKE_OSX_ARCHITECTURES=arm64' }
           - { name: "MacOS-15 x86-64", cache_name: 'macos-clang-x86', runs-on: "macos-15" , compiler_launcher: "ccache", compiler_c: 'clang', compiler_cpp: 'clang++', cmake_generator: "Ninja", artifact_key: "artifact-macos-x86", cmake_xargs: '-D CMAKE_OSX_ARCHITECTURES=x86_64' }

--- a/config/docker/cpp_build/Dockerfile
+++ b/config/docker/cpp_build/Dockerfile
@@ -70,7 +70,7 @@ RUN git clone https://github.com/emscripten-core/emsdk.git /emsdk
 RUN cd /emsdk && git pull && ./emsdk install ${EMSDK_VERSION} && ./emsdk activate ${EMSDK_VERSION} && echo uname -a /emsdk.arch
 # Install shadertools and 3d modules otherwise building from sources will fail.
 RUN python3 -m venv /venv && source /venv/bin/activate \
-  && pip install aqtinstall &&  aqt install-qt linux desktop ${QT_VERSION} -m qtshadertools qtquick3d qt3d qtcanvaspainter qtlottie --outputdir /qt \
+  && pip install aqtinstall &&  aqt install-qt linux desktop ${QT_VERSION} -m qtshadertools --outputdir /qt \
   && rm aqtinstall.log && rm -rf /venv
 
 # Use separate step to build Qt to avoid inflating the size of the build image further.
@@ -90,12 +90,15 @@ RUN wget -q "https://download.qt.io/official_releases/qt/${QT_RELEASE}/${QT_VERS
     && mv /build-qt/qt-everywhere-src-${QT_VERSION} /build-qt/${QT_VERSION} \
     && rm qt-everywhere-src-${QT_VERSION}.tar.xz
 
+# Extra args with which to build Qt
+ARG QT_WASM_XARGS=""
 
 # Must activate EMSDK or it will not build. Skip some features that would require installing additional libraries.
 # Enable excptions, because that was the whole point of building Qt from the sources
 RUN source /emsdk/emsdk_env.sh \
-    && cmake -S /build-qt/${QT_VERSION} -B /build-qt/${QT_VERSION}/build -G Ninja \
+    && cmake -S /build-qt/${QT_VERSION} -B /build-qt/${QT_VERSION}/build -G Ninja -DCMAKE_BUILD_TYPE=MinSizeRel \
        -DCMAKE_TOOLCHAIN_FILE=/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake \
+       ${QT_WASM_XARGS} \
        -DQT_HOST_PATH=/qt/${QT_VERSION}/gcc_64 \
        -DFEATURE_thread=OFF \
        -DFEATURE_wasm_exceptions=ON \
@@ -104,11 +107,21 @@ RUN source /emsdk/emsdk_env.sh \
        -DBUILD_qtremoteobjects=OFF  -DBUILD_qtwebengine=OFF -DBUILD_qtscxml=OFF -DBUILD_qthttpserver=OFF \
        -DBUILD_qtwebview=OFF -DBUILD_qtwebchannel=OFF -DBUILD_qtsensors=OFF -DBUILD_qtwebsockets=OFF \
        -DBUILD_qtlocation=OFF -DBUILD_qtpositioning=OFF -DBUILD_qtactiveqt=OFF -DBUILD_qt5compat=OFF \
-       -DBUILD_qtlottie=OFF -DBUILD_qtcanvaspainter=OFF -DBUILD_qtgraphs=OFF -DBUILD_qtdbus=OFF
+       -DBUILD_qtlottie=OFF -DBUILD_qtcanvaspainter=OFF -DBUILD_qtgraphs=OFF -DBUILD_qtdbus=OFF \
+       -DBUILD_qt3d=OFF -DBUILD_qtcharts=OFF -DBUILD_qtserialport=OFF -DBUILD_qtserialbus=OFF -DBUILD_qtspeech=OFF \
+       -DBUILD_qtquick3d=OFF -DBUILD_qtquick3dphysics=OFF\
+       -DBUILD_qtmultimedia=OFF -DBUILD_qtdatavis3d=OFF \
+       -DBUILD_qtvirtualkeyboard=OFF \
+       -DBUILD_qtopcua=OFF -DBUILD_qtcoap=OFF -DBUILD_qtmqtt=OFF -DBUILD_qtnetworkauth=OFF \
+       -DBUILD_qtpdf=OFF -DBUILD_qtdoc=OFF \
+       -DFEATURE_ssl=OFF -DFEATURE_dtls=OFF -DFEATURE_ocsp=OFF \
+       -DFEATURE_sql_mysql=OFF -DFEATURE_sql_psql=OFF -DFEATURE_sql_odbc=OFF \
+       -DFEATURE_imageformat_webp=ON \
+       -DFEATURE_printer=OFF -DFEATURE_printdialog=OFF -DFEATURE_printpreviewdialog=OFF -DFEATURE_printpreviewwidget=OFF
 # Separate build from configure so that I get better logs
 RUN cd /build-qt/${QT_VERSION}/build \
     && cmake --build . --parallel \
-    && cmake --install .
+    && cmake --install . --prefix /qt/${QT_VERSION}/wasm_singlethread
 
 # Only copy over WASM artifacts, since we already have GCC from the base image.
 FROM base-wasm AS output-wasm

--- a/config/docker/docker-bake.hcl
+++ b/config/docker/docker-bake.hcl
@@ -14,7 +14,7 @@ group "img" {
 
 
 variable "VERSION" {
-  default = "v0.18.0"
+  default = "v0.18.1"
 }
 
 target "gcc-riscv" {
@@ -59,7 +59,7 @@ target "wasm-dbg" {
   platforms = ["linux/amd64"]
   target = "output-wasm"
   args {
-    QT_WASM_XARGS = "-sanitize address  -sanitize undefined -device-option QT_WASM_SOURCE_MAP=1"
+    QT_WASM_XARGS = "-DFEATURE_sanitize_address=ON -DFEATURE_sanitize_undefined=ON -DQT_QMAKE_DEVICE_OPTIONS=QT_WASM_SOURCE_MAP=1"
   }
 }
 
@@ -71,7 +71,7 @@ target "dev-wasm-dbg" {
   target = "output-gcc"
   args {
     BASE_IMAGE = "mcr.microsoft.com/devcontainers/base:ubuntu"
-    QT_WASM_XARGS = "-sanitize address  -sanitize undefined -device-option QT_WASM_SOURCE_MAP=1"
+    QT_WASM_XARGS = "-DFEATURE_sanitize_address=ON -DFEATURE_sanitize_undefined=ON -DQT_QMAKE_DEVICE_OPTIONS=QT_WASM_SOURCE_MAP=1"
   }
 }
 


### PR DESCRIPTION
Sizes from before are 25.5MB compressed.

Compiling with MinSizeRel and removing unneeded features reduces the size to 23.9MB