### PR TITLE
Enable "format source" inside macro bodies

### DIFF
--- a/core/core/langs/asmb/asmb_lexer.cpp
+++ b/core/core/langs/asmb/asmb_lexer.cpp
@@ -68,6 +68,7 @@ std::shared_ptr<pepp::tc::lex::Token> pepp::tc::lex::AsmbLexer::next_token() {
   const std::regex &identifier = _opts.allow_dot_in_ident
                                      ? (_opts.allow_at_in_ident ? identifier_dot_at : identifier_dot_noat)
                                      : (_opts.allow_at_in_ident ? identifier_nodot_at : identifier_nodot_noat);
+  static const std::regex macroarg(R"(\\([@a-zA-Z_+][a-zA-Z0-9_.]*|\(\)))");
   static const std::regex directive("\\.[a-zA-Z][a-zA-Z0-9_]*");
   static const std::regex symbol("[a-zA-Z_][a-zA-Z0-9_]*:");
   static const std::regex decimal("[0-9]+");
@@ -114,6 +115,16 @@ std::shared_ptr<pepp::tc::lex::Token> pepp::tc::lex::AsmbLexer::next_token() {
         auto fmt = sign < 0 ? Format::SignedDec : Format::UnsignedDec;
         current_token = std::make_shared<Integer>(LocationInterval{loc_start, _cursor.location()}, sign * val, fmt);
       } else
+        current_token =
+            std::make_shared<Invalid>(LocationInterval{loc_start, _cursor.location()}, std::string{_cursor.select()});
+      break;
+    } else if (auto maybeMacroArg = _cursor.matchView(macroarg); !maybeMacroArg.empty()) {
+      auto match = maybeMacroArg.str(0);
+      _cursor.advance(match.size());
+      auto const *id = &*_pool->emplace(match.substr(1)).first; // Drop leading backslash
+      if (_opts.allow_macro_arguments)
+        current_token = std::make_shared<MacroPlaceholder>(LocationInterval{loc_start, _cursor.location()}, id);
+      else
         current_token =
             std::make_shared<Invalid>(LocationInterval{loc_start, _cursor.location()}, std::string{_cursor.select()});
       break;

--- a/core/core/langs/asmb/asmb_lexer.cpp
+++ b/core/core/langs/asmb/asmb_lexer.cpp
@@ -7,10 +7,41 @@
 #include "core/langs/asmb/asmb_tokens.hpp"
 #include "core/math/bitmanip/strings.hpp"
 
+static std::unordered_set<char> literals_for(pepp::tc::lex::AsmbOptions opts) {
+  static const std::unordered_set<char> parens{'(', ')'};
+  static const std::unordered_set<char> operators{'+', '-', '*', '/', '%', '|', '&', '^', '=', '~', '!', '<', '>'};
+  static const std::unordered_set<char> r_with_both = [&] {
+    auto r = parens;
+    r.insert(operators.begin(), operators.end());
+    r.insert(',');
+    return r;
+  }();
+
+  static const std::unordered_set<char> r_parens_only = [&] {
+    auto r = parens;
+    r.insert(',');
+    return r;
+  }();
+
+  static const std::unordered_set<char> r_ops_only = [&] {
+    auto r = operators;
+    r.insert(',');
+    return r;
+  }();
+
+  static const std::unordered_set<char> r_comma_only{','};
+
+  if (opts.allow_parens && opts.recognize_operators) return r_with_both;
+  else if (opts.allow_parens && !opts.recognize_operators) return r_parens_only;
+  else if (!opts.allow_parens && opts.recognize_operators) return r_ops_only;
+  else return r_comma_only;
+}
+
 pepp::tc::lex::AsmbLexer::AsmbLexer(std::shared_ptr<std::unordered_set<std::string>> identifier_pool,
                                     support::SeekableData &&data, AsmbOptions options)
     : ALexer(identifier_pool, std::move(data)), _opts(options) {
   _lineCommentRegex = std::make_unique<std::regex>(options.line_comment_leader + "[^\n]*");
+  _literals = literals_for(options);
 }
 
 bool pepp::tc::lex::AsmbLexer::input_remains() const { return _cursor.input_remains(); }
@@ -66,11 +97,11 @@ std::shared_ptr<pepp::tc::lex::Token> pepp::tc::lex::AsmbLexer::next_token() {
       _cursor.skip(1);
       loc_start = _cursor.location();
       continue;
-    } else if (next == ',') {
+    } else if (_literals.contains(next)) {
       _cursor.advance(1);
-      current_token = std::make_shared<Literal>(LocationInterval{loc_start, _cursor.location()}, ",");
+      current_token = std::make_shared<Literal>(LocationInterval{loc_start, _cursor.location()}, std::string{next});
       break;
-    } else if (next == '+' || next == '-') {
+    } else if (!_opts.recognize_operators && (next == '+' || next == '-')) {
       auto sign = (next == '-') ? -1 : 1;
       // "Eat" the sign so that we can parse the number after it.
       _cursor.skip(1);
@@ -85,14 +116,6 @@ std::shared_ptr<pepp::tc::lex::Token> pepp::tc::lex::AsmbLexer::next_token() {
       } else
         current_token =
             std::make_shared<Invalid>(LocationInterval{loc_start, _cursor.location()}, std::string{_cursor.select()});
-      break;
-    } else if (next == '(' && _opts.allow_parens) {
-      _cursor.advance(1);
-      current_token = std::make_shared<Literal>(LocationInterval{loc_start, _cursor.location()}, "(");
-      break;
-    } else if (next == ')' && _opts.allow_parens) {
-      _cursor.advance(1);
-      current_token = std::make_shared<Literal>(LocationInterval{loc_start, _cursor.location()}, ")");
       break;
     } else if (auto maybeSymbol = _cursor.matchView(symbol); !maybeSymbol.empty()) {
       auto match = maybeSymbol.str(0);

--- a/core/core/langs/asmb/asmb_lexer.hpp
+++ b/core/core/langs/asmb/asmb_lexer.hpp
@@ -6,7 +6,12 @@ struct AsmbOptions {
   bool allow_dot_in_ident = true;
   bool allow_parens = false;          // Tokenize ( and ) as literals rather than invalid tokens.
   bool allow_macro_arguments = false; // Macros arguments start with a backslash like \arg1
-  bool allow_at_in_ident = false;     // Allow @ in identifiers, which is used for macros instatniations in Pep/10.
+  bool allow_at_in_ident = false;     // Allow @ in identifiers, which is used for macros instantiations in Pep/10.
+  // Match all GNU as operators, per: https://sourceware.org/binutils/docs-2.24/as/Expressions.html#Expressions
+  // Enabling this flag disables parsing of signed integers. Operator precedence is required to determine if +- are
+  // unary prefix or binary infix.
+  // Multi-character operators need to be "fused" at the parser level.
+  bool recognize_operators = false;
   std::string line_comment_leader = ";";
 };
 struct AsmbLexer : public ALexer {
@@ -30,6 +35,7 @@ private:
   std::unique_ptr<std::regex> _lineCommentRegex = nullptr;
   // Not needed in base lexer since we only need it to support macros/conditionals.
   std::map<decltype(support::Location::row), size_t> _row_to_streampos;
+  std::unordered_set<char> _literals;
 };
 
 } // namespace pepp::tc::lex

--- a/core/core/langs/asmb/asmb_tokens.cpp
+++ b/core/core/langs/asmb/asmb_tokens.cpp
@@ -26,3 +26,14 @@ std::string pepp::tc::lex::StringConstant::type_name() const { return "StringCon
 std::string pepp::tc::lex::StringConstant::to_string() const { return fmt::format("\"{}\"", view()); }
 
 std::string pepp::tc::lex::StringConstant::repr() const { return fmt::format("{}({})", type_name(), view()); }
+
+pepp::tc::lex::MacroPlaceholder::MacroPlaceholder(support::LocationInterval loc, const std::string *v)
+    : Identifier(loc, v) {}
+
+int pepp::tc::lex::MacroPlaceholder::type() const { return TYPE; }
+
+std::string pepp::tc::lex::MacroPlaceholder::type_name() const { return "MacroPlaceholder"; }
+
+std::string pepp::tc::lex::MacroPlaceholder::to_string() const { return fmt::format("\\{}", view()); }
+
+std::string pepp::tc::lex::MacroPlaceholder::repr() const { return fmt::format("{}({})", type_name(), view()); }

--- a/core/core/langs/asmb/asmb_tokens.hpp
+++ b/core/core/langs/asmb/asmb_tokens.hpp
@@ -6,6 +6,7 @@ enum class AsmTokenType {
   DotCommand = static_cast<int>(CommonTokenType::_FirstUser) << 0,
   CharacterConstant = static_cast<int>(CommonTokenType::_FirstUser) << 1,
   StringConstant = static_cast<int>(CommonTokenType::_FirstUser) << 2,
+  MacroPlaceholder = static_cast<int>(CommonTokenType::_FirstUser) << 3,
 };
 
 struct DotCommand : public Identifier {
@@ -30,6 +31,15 @@ struct CharacterConstant : public Token {
 struct StringConstant : public Identifier {
   StringConstant(support::LocationInterval loc, std::string const *v);
   static constexpr int TYPE = static_cast<int>(AsmTokenType::StringConstant);
+  int type() const override;
+  std::string type_name() const override;
+  std::string to_string() const override;
+  std::string repr() const override;
+};
+
+struct MacroPlaceholder : public Identifier {
+  MacroPlaceholder(support::LocationInterval loc, std::string const *v);
+  static constexpr int TYPE = static_cast<int>(AsmTokenType::MacroPlaceholder);
   int type() const override;
   std::string type_name() const override;
   std::string to_string() const override;

--- a/core/core/langs/asmb_pep/text_format.cpp
+++ b/core/core/langs/asmb_pep/text_format.cpp
@@ -45,6 +45,107 @@ std::string pepp::tc::format_as_columns(const std::string &col0, const std::stri
   return bits::rtrimmed(formatted);
 }
 
+namespace {
+/* A helper class to group macro placeholders around a "stem" token.
+ * To format macro placeholders correctly, each of the following should format like a single token when not separated by
+ * spaces. e.g., `A        \m\()A        A\m        \m\()A\m\m`. There is a special case where the stem token is itself
+ * a macro placeholder, which occurs when a macro placeholder is freestanding e.g, `A     \m`
+ *
+ * The terminology here dervies a bit from lingusitics. The stem refers to the core token around which macro
+ * placeholders are "glued on". Macro placeholders before the stem are prefixes, and those after the stem are suffixes:
+ * e.g., `\prefix1\prefix2\()STEM\suffix1\suffix2`.
+ *
+ * Either the prefix or suffix or both can be empty, but the stem token will always be non-null if input remains.
+ * There can only be one stem token per group, and only macro placeholders can be affixes (i.e., prefix or suffix).
+ * The most common case is a single stem token with empty affixes.
+ *
+ * The prefix+stem+suffix is stored in head, whil all remaining tokens are stored in rest.
+ */
+struct TokenGroup {
+  int stem_token_type = (int)pepp::tc::lex::CommonTokenType::Invalid;
+  int stem_token_index = -1;
+  std::span<std::shared_ptr<pepp::tc::lex::Token> const> head = {}, rest = {};
+  // Return the stem token
+  pepp::tc::lex::Token const *stem() const {
+    if (stem_token_index < 0 || stem_token_index >= head.size()) return nullptr;
+    return &*head[stem_token_index];
+  }
+  // Format the "stem" token in head specially, and use default formatting for prefix and suffix.
+  std::string formatted_head(std::string formatted_stem) const {
+    // Create a std::span of the
+    auto prefix = head.subspan(0, stem_token_index);
+    auto suffix = head.subspan(stem_token_index + 1);
+    auto prefix_strs = prefix | std::views::transform([](const auto &elem) { return elem->to_string(); });
+    auto suffix_strs = suffix | std::views::transform([](const auto &elem) { return elem->to_string(); });
+    return fmt::format("{}{}{}", fmt::join(prefix_strs, ""), formatted_stem, fmt::join(suffix_strs, ""));
+  }
+  // Use default formatting for all parts of the head.
+  std::string formatted_head() {
+    auto head_strs = head | std::views::transform([](const auto &elem) { return elem->to_string(); });
+    return fmt::format("{}", fmt::join(head_strs, ""));
+  }
+};
+
+// Helper to idenfitiy when two tokens are touching each other (e.g., not separated by spaces.
+bool adjacent(pepp::tc::support::LocationInterval first, pepp::tc::support::LocationInterval second) {
+  // By definition, an interval is adjacent to itself. Needed to establish the loop invariant for next_group.
+  if (first == second) return true;
+  // Otherwise intervals must describe same row.
+  const bool same_row = first.upper().row == second.lower().row;
+  // There is sometimes an off-by-1 where the upper.column ==lower.column
+  // Rather than have complex == tests, we can just compute the distance.
+  const bool adjacent_columns = second.lower().column - first.upper().column <= 0;
+  return same_row && adjacent_columns;
+}
+
+// Given a span of tokens, return a TokenGroup representing the longest prefix of tokens that meets the requirements
+// prefix+stem+suffix. The remaining tokens are in the "rest" field of the return value. Will return an empty/invalid
+// group if input is already exhausted.
+TokenGroup next_group(std::span<std::shared_ptr<pepp::tc::lex::Token> const> tokens) {
+  using CTT = pepp::tc::lex::CommonTokenType;
+  // comments/empty/eof/literals to "combine" with macro placeholders either to their left or their right.
+  static const int left_uncombinable = (int)CTT::InlineComment | (int)CTT::Empty | (int)CTT::EoF | (int)CTT::Literal;
+  // Symbol declarations allow placeholders to combine from the left but not the right.
+  // e.g., `\a\()World:` is fine, but `world:\a` is not.
+  static const int right_uncombinable = left_uncombinable | (int)CTT::SymbolDeclaration;
+  if (tokens.empty()) return {};
+  auto it = tokens.begin(), stem_token_iterator = tokens.begin(), prev = it;
+
+  // Consume adjacent tokens until we find a non-macro-placeholder token, which is the stem.
+  while (it != tokens.end() && adjacent((*prev)->location(), (*it)->location())) {
+    // Avoid combining specified token types with placeholders to their left.
+    if (const int type = (*it)->type(); (type & left_uncombinable) != 0) {
+      // If starting with an uncombinable token, it must be consumed to ensure forward progress.
+      if (prev == it) it++;
+      // Current value of it becomes the first token of rest.
+      goto ret;
+    } else if (type != (int)pepp::tc::lex::AsmTokenType::MacroPlaceholder) {
+      prev = it, stem_token_iterator = it++;
+      break;
+    } else prev = it++;
+  }
+
+  // Avoid combining specified tokens with placeholders to their right.
+  if (((*stem_token_iterator)->type() & right_uncombinable) != 0) goto ret;
+
+  // Continue consuming adjacent tokens after the stem, which are the suffixes. Do not consume a token which could be
+  // the next group's stem.
+  while (it != tokens.end() && adjacent((*prev)->location(), (*it)->location())) {
+    if (const int type = (*it)->type(); type != (int)pepp::tc::lex::AsmTokenType::MacroPlaceholder) {
+      // If prev is begin (occurs w/2 adjacent stem tokens), do not reset. Else head is empty, CTD ensues.
+      if (prev != tokens.begin()) it = prev;
+      break;
+    } else prev = it++;
+  }
+ret:
+  return TokenGroup{.stem_token_type = (*stem_token_iterator)->type(),
+                    .stem_token_index = (i32)std::distance(tokens.begin(), stem_token_iterator),
+                    .head = std::span(tokens.begin(), it),
+                    .rest = std::span(it, tokens.end())};
+}
+
+} // namespace
+
 std::string pepp::tc::format_source(std::span<std::shared_ptr<lex::Token> const> tokens) {
   using CTT = lex::CommonTokenType;
   using ATT = lex::AsmTokenType;
@@ -60,35 +161,60 @@ std::string pepp::tc::format_source(std::span<std::shared_ptr<lex::Token> const>
   // Accumulate arguments in a list rather directly into the corresponding column.
   std::vector<std::string> arg_list;
   std::string col0 = "", col1 = "", col2 = "", col3 = "", temp = "";
-
   auto state = States::START;
-  for (const auto &token : tokens) {
+  auto handle_argument = [&](auto &group) {
+    state = States::ARGED2;
+    scanned_args++;
+    temp = group.stem()->to_string();
+    if (scanned_args == force_lowercase_on_arg) bits::to_lower_inplace(temp);
+    arg_list.emplace_back(group.formatted_head(temp));
+  };
+  // Combine the argument list into a comma-separated string, inserted into the second column.
+  auto finalize_args = [&]() { col2 = fmt::format("{}", fmt::join(arg_list, space_after_comma ? ", " : ",")); };
+  // Process tokens on (prefix+stem+suffix) group at a time.
+  // next_group guarantees a non-empty head as long as the input is non-empty.
+  std::span<std::shared_ptr<lex::Token> const> rest = tokens;
+  while (!rest.empty()) {
+    auto group = next_group(rest);
+    rest = group.rest;
     if (!valid || state == States::END) break;
     switch (state) {
     case States::START:
-      switch ((int)token->type()) {
+      switch ((int)group.stem_token_type) {
       case (int)CTT::EoF: [[fallthrough]];
-      case (int)CTT::Empty: state = States::END; break;
+      case (int)CTT::Empty: valid = group.head.size() == 1, state = States::END; break;
       case (int)CTT::InlineComment:
         state = States::COMMENT;
-        col0 = ";" + token->to_string();
+        col0 = group.formatted_head(";" + group.stem()->to_string());
         break;
       case (int)CTT::SymbolDeclaration:
         state = States::SYMBOL;
-        col0 = token->to_string() + ":";
+        col0 = group.formatted_head(group.stem()->to_string() + ":");
+        break;
+      case (int)ATT::MacroPlaceholder:
+        state = States::ARGED1;
+        col1 = group.formatted_head();
         break;
       case (int)ATT::DotCommand:
-        col1 = "." + token->to_string();
-        bits::to_upper_inplace(col1);
+        temp = "." + group.stem()->to_string();
+        bits::to_upper_inplace(temp);
+        col1 = group.formatted_head(temp);
         // Need special formatting for macros
         if (col1 == ".MACRO") state = States::MACRO_EXPECT_NAME;
         else state = States::ARGED1;
         space_after_comma = true;
         break;
+      case (int)CTT::Literal:
+        if (group.stem()->to_string() == ":" && group.head.size() > 1) {
+          state = States::SYMBOL;
+          col0 = group.formatted_head();
+        } else valid = false;
+        break;
       case (int)CTT::Identifier:
         state = States::ARGED1;
-        col1 = token->to_string();
-        bits::to_upper_inplace(col1);
+        temp = group.stem()->to_string();
+        bits::to_upper_inplace(temp);
+        col1 = group.formatted_head(temp);
         force_lowercase_on_arg = 2;
         break;
       default: valid = false;
@@ -96,7 +222,7 @@ std::string pepp::tc::format_source(std::span<std::shared_ptr<lex::Token> const>
       break;
 
     case States::COMMENT:
-      switch ((int)token->type()) {
+      switch ((int)group.stem_token_type) {
       case (int)CTT::EoF: [[fallthrough]];
       case (int)CTT::Empty: state = States::END; break;
       default: valid = false;
@@ -104,18 +230,25 @@ std::string pepp::tc::format_source(std::span<std::shared_ptr<lex::Token> const>
       break;
 
     case States::SYMBOL:
-      switch ((int)token->type()) {
+      switch ((int)group.stem_token_type) {
       case (int)ATT::DotCommand:
         state = States::ARGED1;
-        col1 = "." + token->to_string();
-        bits::to_upper_inplace(col1);
+        temp = "." + group.stem()->to_string();
+        bits::to_upper_inplace(temp);
+        col1 = group.formatted_head(temp);
         space_after_comma = true;
         break;
-
       case (int)CTT::Identifier:
         state = States::ARGED1;
-        col1 = token->to_string();
-        bits::to_upper_inplace(col1);
+        temp = group.stem()->to_string();
+        bits::to_upper_inplace(temp);
+        col1 = (temp);
+        force_lowercase_on_arg = 2;
+        break;
+      case (int)ATT::MacroPlaceholder:
+        state = States::ARGED1;
+        col1 = group.formatted_head();
+        // Treat macro placeholder as-if an instruction.
         force_lowercase_on_arg = 2;
         break;
       default: valid = false;
@@ -124,30 +257,28 @@ std::string pepp::tc::format_source(std::span<std::shared_ptr<lex::Token> const>
 
     // Optional argument OR some kind of EoL/comment
     case States::ARGED1:
-      switch ((int)token->type()) {
+      switch ((int)group.stem_token_type) {
       case (int)CTT::EoF: [[fallthrough]];
       case (int)CTT::Empty:
-        col2 = fmt::format("{}", fmt::join(arg_list, space_after_comma ? ", " : ","));
+        finalize_args();
         state = States::END;
         break;
       case (int)CTT::InlineComment:
-        col2 = fmt::format("{}", fmt::join(arg_list, space_after_comma ? ", " : ","));
-        col3 = ";" + token->to_string();
+        finalize_args();
+        col3 = ";" + group.stem()->to_string();
         state = States::COMMENT;
         break;
       case (int)CTT::Literal:
-        if (token->to_string() == ",") state = States::ARGED2;
+        if (group.stem()->to_string() == ",") state = States::ARGED2;
         else valid = false;
         break;
       case (int)CTT::Integer: [[fallthrough]];
       case (int)ATT::CharacterConstant: [[fallthrough]];
       case (int)ATT::StringConstant: [[fallthrough]];
-      case (int)CTT::Identifier:
-        state = States::ARGED2;
-        scanned_args++;
-        temp = token->to_string();
-        if (scanned_args == force_lowercase_on_arg) bits::to_lower_inplace(temp);
-        arg_list.emplace_back(temp);
+      case (int)CTT::Identifier: handle_argument(group); break;
+      case (int)ATT::MacroPlaceholder:
+        state = States::ARGED2, scanned_args++;
+        arg_list.push_back(group.formatted_head());
         break;
       default: valid = false;
       }
@@ -155,19 +286,19 @@ std::string pepp::tc::format_source(std::span<std::shared_ptr<lex::Token> const>
 
     // Last state was an argument! So we can be an EOL or the start of the next arg in a list
     case States::ARGED2:
-      switch ((int)token->type()) {
+      switch ((int)group.stem_token_type) {
       case (int)CTT::EoF: [[fallthrough]];
       case (int)CTT::Empty:
-        col2 = fmt::format("{}", fmt::join(arg_list, space_after_comma ? ", " : ","));
+        finalize_args();
         state = States::END;
         break;
       case (int)CTT::InlineComment:
-        col2 = fmt::format("{}", fmt::join(arg_list, space_after_comma ? ", " : ","));
-        col3 = ";" + token->to_string();
+        finalize_args();
+        col3 = ";" + group.stem()->to_string();
         state = States::COMMENT;
         break;
       case (int)CTT::Literal:
-        if (token->to_string() == ",") state = States::ARGED3;
+        if (group.stem()->to_string() == ",") state = States::ARGED3;
         else valid = false;
         break;
       default: valid = false;
@@ -176,33 +307,35 @@ std::string pepp::tc::format_source(std::span<std::shared_ptr<lex::Token> const>
 
     // Search for an argument seperator
     case States::ARGED3:
-      switch ((int)token->type()) {
+      switch ((int)group.stem_token_type) {
       case (int)CTT::Integer: [[fallthrough]];
       case (int)ATT::CharacterConstant: [[fallthrough]];
       case (int)ATT::StringConstant: [[fallthrough]];
-      case (int)CTT::Identifier:
-        state = States::ARGED2;
-        scanned_args++;
-        temp = token->to_string();
-        if (scanned_args == force_lowercase_on_arg) bits::to_lower_inplace(temp);
-        arg_list.emplace_back(temp);
+      case (int)CTT::Identifier: handle_argument(group); break;
+      case (int)ATT::MacroPlaceholder:
+        state = States::ARGED2, scanned_args++;
+        arg_list.push_back(group.formatted_head());
         break;
       default: valid = false;
       }
       break;
     case States::MACRO_EXPECT_NAME:
-      switch ((int)token->type()) {
+      switch ((int)group.stem_token_type) {
       case (int)CTT::Identifier:
         state = States::ARGED1;
-        col1 += token->to_string();
+        col1 += " " + group.formatted_head(group.stem()->to_string());
         break;
       default: valid = false;
       }
     default: break;
     }
   }
-  if (valid) return format_as_columns(col0, col1, col2, col3);
-  return "";
+
+  if (!valid) return "";
+  // Reached end-of-input w/o hitting an EoF or empty token. This should still format correctly, and requires
+  // finalization of args.
+  else if (!arg_list.empty()) finalize_args();
+  return format_as_columns(col0, col1, col2, col3);
 }
 
 namespace pepp::tc {

--- a/core/core/langs/asmb_pep/text_format.cpp
+++ b/core/core/langs/asmb_pep/text_format.cpp
@@ -131,11 +131,8 @@ TokenGroup next_group(std::span<std::shared_ptr<pepp::tc::lex::Token> const> tok
   // Continue consuming adjacent tokens after the stem, which are the suffixes. Do not consume a token which could be
   // the next group's stem.
   while (it != tokens.end() && adjacent((*prev)->location(), (*it)->location())) {
-    if (const int type = (*it)->type(); type != (int)pepp::tc::lex::AsmTokenType::MacroPlaceholder) {
-      // If prev is begin (occurs w/2 adjacent stem tokens), do not reset. Else head is empty, CTD ensues.
-      if (prev != tokens.begin()) it = prev;
-      break;
-    } else prev = it++;
+    if (const int type = (*it)->type(); type != (int)pepp::tc::lex::AsmTokenType::MacroPlaceholder) break;
+    else prev = it++;
   }
 ret:
   return TokenGroup{.stem_token_type = (*stem_token_iterator)->type(),

--- a/test/core/langs/asmb/asmb_lexer.cpp
+++ b/test/core/langs/asmb/asmb_lexer.cpp
@@ -108,6 +108,24 @@ TEST_CASE("Assembly lexer", "[scope:core][scope:core.langs][level:asmb3][level:a
     check_next(l, (int)CTT::Empty);
     CHECK(!l.input_remains());
   }
+  SECTION("Special macro placeholders") {
+    auto l = Lexer(idpool(), data("\\@\\+\\()"), p10);
+    auto c = check_next(l, (int)ATT::MacroPlaceholder);
+    CHECK(c->to_string() == "\\@");
+    c = check_next(l, (int)ATT::MacroPlaceholder);
+    CHECK(c->to_string() == "\\+");
+    c = check_next(l, (int)ATT::MacroPlaceholder);
+    CHECK(c->to_string() == "\\()");
+    CHECK(!l.input_remains());
+  }
+  SECTION("Identifier macro placeholders") {
+    auto l = Lexer(idpool(), data("\\foo\\bar"), p10);
+    auto c = check_next(l, (int)ATT::MacroPlaceholder);
+    CHECK(c->to_string() == "\\foo");
+    c = check_next(l, (int)ATT::MacroPlaceholder);
+    CHECK(c->to_string() == "\\bar");
+    CHECK(!l.input_remains());
+  }
   SECTION("Comment") {
     // pep-style inline comments
     auto l = Lexer(idpool(), data(" ;Comment here\n"), p10);

--- a/test/core/langs/asmb/asmb_lexer.cpp
+++ b/test/core/langs/asmb/asmb_lexer.cpp
@@ -100,6 +100,14 @@ TEST_CASE("Assembly lexer", "[scope:core][scope:core.langs][level:asmb3][level:a
     check_next(l, (int)CTT::Empty);
     CHECK(!l.input_remains());
   }
+  SECTION("Arithmetic ops") {
+    auto l = Lexer(idpool(), data("   *\n&  "), p10);
+    auto c = check_next(l, (int)CTT::Invalid);
+    check_next(l, (int)CTT::Empty);
+    c = check_next(l, (int)CTT::Invalid);
+    check_next(l, (int)CTT::Empty);
+    CHECK(!l.input_remains());
+  }
   SECTION("Comment") {
     // pep-style inline comments
     auto l = Lexer(idpool(), data(" ;Comment here\n"), p10);

--- a/test/core/langs/asmb_pep/text_format.cpp
+++ b/test/core/langs/asmb_pep/text_format.cpp
@@ -378,6 +378,45 @@ TEST_CASE("Pepp ASM source formatting", "[scope:core][scope:core.langs][level:as
   }
 }
 
+TEST_CASE("Pepp ASM macro argument source formatting",
+          "[scope:core][scope:core.langs][level:asmb3][level:asmb5][kind:unit][arch:*]") {
+  using Lexer = pepp::tc::lex::PepLexer;
+  using Buffer = pepp::tc::lex::Buffer;
+  using Checkpoint = pepp::tc::lex::Checkpoint;
+  using Parser = pepp::tc::parser::PepParser;
+  using MR = pepp::tc::MacroRegistry;
+  using namespace pepp::tc::lex;
+  using pepp::tc::format_source;
+  using T = std::tuple<std::string, std::string>;
+  auto [input, expected] = GENERATE(
+      as<T>{},
+      // Force a line break.
+      std::make_tuple("\\m", "         \\m"),                                        // as-if an monadic instruction
+      std::make_tuple("id: \\m", "id:      \\m"),                                    // as-if a monadic instruction
+      std::make_tuple("id: \\m\\m", "id:      \\m\\m"),                              // as-if a monadic instruction
+      std::make_tuple("a\\m", "         A\\m"),                                      // as-if a monadic instruction
+      std::make_tuple("\\m\\()a\\m", "         \\m\\()A\\m"),                        // as-if a monadic instruction
+      std::make_tuple("\\m\\m", "         \\m\\m"),                                  // as-if a monadic instruction
+      std::make_tuple("\\m \\m", "         \\m      \\m"),                           // as-if a branch instruction
+      std::make_tuple("id:\\m \\m", "id:      \\m      \\m"),                        // as-if a branch instruction
+      std::make_tuple("\\m\\m \\m", "         \\m\\m    \\m"),                       // as-if a branch instruction
+      std::make_tuple("\\m\\m \\m\\m", "         \\m\\m    \\m\\m"),                 // as-if a branch instruction
+      std::make_tuple("\\m\\m \\m\\m;com", "         \\m\\m    \\m\\m        ;com"), // as-if a branch instruction
+      std::make_tuple("id: \\m\\m \\m\\m", "id:      \\m\\m    \\m\\m"),             // as-if a branch instruction
+      std::make_tuple("id: \\m \\m,\\m", "id:      \\m      \\m,\\m"),               // as-if a dyadic instruction
+      std::make_tuple("id: id \\m\\m,\\m", "id:      ID      \\m\\m,\\m"),           // as-if a dyadic instruction
+      std::make_tuple("id: id \\m\\m,\\m\\m", "id:      ID      \\m\\m,\\m\\m")      // as-if a dyadic instruction
+  );
+
+  auto l = Lexer(idpool(), data(input + "\n"));
+  auto b = Buffer(&l);
+  Checkpoint{b};
+  b.match_until<pepp::tc::lex::Empty>();
+  auto sp = b.matched_tokens();
+  auto lexer_formatted = format_source(sp);
+  CHECK(lexer_formatted == expected);
+}
+
 TEST_CASE("Pepp ASM listing formatting",
           "[scope:core][scope:core.langs][level:asmb3][level:asmb5][kind:unit][arch:*]") {
   using Lexer = pepp::tc::lex::PepLexer;

--- a/test/core/langs/asmb_pep/text_format.cpp
+++ b/test/core/langs/asmb_pep/text_format.cpp
@@ -361,6 +361,45 @@ TEST_CASE("Pepp ASM source formatting", "[scope:core][scope:core.langs][level:as
 .BYTE 0
          .ENDM)");
   }
+  SECTION("Macro definition with placeholders") {
+    static const auto txt =
+        R"(.macro test hello,world
+LDWa a\hello,\world
+.endm
+)";
+    auto l = Lexer(idpool(), data(txt));
+    auto b = Buffer(&l);
+    auto p = Parser(data(txt), std::make_shared<MR>());
+    pepp::tc::DiagnosticTable diag;
+    auto r = p.parse(diag);
+    CHECK(diag.count() == 0);
+    CHECK(r.size() == 1);
+    {
+      Checkpoint{b};
+      CHECK(b.match<DotCommand>());
+      CHECK(b.match<Identifier>());
+      CHECK(b.match<Identifier>());
+      CHECK(b.match_literal(","));
+      CHECK(b.match<Identifier>());
+      CHECK(b.match<Empty>());
+      auto sp = b.matched_tokens();
+      auto lexer_formatted = format_source(sp);
+      CHECK(lexer_formatted == R"(         .MACRO test hello, world)");
+      // CHECK(format_source(r[0].get()) == lexer_formatted);
+    }
+    {
+      Checkpoint{b};
+      CHECK(b.match<Identifier>());
+      CHECK(b.match<Identifier>());
+      CHECK(b.match<MacroPlaceholder>());
+      CHECK(b.match_literal(","));
+      CHECK(b.match<MacroPlaceholder>());
+      CHECK(b.match<Empty>());
+      auto sp = b.matched_tokens();
+      auto lexer_formatted = format_source(sp);
+      CHECK(lexer_formatted == R"(         LDWA    a\hello,\world)");
+    }
+  }
   SECTION("Macro Instance") {
     static const auto txt = R"(execErr:   my_macro  ;comment)";
     pepp::tc::DiagnosticTable diag;


### PR DESCRIPTION
Should make the editing/compile experience slightly better.

Prior to this PR, the following macro body cannot be formatted at all.
Instead, the macro body would just have to be copied thru from the original source text without formatting.
```pep
.macro test hello,world
   LdsA   a\hello,   \world
.endm
```