### PR TITLE
Add tracing support for MMIO

### DIFF
--- a/core/core/sim/debugger/trace_recorder.cpp
+++ b/core/core/sim/debugger/trace_recorder.cpp
@@ -84,34 +84,7 @@ void Recorder::emit_write(const Operation &op, Address address, bits::span<const
   // Always use now ^ old encoded payloads, since that operation is its own inverse.
   bits::inplace_xor(payload, now);
 
-  // Update DP to point at our data body, using the cheapest/smallest encoding possible.
-  const auto anchor = _tb->dp_anchor(*rec);
-  if (!anchor.set) {
-    // This is the first data payload of this instruction. DP will be preloaded from the location buffer via
-    // run_each, but DS is left unset/0. So set DS to this payload's size
-    const auto set_ds = tvm::EncodedOp::LDR<tvm::RegMask::DS>{(u16)len}.encode();
-    _tb->emit_body(*rec, {set_ds.data(), set_ds.size()});
-  } else if (anchor.at.id != slot.loc.id) {
-    // The data chain rolled onto a new buffer mid-recording, which means mid-body update to DP.
-    const auto ldp =
-        tvm::EncodedOp::LDP<3>{tvm::SegmentPair{.hi = slot.loc.id.value, .lo = slot.loc.offset}, (u16)len}.encode();
-    _tb->emit_body(*rec, {ldp.data(), ldp.size()});
-  } else if (anchor.stride == anchor.size && slot.loc.offset == (u16)(anchor.at.offset + anchor.stride)) {
-    // Packed directly after the previous record, which is what happens when one initiator writes several times in a
-    // row. ACCDP advances DP by the *previous* DS, so this encodes in 4 bytes and carries no absolute address --
-    // making it identical across programs that touch the same things.
-    //
-    // Only valid when that previous record was exactly its payload. If the allocation != DS, we have to choose INCDP
-    // with the explicit DP increment.
-    const auto accdp = tvm::EncodedOp::ACCDP{(u16)len}.encode();
-    _tb->emit_body(*rec, {accdp.data(), accdp.size()});
-  } else {
-    // The step is explicit: either the previous record carried a prologue, or something sits between the two. Still
-    // a constant for a given instruction shape, so it does not by itself spoil de-duplication.
-    const auto incdp = tvm::EncodedOp::INCDP{(u16)(slot.loc.offset - anchor.at.offset), (u16)len}.encode();
-    _tb->emit_body(*rec, {incdp.data(), incdp.size()});
-  }
-  _tb->set_dp_anchor(*rec, slot.loc, (u16)len, (u16)(prologue + len));
+  emit_dp_update(slot, *rec, (u16)len, (u16)prologue);
 
   if (address_in_payload) {
     // No address or data in instruction, which increase opportunities for templatization.
@@ -122,6 +95,68 @@ void Recorder::emit_write(const Operation &op, Address address, bits::span<const
     const auto set = tvm::EncodedOp::SetMem<true, 4>{.access = op.as_u16(), .dev = _emitter.value, .off = off}.encode();
     _tb->emit_body(*rec, {set.data(), set.size()});
   }
+}
+
+void Recorder::emit_mm_write(const Operation &op, Address address, u8 pushed) {
+  return emit_mm(op, address, pushed, true);
+}
+
+void Recorder::emit_mm_read(const Operation &op, Address address, u8 popped) {
+  return emit_mm(op, address, popped, false);
+}
+
+void Recorder::emit_mm(const Operation &op, Address address, u8 pushed, bool read_write) {
+  static constexpr u16 len = 1; // MMIO data payload is one byte.
+  if (!traced()) return;        // Don't record for untraced.
+  else if (op.type == Operation::Type::BufferInternal)
+    return; // Access related to TB or UI. Filter or we'll loop infinitely.
+  const auto rec = _tb->find_recording(op.initiator);
+  // begin() never called for that initiator.
+  if (rec == nullptr) return;
+  const auto slot = _tb->append_data_uninitialized(*rec, tvm::MMIO_PROLOGUE_BYTES + len);
+  // OFF.hi then OFF.lo, each a little-endian 16-bit word.
+  slot.bytes[0] = (u8)((address >> 16) & 0xFF);
+  slot.bytes[1] = (u8)((address >> 24) & 0xFF);
+  slot.bytes[2] = (u8)((address >> 0) & 0xFF);
+  slot.bytes[3] = (u8)((address >> 8) & 0xFF);
+  // Followed by the by the data value read or written.
+  slot.bytes[4] = pushed;
+  emit_dp_update(slot, *rec, 1, tvm::MMIO_PROLOGUE_BYTES);
+  // Emit the actual MMIO instruct after the DP update instruction.
+  const auto mmio =
+      tvm::EncodedOp::MMIO<3>{.read_write = read_write, .access = op.as_u16(), .dev = _emitter.value}.encode();
+  _tb->emit_body(*rec, {mmio.data(), mmio.size()});
+}
+
+void Recorder::emit_dp_update(const tvm::DataSlot &slot, tvm::Recording &rec, u16 len, u16 prologue) {
+  // Update DP to point at our data body, using the cheapest/smallest encoding possible.
+  const auto anchor = _tb->dp_anchor(rec);
+  if (!anchor.set) {
+    // This is the first data payload of this instruction. DP will be preloaded from the location buffer via
+    // run_each, but DS is left unset/0. So set DS to this payload's size
+    const auto set_ds = tvm::EncodedOp::LDR<tvm::RegMask::DS>{(u16)len}.encode();
+    _tb->emit_body(rec, {set_ds.data(), set_ds.size()});
+  } else if (anchor.at.id != slot.loc.id) {
+    // The data chain rolled onto a new buffer mid-recording, which means mid-body update to DP.
+    const auto ldp =
+        tvm::EncodedOp::LDP<3>{tvm::SegmentPair{.hi = slot.loc.id.value, .lo = slot.loc.offset}, (u16)len}.encode();
+    _tb->emit_body(rec, {ldp.data(), ldp.size()});
+  } else if (anchor.stride == anchor.size && slot.loc.offset == (u16)(anchor.at.offset + anchor.stride)) {
+    // Packed directly after the previous record, which is what happens when one initiator writes several times in a
+    // row. ACCDP advances DP by the *previous* DS, so this encodes in 4 bytes and carries no absolute address --
+    // making it identical across programs that touch the same things.
+    //
+    // Only valid when that previous record was exactly its payload. If the allocation != DS, we have to choose INCDP
+    // with the explicit DP increment.
+    const auto accdp = tvm::EncodedOp::ACCDP{(u16)len}.encode();
+    _tb->emit_body(rec, {accdp.data(), accdp.size()});
+  } else {
+    // The step is explicit: either the previous record carried a prologue, or something sits between the two. Still
+    // a constant for a given instruction shape, so it does not by itself spoil de-duplication.
+    const auto incdp = tvm::EncodedOp::INCDP{(u16)(slot.loc.offset - anchor.at.offset), (u16)len}.encode();
+    _tb->emit_body(rec, {incdp.data(), incdp.size()});
+  }
+  _tb->set_dp_anchor(rec, slot.loc, (u16)len, (u16)(prologue + len));
 }
 
 } // namespace trace

--- a/core/core/sim/debugger/trace_recorder.cpp
+++ b/core/core/sim/debugger/trace_recorder.cpp
@@ -119,10 +119,10 @@ void Recorder::emit_mm(const Operation &op, Address address, u8 pushed, bool rea
   slot.bytes[1] = (u8)((address >> 24) & 0xFF);
   slot.bytes[2] = (u8)((address >> 0) & 0xFF);
   slot.bytes[3] = (u8)((address >> 8) & 0xFF);
-  // Followed by the by the data value read or written.
+  // Followed by the data value read or written.
   slot.bytes[4] = pushed;
   emit_dp_update(slot, *rec, 1, tvm::MMIO_PROLOGUE_BYTES);
-  // Emit the actual MMIO instruct after the DP update instruction.
+  // Emit the actual MMIO instruction after the DP update instruction.
   const auto mmio =
       tvm::EncodedOp::MMIO<3>{.read_write = read_write, .access = op.as_u16(), .dev = _emitter.value}.encode();
   _tb->emit_body(*rec, {mmio.data(), mmio.size()});

--- a/core/core/sim/debugger/trace_recorder.hpp
+++ b/core/core/sim/debugger/trace_recorder.hpp
@@ -8,8 +8,10 @@
 #include "core/sim/api/memory.hpp"
 
 namespace tvm {
+class DataSlot;
 class TraceBuffer;
-}
+class Recording;
+} // namespace tvm
 
 namespace trace {
 
@@ -79,6 +81,12 @@ public:
   // that would have been thrown away beyond the cost of allocating a function ref.
   void emit_write(const Operation &op, Address address, bits::span<const u8> now, PriorFiller fill_prior);
 
+  // Pushing a byte onto "output" side of memory-mapped FIFO.
+  void emit_mm_write(const Operation &op, Address address, u8 pushed);
+  // Popped a byte from the "input" side of the memory-mapped FIFO. Since pop from a FIFO is destructive, we must
+  // record that value, otherwise we cannot undo this action.
+  void emit_mm_read(const Operation &op, Address address, u8 popped);
+
   // A helper class which which helps open & close a recording for a single instruction.
   class Instruction {
   public:
@@ -110,6 +118,9 @@ public:
   };
 
 private:
+  // 0 if read, 1 if write.
+  void emit_mm(const Operation &op, Address address, u8 pushed, bool read_write);
+  void emit_dp_update(const tvm::DataSlot &slot, tvm::Recording &rec, u16 size, u16 prologue);
   // Null means this device was never bound to a buffer.
   tvm::TraceBuffer *_tb = nullptr;
   Device::ID _emitter{};

--- a/core/core/sim/debugger/tvm_apply_backend.cpp
+++ b/core/core/sim/debugger/tvm_apply_backend.cpp
@@ -249,10 +249,10 @@ void ApplyBackend::on_clrreg(MachineState &state, const tvm::DecodedOp::ClrReg &
 }
 
 void ApplyBackend::on_traddr(MachineState &state, const tvm::DecodedOp::TRADDR &op) {
-  // Refuse through the ISA's own failure channel rather than by throwing. TRADDR decodes and encodes like any other
-  // opcode, so a trace containing one is not a programming error in the driver -- it is a program this backend
-  // cannot run, and it should stop the machine the way every other refusal does instead of unwinding out of
-  // Interpreter::step and past run_each.
+  state.hard_stop(tvm::StopCause::Unimplemented);
+}
+
+void ApplyBackend::on_mmio(MachineState &state, const DecodedOp::MMIO &op) {
   state.hard_stop(tvm::StopCause::Unimplemented);
 }
 

--- a/core/core/sim/debugger/tvm_apply_backend.cpp
+++ b/core/core/sim/debugger/tvm_apply_backend.cpp
@@ -3,6 +3,7 @@
 #include <stdexcept>
 #include "core/sim/api/memory.hpp"
 #include "core/sim/memory/errors.hpp"
+#include "core/sim/memory/io/fifo.hpp"
 #include "core/sim/system.hpp"
 
 namespace {
@@ -253,7 +254,29 @@ void ApplyBackend::on_traddr(MachineState &state, const tvm::DecodedOp::TRADDR &
 }
 
 void ApplyBackend::on_mmio(MachineState &state, const DecodedOp::MMIO &op) {
-  state.hard_stop(tvm::StopCause::Unimplemented);
+  // Not in target mode or there is no system.
+  if (state.csrs.TR == 1) return state.hard_stop(StopCause::WrongTR);
+  else if (_system == nullptr) return state.hard_stop(tvm::StopCause::MissingSystem);
+
+  // Attempt to convert our ID to a FIFORegister
+  auto dev = _system->find_by_id(op.target);
+  if (!dev) return state.hard_stop(StopCause::TargetInvalid);
+  auto target = dev->capability<Target>();
+  if (!target) return state.hard_stop(StopCause::TargetNotMemory);
+  auto fifo = dynamic_cast<FIFORegister *>(target);
+  if (!fifo) return state.hard_stop(StopCause::TargetNotFIFO);
+
+  // Traces cannot be replayed from the middle; you have to start from one end or the other.
+  // So, we can operate on the head/tail of the FIFO directly rather than having to modify indices.
+  if (is_forward()) {
+    if (op.write) fifo->output().push(op.data);
+    // Not a bare push: the byte may already be queued, either because an undo stepped back over it or because the
+    // user typed ahead. advance_input queues it only when the read position has run off the end.
+    else fifo->advance_input(op.data);
+  } else {
+    if (op.write) fifo->output().pop_back();
+    else fifo->rewind_input();
+  }
 }
 
 } // namespace tvm

--- a/core/core/sim/debugger/tvm_apply_backend.hpp
+++ b/core/core/sim/debugger/tvm_apply_backend.hpp
@@ -32,6 +32,7 @@ public:
   void on_cmpreg(MachineState &state, const tvm::DecodedOp::CmpReg &op) override;
   void on_clrreg(MachineState &state, const tvm::DecodedOp::ClrReg &op) override;
   void on_traddr(MachineState &state, const tvm::DecodedOp::TRADDR &op) override;
+  void on_mmio(MachineState &state, const tvm::DecodedOp::MMIO &op) override;
 
 private:
   std::shared_ptr<pepp::bts::BufferManager> _mgr;

--- a/core/core/sim/debugger/tvm_backend.cpp
+++ b/core/core/sim/debugger/tvm_backend.cpp
@@ -6,7 +6,7 @@
 namespace {
 // Visitor for Backend::dispatch. Deliberately a hand-written struct rather than the usual pile of `[&]` lambdas: each
 // lambda would be its own closure type carrying its own copy of the two captures, so an 18-alternative overload set
-// costs ~272 bytes of stack and 34 stores to build -- per dispatched instruction, and with nothing optimized away in a
+// costs ~272 bytes of stack and 35 stores to build -- per dispatched instruction, and with nothing optimized away in a
 // Debug build. This is two pointers, passed in registers.
 struct Dispatch {
   tvm::Backend *self;
@@ -30,6 +30,7 @@ struct Dispatch {
   void operator()(const tvm::DecodedOp::TRADDR &op) const { self->on_traddr(*state, op); }
   void operator()(const tvm::DecodedOp::LDP &op) const { self->on_ldp(*state, op); }
   void operator()(const tvm::DecodedOp::DPIncr &op) const { self->on_dpincr(*state, op); }
+  void operator()(const tvm::DecodedOp::MMIO &op) const { self->on_mmio(*state, op); }
 };
 } // namespace
 

--- a/core/core/sim/debugger/tvm_backend.cpp
+++ b/core/core/sim/debugger/tvm_backend.cpp
@@ -5,7 +5,7 @@
 
 namespace {
 // Visitor for Backend::dispatch. Deliberately a hand-written struct rather than the usual collection of capturing
-// lambdas to avoid the the closure overhead per-alternative.
+// lambdas to avoid the closure overhead per-alternative.
 struct Dispatch {
   tvm::Backend *self;
   tvm::MachineState *state;

--- a/core/core/sim/debugger/tvm_backend.cpp
+++ b/core/core/sim/debugger/tvm_backend.cpp
@@ -4,10 +4,8 @@
 #include "core/sim/debugger/tvm_tracebuffer.hpp"
 
 namespace {
-// Visitor for Backend::dispatch. Deliberately a hand-written struct rather than the usual pile of `[&]` lambdas: each
-// lambda would be its own closure type carrying its own copy of the two captures, so an 18-alternative overload set
-// costs ~272 bytes of stack and 35 stores to build -- per dispatched instruction, and with nothing optimized away in a
-// Debug build. This is two pointers, passed in registers.
+// Visitor for Backend::dispatch. Deliberately a hand-written struct rather than the usual collection of capturing
+// lambdas to avoid the the closure overhead per-alternative.
 struct Dispatch {
   tvm::Backend *self;
   tvm::MachineState *state;

--- a/core/core/sim/debugger/tvm_backend.hpp
+++ b/core/core/sim/debugger/tvm_backend.hpp
@@ -67,7 +67,7 @@ public:
   // ISA, not part of what a backend gets to decide.
   void dispatch(MachineState &state, const tvm::DecodedOp::OpChoice &decoded);
 
-  // --- Ops that only touch MachineState: shared meaning, concrete here ---
+  // Ops that only modify trace VM state.
   virtual void on_halt(MachineState &state, const tvm::DecodedOp::Halt &op);
   virtual void on_ret(MachineState &state, const tvm::DecodedOp::Ret &op);
   virtual void on_call(MachineState &state, const tvm::DecodedOp::Call &op);
@@ -80,7 +80,7 @@ public:
   virtual void on_ldp(MachineState &state, const tvm::DecodedOp::LDP &op);
   virtual void on_dpincr(MachineState &state, const tvm::DecodedOp::DPIncr &op);
 
-  // --- Ops that reach outside the machine: no default is meaningful ---
+  // Ops that involve the target under test.
   virtual void on_setmem(MachineState &state, const tvm::DecodedOp::SetMem &op) = 0;
   virtual void on_cmpmem(MachineState &state, const tvm::DecodedOp::CmpMem &op) = 0;
   virtual void on_clrmem(MachineState &state, const tvm::DecodedOp::ClrMem &op) = 0;
@@ -88,6 +88,7 @@ public:
   virtual void on_cmpreg(MachineState &state, const tvm::DecodedOp::CmpReg &op) = 0;
   virtual void on_clrreg(MachineState &state, const tvm::DecodedOp::ClrReg &op) = 0;
   virtual void on_traddr(MachineState &state, const tvm::DecodedOp::TRADDR &op) = 0;
+  virtual void on_mmio(MachineState &state, const tvm::DecodedOp::MMIO &op) = 0;
 
 protected:
   Operation effective_access(const Operation &recorded) const {

--- a/core/core/sim/debugger/tvm_backend.hpp
+++ b/core/core/sim/debugger/tvm_backend.hpp
@@ -25,12 +25,6 @@ enum class AccessMode : u8 {
 //   - an analyzer, one of which reports which target memory locations would be touched w/o touching, which is
 //     used to implement dirty tracking of main memory.
 //
-// Two tiers of handler:
-//   - The ops below that only move data around MachineState (control flow, the MOD/DP/register-programming ops) have
-//     concrete implementations here, because their meaning is the same everywhere. Override one only to restrict it.
-//   - The ops that reach outside the machine (SET*/CMP*/CLR*, TRADDR) are pure virtual, because there is no sensible
-//     default for "touch the target".
-//
 // An backend refuses an op by implementing that handler with a hard_stop. I did not use an opcode mask,
 // because some backends might want to implement a subset of ops which share a DecodedOP (e.g., implement unconditional
 // branches only).

--- a/core/core/sim/debugger/tvm_decoder.cpp
+++ b/core/core/sim/debugger/tvm_decoder.cpp
@@ -61,6 +61,7 @@ void Decoder::decode() {
   case Opcode::LDP: _decoded = decode_ldp(ibp, iop); break;
   case Opcode::ACCDP: _decoded = decode_accdp(ibp, iop); break;
   case Opcode::INCDP: _decoded = decode_incdp(ibp, iop); break;
+  case Opcode::MMIO: _decoded = decode_mmio(ibp, iop); break;
   default: _state.hard_stop(StopCause::IllegalOpcode); break; // Treat unrecognized upcodes as hard failures.
   }
 }
@@ -469,6 +470,37 @@ tvm::DecodedOp::DPIncr Decoder::decode_incdp(pepp::bts::Buffer::ID ibp, u16 iop)
   case 1: ret.dp_incr = read(ibp, iop + 0);
   case 0: break;
   }
+  return ret;
+}
+
+DecodedOp::MMIO Decoder::decode_mmio(pepp::bts::Buffer::ID ibp, u16 iop) {
+  tvm::DecodedOp::MMIO ret;
+  auto &regs = _state.regs;
+  _state.csrs.TR = 0; // Enter target mode.
+  ret.size = regs.DS;
+
+  switch (regs.IS.word_len) {
+  default: [[fallthrough]];
+  case 3: regs.MOD1.lo = read(ibp, iop + 4), _state.csrs.M1 = 1; [[fallthrough]];
+  case 2: regs.ID.lo = read(ibp, iop + 2); [[fallthrough]];
+  case 1: regs.ACCESS = read(ibp, iop + 0); [[fallthrough]];
+  case 0: break;
+  }
+
+  // Offset first, then the payload. Bound both together against the buffer.
+  auto dbuff = _mgr->find((pepp::bts::Buffer::ID)regs.DP.hi);
+  if (!dbuff) return _state.hard_stop(StopCause::InvalidDBuffer), ret;
+  auto span = dbuff->span();
+  if ((size_t)regs.DP.lo + MMIO_PROLOGUE_BYTES + ret.size > span.size())
+    return _state.hard_stop(StopCause::InvalidDBuffer), ret;
+  regs.OFF.hi = (u16)span[regs.DP.lo + 0] | ((u16)span[regs.DP.lo + 1] << 8);
+  regs.OFF.lo = (u16)span[regs.DP.lo + 2] | ((u16)span[regs.DP.lo + 3] << 8);
+
+  // DS stays the payload size, so the payload begins past the offset rather than at DP.
+  ret.data = tvm::SegmentPair{.hi = regs.DP.hi, .lo = (u16)(regs.DP.lo + MMIO_PROLOGUE_BYTES)};
+  ret.access = Operation(regs.ACCESS);
+  ret.target = (Device::ID)regs.ID.lo;
+  ret.offset = regs.OFF.as_u32();
   return ret;
 }
 

--- a/core/core/sim/debugger/tvm_decoder.cpp
+++ b/core/core/sim/debugger/tvm_decoder.cpp
@@ -477,7 +477,7 @@ DecodedOp::MMIO Decoder::decode_mmio(pepp::bts::Buffer::ID ibp, u16 iop) {
   tvm::DecodedOp::MMIO ret;
   auto &regs = _state.regs;
   _state.csrs.TR = 0; // Enter target mode.
-  ret.size = regs.DS;
+  ret.size = 1;
   ret.write = false;
 
   switch (regs.IS.word_len) {
@@ -500,7 +500,6 @@ DecodedOp::MMIO Decoder::decode_mmio(pepp::bts::Buffer::ID ibp, u16 iop) {
   regs.OFF.hi = (u16)span[regs.DP.lo + 0] | ((u16)span[regs.DP.lo + 1] << 8);
   regs.OFF.lo = (u16)span[regs.DP.lo + 2] | ((u16)span[regs.DP.lo + 3] << 8);
 
-  regs.DS = 1;
   ret.data = span[regs.DP.lo + MMIO_PROLOGUE_BYTES];
 
   ret.access = Operation(regs.ACCESS);

--- a/core/core/sim/debugger/tvm_decoder.cpp
+++ b/core/core/sim/debugger/tvm_decoder.cpp
@@ -478,10 +478,14 @@ DecodedOp::MMIO Decoder::decode_mmio(pepp::bts::Buffer::ID ibp, u16 iop) {
   auto &regs = _state.regs;
   _state.csrs.TR = 0; // Enter target mode.
   ret.size = regs.DS;
+  ret.write = false;
 
   switch (regs.IS.word_len) {
   default: [[fallthrough]];
-  case 3: regs.MOD1.lo = read(ibp, iop + 4), _state.csrs.M1 = 1; [[fallthrough]];
+  case 3:
+    regs.MOD1.lo = read(ibp, iop + 4), _state.csrs.M1 = 1;
+    ret.write = regs.MOD1.lo;
+    [[fallthrough]];
   case 2: regs.ID.lo = read(ibp, iop + 2); [[fallthrough]];
   case 1: regs.ACCESS = read(ibp, iop + 0); [[fallthrough]];
   case 0: break;
@@ -496,11 +500,13 @@ DecodedOp::MMIO Decoder::decode_mmio(pepp::bts::Buffer::ID ibp, u16 iop) {
   regs.OFF.hi = (u16)span[regs.DP.lo + 0] | ((u16)span[regs.DP.lo + 1] << 8);
   regs.OFF.lo = (u16)span[regs.DP.lo + 2] | ((u16)span[regs.DP.lo + 3] << 8);
 
-  // DS stays the payload size, so the payload begins past the offset rather than at DP.
-  ret.data = tvm::SegmentPair{.hi = regs.DP.hi, .lo = (u16)(regs.DP.lo + MMIO_PROLOGUE_BYTES)};
+  regs.DS = 1;
+  ret.data = span[regs.DP.lo + MMIO_PROLOGUE_BYTES];
+
   ret.access = Operation(regs.ACCESS);
   ret.target = (Device::ID)regs.ID.lo;
   ret.offset = regs.OFF.as_u32();
+
   return ret;
 }
 

--- a/core/core/sim/debugger/tvm_decoder.hpp
+++ b/core/core/sim/debugger/tvm_decoder.hpp
@@ -62,6 +62,7 @@ private:
   tvm::DecodedOp::LDP decode_ldp(pepp::bts::Buffer::ID ibp, u16 iop);
   tvm::DecodedOp::DPIncr decode_accdp(pepp::bts::Buffer::ID ibp, u16 iop);
   tvm::DecodedOp::DPIncr decode_incdp(pepp::bts::Buffer::ID ibp, u16 iop);
+  tvm::DecodedOp::MMIO decode_mmio(pepp::bts::Buffer::ID ibp, u16 iop);
 
   u16 read(pepp::bts::Buffer::ID id, u16 offset) { return tvm::read16(*_mgr, _state, id, offset); }
 

--- a/core/core/sim/debugger/tvm_encoding.hpp
+++ b/core/core/sim/debugger/tvm_encoding.hpp
@@ -358,6 +358,22 @@ struct INCDP {
   constexpr auto encode() const { return encode_op<Opcode::INCDP, true>(dp_incr, DS); }
 };
 
+// MMIO puts offset in the payload rather than the packet for the same reasons as SETMEMDX
+template <std::size_t> struct MMIO;
+template <> struct MMIO<1> {
+  u16 access;
+  constexpr auto encode() const { return encode_op<Opcode::MMIO, true>(access); }
+};
+template <> struct MMIO<2> {
+  u16 access, dev;
+  constexpr auto encode() const { return encode_op<Opcode::MMIO, true>(access, dev); }
+};
+template <> struct MMIO<3> {
+  // false if read, true if write.
+  bool read_write;
+  u16 access, dev;
+  constexpr auto encode() const { return encode_op<Opcode::MMIO, true>(access, dev, (u8)read_write); }
+};
 } // namespace EncodedOp
 
 // Helpers containing the fully-decoded layout of each opcode.
@@ -452,7 +468,16 @@ struct DPIncr {
   u16 DS = 0;
 };
 
-using OpChoice = std::variant<Halt, Ret, Call, InvCall, InvRet, ASyn, ISyn, LMR, BR, SetMem, CmpMem, ClrMem,
-                              SetReg, CmpReg, ClrReg, TRADDR, LDP, DPIncr>;
+struct MMIO {
+  bool write = false;
+  Operation access{};
+  Device::ID target{};
+  u32 offset = 0;
+  SegmentPair data{};
+  u16 size = 0;
+};
+
+using OpChoice = std::variant<Halt, Ret, Call, InvCall, InvRet, ASyn, ISyn, LMR, BR, SetMem, CmpMem, ClrMem, SetReg,
+                              CmpReg, ClrReg, TRADDR, LDP, DPIncr, MMIO>;
 } // namespace DecodedOp
 } // namespace tvm

--- a/core/core/sim/debugger/tvm_encoding.hpp
+++ b/core/core/sim/debugger/tvm_encoding.hpp
@@ -358,16 +358,11 @@ struct INCDP {
   constexpr auto encode() const { return encode_op<Opcode::INCDP, true>(dp_incr, DS); }
 };
 
-// MMIO puts offset in the payload rather than the packet for the same reasons as SETMEMDX
+// MMIO puts offset in the payload rather than the packet for the same reasons as SETMEMDX.
+// Omitted the shorter forms because dropping the read/write bit in the 3 data word will be confusing.
+// In the future, it might be worth consuming 2 opcodes (one for in, one for out) if this instruction does not compress
+// well in practice.
 template <std::size_t> struct MMIO;
-template <> struct MMIO<1> {
-  u16 access;
-  constexpr auto encode() const { return encode_op<Opcode::MMIO, true>(access); }
-};
-template <> struct MMIO<2> {
-  u16 access, dev;
-  constexpr auto encode() const { return encode_op<Opcode::MMIO, true>(access, dev); }
-};
 template <> struct MMIO<3> {
   // false if read, true if write.
   bool read_write;
@@ -469,12 +464,12 @@ struct DPIncr {
 };
 
 struct MMIO {
+  // false is read, true is write.
   bool write = false;
-  Operation access{};
+  u8 data = 0, size = 0;
   Device::ID target{};
+  Operation access{};
   u32 offset = 0;
-  SegmentPair data{};
-  u16 size = 0;
 };
 
 using OpChoice = std::variant<Halt, Ret, Call, InvCall, InvRet, ASyn, ISyn, LMR, BR, SetMem, CmpMem, ClrMem, SetReg,

--- a/core/core/sim/debugger/tvm_opcodes.hpp
+++ b/core/core/sim/debugger/tvm_opcodes.hpp
@@ -192,12 +192,18 @@ enum class Opcode : u8 {
   // Always XOR-encoded, because this is a specialized instruction to optimize invertible traces.
   // Packet registers: ACCESS, ID.lo
   SETMEMDX = 0b01'1110,
+  //
+  // Data pointer contains: OFFSET, SIZE, DATA.
+  // Packet registers: ACCESS, ID.lo, MOD1.lo = rd^wr
+  MMIO = 0b01'1111,
   // Must always be 1 greater than the last opcode. Used to size the decoder table at compile-time.
-  MAX = ((u8)SETMEMDX) + 1,
+  MAX = ((u8)MMIO) + 1,
 };
 
 // How many data-chain bytes SETMEMDX consumes as the target offset, ahead of the payload.
 inline constexpr u16 SETMEMDX_ADDRESS_BYTES = 4;
+// (4) address
+inline constexpr u16 MMIO_PROLOGUE_BYTES = 4;
 
 // Instructions to the tvm::Interpreter are always multiples of 16bits
 struct OpWord {

--- a/core/core/sim/debugger/tvm_opcodes.hpp
+++ b/core/core/sim/debugger/tvm_opcodes.hpp
@@ -21,6 +21,8 @@ enum class StopCause {
   RegisterWidthIllegal,
   TargetInvalid,
   TargetNotMemory,
+  // Can't apply MMIO opcode to a non-FIFO target.
+  TargetNotFIFO,
   // An INVRET with no matching INVCALL, or a program that reached HALT while still inside one. Either way the
   // direction counter no longer describes reality, so continuing would silently replay ops the wrong way round.
   UnbalancedInvCall,
@@ -192,17 +194,21 @@ enum class Opcode : u8 {
   // Always XOR-encoded, because this is a specialized instruction to optimize invertible traces.
   // Packet registers: ACCESS, ID.lo
   SETMEMDX = 0b01'1110,
+  // An operation that modifies a FIFORegister. FIFOs can change state on read, which makes them different than other
+  // memory types. I've created a unified opcode for both reading and writing to FIFOs rather than modify SETMEM/D/X
+  // which handles both reading and writing.
+  // Sets DS to 1 for the sizeof data.
   //
-  // Data pointer contains: OFFSET, SIZE, DATA.
+  // Data pointer contains: (4)OFFSET, (1)DATA.
   // Packet registers: ACCESS, ID.lo, MOD1.lo = rd^wr
   MMIO = 0b01'1111,
   // Must always be 1 greater than the last opcode. Used to size the decoder table at compile-time.
   MAX = ((u8)MMIO) + 1,
 };
 
-// How many data-chain bytes SETMEMDX consumes as the target offset, ahead of the payload.
+// (4) OFFSET
 inline constexpr u16 SETMEMDX_ADDRESS_BYTES = 4;
-// (4) address
+// (4) OFFSET
 inline constexpr u16 MMIO_PROLOGUE_BYTES = 4;
 
 // Instructions to the tvm::Interpreter are always multiples of 16bits

--- a/core/core/sim/debugger/tvm_opcodes.hpp
+++ b/core/core/sim/debugger/tvm_opcodes.hpp
@@ -178,20 +178,16 @@ enum class Opcode : u8 {
   // subroutine is explicit: RET is used by ordinary calls nested inside one, and must not end the suspension.
   // No packet registers.
   INVRET = 0b01'1101,
-  // SETMEMX with the target offset taken from the data chain instead of the instruction packet.
-  //
   // SETMEMX carries OFF in its packet, which makes the body of a program that stores to a different address each
-  // time unique -- so it can never be de-duplicated into a template, and a store costs its body in full on every
-  // execution. Here the first 4 bytes at DP are the offset (OFF.hi then OFF.lo, each a little-endian 16-bit word)
-  // and the DS payload bytes follow. The body is then byte-identical across every execution of the same store, at
-  // the price of 4 bytes of payload.
+  // time unique, preventing it from being templatized. For SETMEMDX,  the first 4 bytes at DP are the offset (OFF.hi,
+  // OFF.lo) each. The DS and payload bytes follow as in SETMEM/X. With the unique portion (offset) move out of the
+  // instruction packet, we have more opportunities to promote instructions to templates.
   //
-  // Only worth it where addresses actually vary. For a register bank, whose offsets are a constant handful, SETMEMX
-  // is strictly smaller -- the emitter picks per target device.
+  // When promoted to a template, SETMEMDX costs 4 bytes/instr more than SETMEM/X. For memory devices with predictable
+  // access patterns across an entire instruction (register banks, CSRs), prefer SETMEM/X.
   //
-  // Note DS remains the *payload* size, not the size of the whole region: DP addresses the offset, and the payload
-  // starts 4 bytes later. That means DP-relative stepping cannot use ACCDP after one of these, since ACCDP advances
-  // by DS and would land 4 bytes short; emitters must use an explicit INCDP.
+  // DS remains the *payload* size, not the size of the whole DP carveout. That means DP-relative stepping cannot use
+  // ACCDP after this, since ACCDP advances by DS and would land 4 bytes short. Use INCDP instead.
   //
   // Always XOR-encoded, because this is a specialized instruction to optimize invertible traces.
   // Packet registers: ACCESS, ID.lo

--- a/core/core/sim/debugger/tvm_tracebuffer.cpp
+++ b/core/core/sim/debugger/tvm_tracebuffer.cpp
@@ -62,7 +62,7 @@ TraceBuffer::~TraceBuffer() noexcept {
 
 // --- Recording lifecycle ---
 
-TraceBuffer::Recording *TraceBuffer::find_recording(Device::ID initiator) {
+Recording *TraceBuffer::find_recording(Device::ID initiator) {
   auto it = _recordings.find(initiator);
   // Closed recordings are not findable. Entries outlive their commit() so the scratch vectors keep their capacity,
   // which means a bare map hit says "this initiator has recorded before", not "this initiator is recording now" --
@@ -178,7 +178,7 @@ void TraceBuffer::emit_postfix(Recording &rec, bits::span<const u8> encoded) {
   rec.postfix.insert(rec.postfix.end(), encoded.begin(), encoded.end());
 }
 
-TraceBuffer::DpAnchor TraceBuffer::dp_anchor(Recording &rec) const { return rec.dp; }
+DpAnchor TraceBuffer::dp_anchor(Recording &rec) const { return rec.dp; }
 
 void TraceBuffer::set_dp_anchor(Recording &rec, pepp::bts::Buffer::Location at, u16 size, u16 stride) {
   rec.dp = DpAnchor{true, at, size, stride};
@@ -212,7 +212,7 @@ pepp::bts::Buffer::Location TraceBuffer::append_data(Device::ID initiator, bits:
   return loc;
 }
 
-TraceBuffer::DataSlot TraceBuffer::append_data_uninitialized(Recording &rec, std::size_t len) {
+DataSlot TraceBuffer::append_data_uninitialized(Recording &rec, std::size_t len) {
   const auto res = data_chain(rec).reserve(len);
   _footprint.data += len;
   // The first payload of a record is where the driver points DP before entering the program, so it is remembered
@@ -221,7 +221,7 @@ TraceBuffer::DataSlot TraceBuffer::append_data_uninitialized(Recording &rec, std
   return DataSlot{res.loc, res.bytes};
 }
 
-TraceBuffer::DataSlot TraceBuffer::append_data_uninitialized(Device::ID initiator, std::size_t len) {
+DataSlot TraceBuffer::append_data_uninitialized(Device::ID initiator, std::size_t len) {
   auto rec = find_recording(initiator);
   assert(rec && "append_data_uninitialized() outside a begin()/commit() pair");
   return append_data_uninitialized(*rec, len);

--- a/core/core/sim/debugger/tvm_tracebuffer.hpp
+++ b/core/core/sim/debugger/tvm_tracebuffer.hpp
@@ -35,7 +35,7 @@ private:
 // A position within the trace buffer, identifying a specific entry in a specific ring slot.
 struct Cursor {
   size_t slot = 0; // must be taken % ring size.
-  u16 entry = 0;   // an index index within that slot's location buffer.
+  u16 entry = 0;   // an index within that slot's location buffer.
   auto operator<=>(const Cursor &) const = default;
   bool operator==(const Cursor &) const = default;
 };
@@ -60,7 +60,7 @@ struct DpAnchor {
 };
 
 struct Recording {
-  // Buffers to hold uncommited code, which should not be reduced in size between iterations. After some # of
+  // Buffers to hold uncommitted code, which should not be reduced in size between iterations. After some # of
   // instructions, I expect we'll reach a steady state and these buffers will stop growing and we can avoid dynamic
   // memory allocation in the long run.
   std::vector<u8> prefix, body, postfix;

--- a/core/core/sim/debugger/tvm_tracebuffer.hpp
+++ b/core/core/sim/debugger/tvm_tracebuffer.hpp
@@ -42,6 +42,49 @@ struct Cursor {
   bool operator==(const Cursor &) const = default;
 };
 
+// Unitialized data and a writable view of it.
+struct DataSlot {
+  pepp::bts::Buffer::Location loc;
+  bits::span<u8> bytes;
+};
+
+// --- Per-initiator recording state ---
+// Do not reduce capcity between iterations. After some # of instructions, I expect we'll reach a steady state and
+// these buffers will stop growing.
+struct DpAnchor {
+  bool set = false;
+  pepp::bts::Buffer::Location at{};
+  // DS the program set, i.e. the payload size.
+  u16 size = 0;
+  // Bytes this payload actually reserved, which is larger than `size` when the record carries something ahead of
+  // the payload. SETMEMDX reserves an extra 4 bytes for a target address.
+  // If stride != size, when you update the DP you MUST use INCDP and advance by stride rather than ACCCDP (with
+  // size). SETMEMDX+ACCDP would leave DP 4 bytes behind the new payload.
+  u16 stride = 0;
+};
+
+struct Recording {
+  std::vector<u8> prefix;
+  std::vector<u8> body;
+  std::vector<u8> postfix;
+  // Which initiator this belongs to, which is needed to find the right data chain.
+  Device::ID id{};
+  bool active = false;
+  // See DpAnchor. Reset by begin().
+  DpAnchor dp{};
+  // Where this record's first data payload byte landed, which is what commit() stores in the location buffer so the
+  // driver can point DP at it before entering the program. Distinct from DpAnchor::at, which tracks the most recent
+  // payload. Null when the record wrote nothing.
+  pepp::bts::Buffer::Location data_start{};
+  // The ring slot and location-buffer index this recording claimed at begin().
+  // Reserving these values at begin() allows safe interleaving of initiators.
+  std::size_t slot = 0;
+  u16 entry = 0;
+  // Memoize the result of data_chain to avoid a map lookup on every traced write. Resolved once per recording now
+  // that the slot cannot move underneath it; begin() clears it.
+  pepp::bts::BufferChain *chain = nullptr;
+};
+
 // Trace log of TVM programs.
 //
 // TB delegates serializing opcodes to trace::Recorder to avoid modification with addition of new ops.
@@ -90,9 +133,6 @@ struct Cursor {
 // This decision simplifies the TraceBuffer implementation and should increase hit-rates for templatization by reducing
 // unnecessary implicit state.
 class TraceBuffer {
-  // Forward-declared so the public Open handle below can name it; defined in the private section.
-  struct Recording;
-
 public:
   // Minimum body size (in bytes) to be eligible for template promotion.
   // If a call is 6 bytes, then the body needs to exceed 6 bytes (+ 2 for a ret)
@@ -163,11 +203,6 @@ public:
   // onto it, and records the result with set_dp_anchor().
   pepp::bts::Buffer::Location append_data(Device::ID initiator, bits::span<const u8> data);
 
-  // Unitialized data and a writable view of it.
-  struct DataSlot {
-    pepp::bts::Buffer::Location loc;
-    bits::span<u8> bytes;
-  };
   // Reserves a contiguous chunk of the data chain without initializing the memory, and return that memory as a span of
   // bytes. Allows us to avoid an extra data copy in some places. Reports the location the same way append_data does.
   DataSlot append_data_uninitialized(Device::ID initiator, std::size_t len);
@@ -180,17 +215,6 @@ public:
   //
   // Tracked per recording rather than per emitter because several devices contribute to one CPU instruction's record,
   // and they share the one data pointer.
-  struct DpAnchor {
-    bool set = false;
-    pepp::bts::Buffer::Location at{};
-    // DS the program set, i.e. the payload size.
-    u16 size = 0;
-    // Bytes this payload actually reserved, which is larger than `size` when the record carries something ahead of
-    // the payload. SETMEMDX reserves an extra 4 bytes for a target address.
-    // If stride != size, when you update the DP you MUST use INCDP and advance by stride rather than ACCCDP (with
-    // size). SETMEMDX+ACCDP would leave DP 4 bytes behind the new payload.
-    u16 stride = 0;
-  };
   DpAnchor dp_anchor(Recording &rec) const;
   void set_dp_anchor(Recording &rec, pepp::bts::Buffer::Location at, u16 size, u16 stride);
 
@@ -402,31 +426,6 @@ private:
     u16 open = 0;
 
     void reset(pepp::bts::BufferManager &mgr);
-  };
-
-  // --- Per-initiator recording state ---
-  // Do not reduce capcity between iterations. After some # of instructions, I expect we'll reach a steady state and
-  // these buffers will stop growing.
-  struct Recording {
-    std::vector<u8> prefix;
-    std::vector<u8> body;
-    std::vector<u8> postfix;
-    // Which initiator this belongs to, which is needed to find the right data chain.
-    Device::ID id{};
-    bool active = false;
-    // See DpAnchor. Reset by begin().
-    DpAnchor dp{};
-    // Where this record's first data payload byte landed, which is what commit() stores in the location buffer so the
-    // driver can point DP at it before entering the program. Distinct from DpAnchor::at, which tracks the most recent
-    // payload. Null when the record wrote nothing.
-    pepp::bts::Buffer::Location data_start{};
-    // The ring slot and location-buffer index this recording claimed at begin().
-    // Reserving these values at begin() allows safe interleaving of initiators.
-    std::size_t slot = 0;
-    u16 entry = 0;
-    // Memoize the result of data_chain to avoid a map lookup on every traced write. Resolved once per recording now
-    // that the slot cannot move underneath it; begin() clears it.
-    pepp::bts::BufferChain *chain = nullptr;
   };
 
   // --- Template dedup ---

--- a/core/core/sim/debugger/tvm_tracebuffer.hpp
+++ b/core/core/sim/debugger/tvm_tracebuffer.hpp
@@ -33,11 +33,9 @@ private:
 };
 
 // A position within the trace buffer, identifying a specific entry in a specific ring slot.
-// Slot indices must be taken % ring size.
-// Entry is the index within that slot's location buffer.
 struct Cursor {
-  size_t slot = 0;
-  u16 entry = 0;
+  size_t slot = 0; // must be taken % ring size.
+  u16 entry = 0;   // an index index within that slot's location buffer.
   auto operator<=>(const Cursor &) const = default;
   bool operator==(const Cursor &) const = default;
 };
@@ -48,10 +46,8 @@ struct DataSlot {
   bits::span<u8> bytes;
 };
 
-// --- Per-initiator recording state ---
-// Do not reduce capcity between iterations. After some # of instructions, I expect we'll reach a steady state and
-// these buffers will stop growing.
 struct DpAnchor {
+  // False if no program has written data yet
   bool set = false;
   pepp::bts::Buffer::Location at{};
   // DS the program set, i.e. the payload size.
@@ -64,9 +60,10 @@ struct DpAnchor {
 };
 
 struct Recording {
-  std::vector<u8> prefix;
-  std::vector<u8> body;
-  std::vector<u8> postfix;
+  // Buffers to hold uncommited code, which should not be reduced in size between iterations. After some # of
+  // instructions, I expect we'll reach a steady state and these buffers will stop growing and we can avoid dynamic
+  // memory allocation in the long run.
+  std::vector<u8> prefix, body, postfix;
   // Which initiator this belongs to, which is needed to find the right data chain.
   Device::ID id{};
   bool active = false;
@@ -85,8 +82,6 @@ struct Recording {
   pepp::bts::BufferChain *chain = nullptr;
 };
 
-// Trace log of TVM programs.
-//
 // TB delegates serializing opcodes to trace::Recorder to avoid modification with addition of new ops.
 // The class manages the lifetimes of buffers used by a tvm::Interpreter, and provides a circular-queue
 // abstraction. Commit()'ed programs go to a ring, whose size provides an upper limit of the length of a trace histroy.
@@ -100,7 +95,6 @@ struct Recording {
 // Program data and code are stored separately per ring entry. There will always be internal fragmentation because
 // data/code buffers are not shared between ring entries, which was a deliberate choice to reduce the difficultly of
 // lifetime mangamenet. As soon as a ring slot is freed, its pages can be released to the BufferManager.
-//
 //
 // Programs are built incrementally in a per-initiator temporary buffer in 3 parts: a prefix, a body,
 // and a postfix. begin() claims the ring slot and the location-buffer index the program will occupy; the bytes are

--- a/core/core/sim/memory/io/fifo.cpp
+++ b/core/core/sim/memory/io/fifo.cpp
@@ -65,7 +65,10 @@ u8 FIFORegister::FIFO::at(Address index) const {
   return res;
 }
 
-void FIFORegister::FIFO::clear() { _data.clear(0); }
+void FIFORegister::FIFO::clear() {
+  _data.clear(0);
+  _max_index = 0;
+}
 
 size_t FIFORegister::FIFO::size() const noexcept {
   return _max_index; // Since we always push to the end, the size is equal to the max index.
@@ -148,7 +151,10 @@ FIFORegister::FIFORegister(Configuration config) : Device(), _config(config), _i
     throw std::logic_error("Memory-Mapped Reg must only span single byte.");
 }
 
-void FIFORegister::rewind_input() const { _input_it = --_input_it; }
+u8 FIFORegister::rewind_input() {
+  _input_it = --_input_it;
+  return _input_it.value_or(_config.fill);
+}
 
 FIFORegister::FIFO &FIFORegister::input() { return _input; }
 
@@ -188,7 +194,7 @@ bool FIFORegister::traced() const { return _trace.traced(); }
 
 AddressSpan FIFORegister::span() const { return _config.span; }
 
-void FIFORegister::clear(u8 fill) {
+void FIFORegister::clear(u8) {
   _input.clear(), _output.clear();
   _input_it = _input.begin();
 }
@@ -198,7 +204,7 @@ void FIFORegister::dump(bits::span<u8> dest) const {
   if (dest.size() <= 0) throw std::logic_error("dump requires non-0 size");
   u8 v = _config.fill;
   if (any(_config.direction & FIFORegister::Direction::Output)) {
-    _output.latest_or(_config.fill);
+    v = _output.latest_or(_config.fill);
   } else if (any(_config.direction & FIFORegister::Direction::Input)) {
     v = _input_it.value_or(_config.fill);
   }

--- a/core/core/sim/memory/io/fifo.cpp
+++ b/core/core/sim/memory/io/fifo.cpp
@@ -205,9 +205,9 @@ Target::Result FIFORegister::read(Address address, bits::span<u8> dest, Operatio
       if (_config.fail_policy == FailPolicy::RaiseError) throw Error(Error::Type::NeedsMMI, address);
       else src = _config.fill;
     } else src = _input_it.value_or(_config.fill);
-
+    // Record that the read consumed values from the input queue
     if (advances_input) {
-      // TODO: emit a trace which indicates that we consumed a value from the input queue, which we must emit by-value.
+      _trace.emit_mm_read(op, address, src);
       if (!(_input_it.at_end())) ++_input_it;
     }
   } else if (any(_config.direction & FIFORegister::Direction::Output)) {
@@ -230,7 +230,7 @@ Target::Result FIFORegister::write(Address address, bits::span<const u8> src, Op
   const bool advances_output = !(op.type == Operation::Type::Application || op.type == Operation::Type::BufferInternal);
   // This is an output reg. Only enqueue value if the operation is not part of an app-internal update.
   if (advances_output && any(_config.direction & FIFORegister::Direction::Output)) {
-    // TODO: emit a trace which indicates that we produced a value to the output queue.
+    _trace.emit_mm_write(op, address, src.front());
     _output.push(src.front());
   }
   // Ignore writes to non-output registers.

--- a/core/core/sim/memory/io/fifo.cpp
+++ b/core/core/sim/memory/io/fifo.cpp
@@ -21,6 +21,17 @@ FIFORegister::FIFO::Iterator FIFORegister::FIFO::Iterator::operator++(int) {
   return tmp;
 }
 
+FIFORegister::FIFO::Iterator &FIFORegister::FIFO::Iterator::operator--() {
+  if (_index != 0) _index -= 1;
+  return *this;
+}
+
+FIFORegister::FIFO::Iterator FIFORegister::FIFO::Iterator::operator--(int) {
+  Iterator tmp = *this;
+  --(*this);
+  return tmp;
+}
+
 bool FIFORegister::FIFO::Iterator::operator!=(const Iterator &other) const { return !(*this == other); }
 
 bool FIFORegister::FIFO::Iterator::operator==(const Iterator &other) const {
@@ -42,6 +53,11 @@ FIFORegister::FIFO::Iterator FIFORegister::FIFO::begin() { return Iterator(this,
 FIFORegister::FIFO::Iterator FIFORegister::FIFO::end() { return Iterator(this, size()); }
 
 void FIFORegister::FIFO::push(u8 value) { _data.write(_max_index++, {&value, 1}); }
+
+u8 FIFORegister::FIFO::pop_back() {
+  if (_max_index == 0) return 0;
+  return at(--_max_index);
+}
 
 u8 FIFORegister::FIFO::at(Address index) const {
   u8 res;
@@ -131,6 +147,8 @@ FIFORegister::FIFORegister(Configuration config) : Device(), _config(config), _i
   if (_config.span.lower() != _config.span.upper())
     throw std::logic_error("Memory-Mapped Reg must only span single byte.");
 }
+
+void FIFORegister::rewind_input() const { _input_it = --_input_it; }
 
 FIFORegister::FIFO &FIFORegister::input() { return _input; }
 

--- a/core/core/sim/memory/io/fifo.cpp
+++ b/core/core/sim/memory/io/fifo.cpp
@@ -156,6 +156,13 @@ u8 FIFORegister::rewind_input() {
   return _input_it.value_or(_config.fill);
 }
 
+void FIFORegister::advance_input(u8 byte) {
+  // Only queue the byte when there is nothing under the read position.
+  // Pushing unconditionally would cause undo/redo to not be mirrors.
+  if (_input_it.at_end()) _input.push(byte);
+  _input_it = ++_input_it;
+}
+
 FIFORegister::FIFO &FIFORegister::input() { return _input; }
 
 FIFORegister::FIFO &FIFORegister::output() { return _output; }

--- a/core/core/sim/memory/io/fifo.hpp
+++ b/core/core/sim/memory/io/fifo.hpp
@@ -49,6 +49,8 @@ public:
       Iterator(FIFO *q, size_t index);
       Iterator &operator++();
       Iterator operator++(int);
+      Iterator &operator--();
+      Iterator operator--(int);
       bool operator!=(const Iterator &other) const;
       bool operator==(const Iterator &other) const;
       bool at_end() const;
@@ -63,6 +65,7 @@ public:
     // On insert, previously captured end() iterator will become invalidated.
     Iterator end();
     void push(u8 value);
+    u8 pop_back();
     u8 at(Address index) const;
     void clear();
     size_t size() const noexcept;
@@ -102,6 +105,7 @@ public:
   FIFORegister &operator=(const FIFORegister &) = delete;
 
   FIFO &input();
+  void rewind_input() const; // Decrement _input_it.
   FIFO &output();
 
   // Device interface

--- a/core/core/sim/memory/io/fifo.hpp
+++ b/core/core/sim/memory/io/fifo.hpp
@@ -42,7 +42,7 @@ public:
   public:
     struct Iterator {
     public:
-      using iterator_category = std::forward_iterator_tag;
+      using iterator_category = std::bidirectional_iterator_tag;
       using difference_type = std::ptrdiff_t;
       using value_type = u8;
       explicit Iterator();

--- a/core/core/sim/memory/io/fifo.hpp
+++ b/core/core/sim/memory/io/fifo.hpp
@@ -74,7 +74,7 @@ public:
     u8 latest_or(u8 def) const noexcept;
 
   private:
-    Address _max_index;
+    Address _max_index = 0;
     pepp::bts::PagedPool<u8> _data;
   };
 
@@ -105,7 +105,8 @@ public:
   FIFORegister &operator=(const FIFORegister &) = delete;
 
   FIFO &input();
-  void rewind_input() const; // Decrement _input_it.
+  // Call FIFO::pop_back() on _input_it. Saturates at the front yielding the fill value rather than wrapping.
+  u8 rewind_input();
   FIFO &output();
 
   // Device interface

--- a/core/core/sim/memory/io/fifo.hpp
+++ b/core/core/sim/memory/io/fifo.hpp
@@ -107,6 +107,9 @@ public:
   FIFO &input();
   // Call FIFO::pop_back() on _input_it. Saturates at the front yielding the fill value rather than wrapping.
   u8 rewind_input();
+  // Step forward the read position by one byte. If the queue is empty, push the provided byte value.
+  // For non-empty queues, the byte is ignored.
+  void advance_input(u8 byte);
   FIFO &output();
 
   // Device interface

--- a/core/core/sim/memory/io/fifo.hpp
+++ b/core/core/sim/memory/io/fifo.hpp
@@ -133,7 +133,7 @@ private:
   Configuration _config;
   FIFO _input, _output;
   mutable FIFO::Iterator _input_it;
-  trace::Recorder _trace;
+  mutable trace::Recorder _trace;
 };
 
 consteval void is_bitflags(FIFORegister::Direction);

--- a/test/core/sim/hwdbg/trace_mmio.cpp
+++ b/test/core/sim/hwdbg/trace_mmio.cpp
@@ -235,7 +235,7 @@ TEST_CASE("trace::Recorder: MMIO on a bidirectional FIFO", "[scope:core][scope:c
   }
 
   SECTION("An MMIO record shares a data chain with an ordinary write") {
-    // Real insturctions can touch both DRAM and a FIFO register. Like SETMEMDX, the data size will not equal the
+    // Real instructions can touch both DRAM and a FIFO register. Like SETMEMDX, the data size will not equal the
     // stride.
     h.fifo->input().push(0xAB);
     h.poke_ram(0x1111);

--- a/test/core/sim/hwdbg/trace_mmio.cpp
+++ b/test/core/sim/hwdbg/trace_mmio.cpp
@@ -1,0 +1,494 @@
+/*
+ * Copyright (c) 2026 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <memory>
+#include <vector>
+
+#include <catch.hpp>
+#include "core/math/bitmanip/enums.hpp"
+#include "core/sim/api/memory.hpp"
+#include "core/sim/debugger/trace_device.hpp"
+#include "core/sim/debugger/tvm_apply_backend.hpp"
+#include "core/sim/debugger/tvm_interpreter.hpp"
+#include "core/sim/debugger/tvm_tracebuffer.hpp"
+#include "core/sim/memory/errors.hpp"
+#include "core/sim/memory/io/fifo.hpp"
+#include "core/sim/memory/ram/dense.hpp"
+#include "core/sim/system.hpp"
+
+namespace {
+using namespace bits;
+
+constexpr auto BIDI = FIFORegister::Direction::Input | FIFORegister::Direction::Output;
+
+// Stands in for the CPU that caused the accesses.
+constexpr Device::ID CPU{1};
+// Deliberately wider than 16 bits. An MMIO record carries its address as four payload bytes ahead of the data, so a
+// port whose high half is non-zero is the only way to notice if that half is dropped on the way through.
+constexpr Address PORT = 0x1FC15;
+// Somewhere in the RAM that shares the system with the port, for the case where one instruction touches both.
+constexpr Address RAM = 0x1234;
+// What one MMIO record costs in the data chain: the four address bytes plus its one-byte payload.
+constexpr std::size_t RECORD_BYTES = tvm::MMIO_PROLOGUE_BYTES + 1;
+
+const Operation cpu_op(Operation::Type::Standard, Operation::Kind::data, CPU);
+const Operation app_op(Operation::Type::Application, Operation::Kind::data, CPU);
+const Operation internal_op(Operation::Type::BufferInternal, Operation::Kind::data, CPU);
+
+// A system holding one FIFO register and a trace buffer.
+struct Harness {
+  std::unique_ptr<System> sys;
+  FIFORegister *fifo = nullptr;
+  Dense *mem = nullptr;
+  trace::BufferDevice *tbdev = nullptr;
+
+  tvm::TraceBuffer &tb() { return tbdev->buffer(); }
+  Target *port() { return static_cast<Target *>(fifo); }
+
+  u8 read(Operation op = cpu_op) { return port()->read<u8>(PORT, op).second; }
+  void write(u8 value, Operation op = cpu_op) { port()->write<u8>(PORT, value, op); }
+  // The byte the next read would consume. An Application access does not advance the queue and is never recorded, so
+  // this observes the read position without being the thing under test.
+  u8 peek() { return read(app_op); }
+
+  // Straight at the RAM, bypassing anything that might itself be traced.
+  u16 peek_ram() { return ((Target *)mem)->read<u16, bits::host_is_le>(RAM, app_op).second; }
+  void poke_ram(u16 v) { ((Target *)mem)->write<u16, bits::host_is_le>(RAM, v, app_op); }
+  void write_ram(u16 v) { ((Target *)mem)->write<u16, bits::host_is_le>(RAM, v, cpu_op); }
+
+  // One instruction's worth of accesses: open a recording, run `body`, close it.
+  template <typename F> tvm::ProgramLocation instruction(F &&body) {
+    tb().begin(CPU);
+    body();
+    return tb().commit(CPU);
+  }
+
+  // Replay one recorded program through the real apply backend. Backward is the undo direction. A stop means the
+  // program never reached its MMIO op, which would make every assertion after it vacuous.
+  void replay(tvm::ProgramLocation loc, tvm::Direction dir) {
+    auto blaster = sys->make_trace_interpreter();
+    blaster->backend().set_direction(dir);
+    blaster->run(loc);
+    REQUIRE(blaster->stop_cause() == tvm::StopCause::None);
+  }
+
+  // Bytes committed to data chains so far. Records carry their payload here and nowhere else, so a delta across one
+  // instruction counts the records it produced without depending on what replaying them does.
+  std::size_t recorded_bytes() { return tb().footprint().data; }
+};
+
+Harness make_harness(FIFORegister::Direction direction, FailPolicy policy = FailPolicy::RaiseError, u8 fill = 0x00) {
+  System::Configuration root_cfg{{.basename = "/", .compatible = System::compatible}};
+  FIFORegister::Configuration fifo_cfg{
+      Device::Configuration{.basename = "port", .compatible = FIFORegister::compatible}};
+  fifo_cfg.span = AddressSpan(PORT, PORT);
+  fifo_cfg.direction = direction;
+  fifo_cfg.fail_policy = policy;
+  fifo_cfg.fill = fill;
+  // A RAM alongside the port, so a recording can hold an ordinary write and an MMIO record at once. Its span is wide
+  // enough that bind_recorders() picks the address-in-payload encoding for it, which is what main memory really gets.
+  Dense::Configuration mem_cfg{
+      Device::Configuration{.basename = "memory", .compatible = Dense::compatible},
+      0x00,
+      AddressSpan(0x0000, 0xffff),
+  };
+  trace::BufferDevice::Configuration tb_cfg{Device::Configuration{.basename = "trace"}, 4};
+
+  Harness h;
+  h.sys = std::make_unique<System>(root_cfg);
+  h.fifo = h.sys->make_device<FIFORegister>(fifo_cfg);
+  h.mem = h.sys->make_device<Dense>(mem_cfg);
+  h.tbdev = h.sys->make_device<trace::BufferDevice>(tb_cfg);
+  h.sys->initialize();
+  h.tbdev->trace(h.fifo->id(), true);
+  h.tbdev->trace(h.mem->id(), true);
+  return h;
+}
+
+} // namespace
+
+TEST_CASE("trace::Recorder: MMIO on a bidirectional FIFO", "[scope:core][scope:core.dbg][kind:unit][arch:pep10]") {
+  auto h = make_harness(BIDI);
+
+  SECTION("A recorded write replays forward, then undoes itself") {
+    // Moves the output queue to where it belongs and back.
+    auto loc = h.instruction([&] { h.write(0x5A); });
+    REQUIRE(h.fifo->output().size() == 1);
+    CHECK(h.fifo->output().latest_or(0) == 0x5A);
+
+    h.replay(loc, tvm::Direction::Backward);
+    CHECK(h.fifo->output().empty());
+
+    h.replay(loc, tvm::Direction::Forward);
+    REQUIRE(h.fifo->output().size() == 1);
+    CHECK(h.fifo->output().latest_or(0) == 0x5A);
+  }
+
+  SECTION("Undoing a read steps the read position back over the byte") {
+    // Undo runs against the device that did the read, so the byte is still queued -- only the position moved, and
+    // only the position has to come back. Leaving the byte in place is what lets the machine consume it again when
+    // it re-executes the instruction.
+    h.fifo->input().push(0xAB);
+    h.fifo->input().push(0xCD);
+    auto loc = h.instruction([&] { CHECK(h.read() == 0xAB); });
+    REQUIRE(h.peek() == 0xCD); // consumed 0xAB and moved on
+
+    h.replay(loc, tvm::Direction::Backward);
+    CHECK(h.peek() == 0xAB);            // back where the instruction started
+    CHECK(h.fifo->input().size() == 2); // and nothing was taken out of the queue
+  }
+
+  SECTION("Replaying a read forward queues the byte it recorded") {
+    // The other direction runs against a device that does not have the byte yet, which is what lets register
+    // programming pre-queue input straight out of a trace: the record carries the consumed byte by value, so
+    // replaying it forward puts that byte back where the machine can read it.
+    h.fifo->input().push(0xAB);
+    auto loc = h.instruction([&] { CHECK(h.read() == 0xAB); });
+
+    h.fifo->clear(0); // as if the trace were being replayed onto a fresh machine
+    REQUIRE(h.fifo->input().empty());
+
+    h.replay(loc, tvm::Direction::Forward);
+    REQUIRE(h.fifo->input().size() == 1);
+    CHECK(h.fifo->input().at(0) == 0xAB);
+    // Forward replay reproduces the execution rather than staging it, so the byte ends up queued *and* consumed.
+    // 0x00 is the configured fill, which is what an exhausted queue yields.
+    CHECK(h.peek() == 0x00);
+  }
+
+  SECTION("Stepping back over a read and forward again leaves the queue as it was") {
+    // The two directions touch different state -- undo moves the read position and leaves the byte, redo appends a
+    // byte and leaves the position -- so this is where they have to agree. The byte never left the queue, and the
+    // machine ends up back where it started rather than looking at a second copy of input it already consumed.
+    h.fifo->input().push(0xAB);
+    h.fifo->input().push(0xCD);
+    auto loc = h.instruction([&] { CHECK(h.read() == 0xAB); });
+    REQUIRE(h.fifo->input().size() == 2);
+    REQUIRE(h.peek() == 0xCD);
+
+    h.replay(loc, tvm::Direction::Backward);
+    h.replay(loc, tvm::Direction::Forward);
+
+    CHECK(h.fifo->input().size() == 2);
+    CHECK(h.peek() == 0xCD);
+  }
+
+  SECTION("Both directions of one instruction are recorded") {
+    h.fifo->input().push(0xAB);
+    const auto before = h.recorded_bytes();
+
+    auto loc = h.instruction([&] {
+      CHECK(h.read() == 0xAB);
+      h.write(0x5A);
+    });
+    CHECK(h.recorded_bytes() - before == 2 * RECORD_BYTES);
+
+    h.replay(loc, tvm::Direction::Backward);
+    CHECK(h.fifo->output().empty());
+  }
+
+  SECTION("Several writes in one recording undo together") {
+    auto loc = h.instruction([&] {
+      h.write(0x11);
+      h.write(0x22);
+    });
+    REQUIRE(h.fifo->output().size() == 2);
+
+    h.replay(loc, tvm::Direction::Backward);
+    CHECK(h.fifo->output().empty());
+
+    // And redo restores them in the order they were written, not reversed.
+    h.replay(loc, tvm::Direction::Forward);
+    REQUIRE(h.fifo->output().size() == 2);
+    CHECK(h.fifo->output().at(0) == 0x11);
+    CHECK(h.fifo->output().at(1) == 0x22);
+  }
+
+  SECTION("Identical accesses de-duplicate into one template") {
+    // The point of putting the address in the payload: the body carries neither the port nor the byte, so two writes
+    // to the same port produce byte-identical bodies and the second collapses into a CALL.
+    CHECK(h.tb().template_count() == 0);
+
+    h.instruction([&] { h.write(0x11); });
+    CHECK(h.tb().template_count() == 0); // first sighting: nothing to match against yet
+
+    auto second = h.instruction([&] { h.write(0x22); });
+    CHECK(h.tb().template_count() == 1);
+    REQUIRE(h.fifo->output().size() == 2);
+
+    // The CALL still reaches this instruction's own payload rather than the one the template was built from.
+    h.replay(second, tvm::Direction::Backward);
+    REQUIRE(h.fifo->output().size() == 1);
+    CHECK(h.fifo->output().latest_or(0) == 0x11);
+  }
+
+  SECTION("An MMIO record shares a data chain with an ordinary write") {
+    // Real insturctions can touch both DRAM and a FIFO register. Like SETMEMDX, the data size will not equal the
+    // stride.
+    h.fifo->input().push(0xAB);
+    h.poke_ram(0x1111);
+
+    auto loc = h.instruction([&] {
+      CHECK(h.read() == 0xAB);
+      h.write_ram(0x2222);
+      h.write(0x5A);
+    });
+    REQUIRE(h.peek_ram() == 0x2222);
+    REQUIRE(h.fifo->output().size() == 1);
+
+    h.replay(loc, tvm::Direction::Backward);
+    CHECK(h.peek_ram() == 0x1111); // the ordinary write found its payload
+    CHECK(h.fifo->output().empty());
+    CHECK(h.peek() == 0xAB); // and the read position came back with it
+  }
+
+  SECTION("A run of instructions unwinds newest-first") {
+    // Undone
+    // The linear-walk assumption in practice. Undone in reverse order every record finds the byte it wrote sitting on
+    // top of the queue, which is the whole reason undo can be a bare pop.
+    std::vector<tvm::ProgramLocation> locs;
+    for (u8 i = 0; i < 3; ++i) locs.push_back(h.instruction([&, i] { h.write(0x10 + i); }));
+    REQUIRE(h.fifo->output().size() == 3);
+
+    for (auto it = locs.rbegin(); it != locs.rend(); ++it) h.replay(*it, tvm::Direction::Backward);
+    CHECK(h.fifo->output().empty());
+  }
+
+  SECTION("Applying a record without a system stops rather than throws") {
+    // A backend with no System cannot resolve the target ID. The refusal has to arrive through the ISA's own failure
+    // channel, because run_each sits above this and an exception would unwind past it.
+    auto loc = h.instruction([&] { h.write(0x5A); });
+
+    auto mgr = h.sys->buffer_manager();
+    tvm::Interpreter blaster(mgr, std::make_unique<tvm::ApplyBackend>(mgr));
+    blaster.run(loc);
+    CHECK(blaster.stop_cause() == tvm::StopCause::MissingSystem);
+    CHECK(h.fifo->output().size() == 1); // and it stopped before touching anything
+  }
+}
+
+TEST_CASE("trace::Recorder: MMIO on an input-only FIFO", "[scope:core][scope:core.dbg][kind:unit][arch:pep10]") {
+  SECTION("A recorded read undoes itself") {
+    auto h = make_harness(FIFORegister::Direction::Input);
+    h.fifo->input().push(0xAB);
+    h.fifo->input().push(0xCD);
+    const auto before = h.recorded_bytes();
+
+    auto loc = h.instruction([&] { CHECK(h.read() == 0xAB); });
+    CHECK(h.recorded_bytes() - before == RECORD_BYTES);
+    REQUIRE(h.peek() == 0xCD);
+
+    h.replay(loc, tvm::Direction::Backward);
+    CHECK(h.peek() == 0xAB);
+    CHECK(h.fifo->input().size() == 2);
+  }
+
+  SECTION("Several reads in one recording undo together") {
+    // One instruction's worth of accesses is one unit of history, so the position walks back over all three in a
+    // single replay -- an off-by-one anywhere in the run leaves it pointing at the wrong byte.
+    auto h = make_harness(FIFORegister::Direction::Input);
+    for (u8 i = 0; i < 4; ++i) h.fifo->input().push(0x10 + i);
+
+    auto loc = h.instruction([&] {
+      CHECK(h.read() == 0x10);
+      CHECK(h.read() == 0x11);
+      CHECK(h.read() == 0x12);
+    });
+    REQUIRE(h.peek() == 0x13);
+
+    h.replay(loc, tvm::Direction::Backward);
+    CHECK(h.peek() == 0x10);
+    CHECK(h.fifo->input().size() == 4);
+  }
+
+  SECTION("Several reads replay forward in the order they were consumed") {
+    // Rebuilding a queue from a trace has to preserve order: the records run serially in program order whichever way
+    // the walk is going, so pushing them puts the bytes back the way the machine saw them.
+    auto h = make_harness(FIFORegister::Direction::Input);
+    for (u8 i = 0; i < 3; ++i) h.fifo->input().push(0x10 + i);
+
+    auto loc = h.instruction([&] {
+      CHECK(h.read() == 0x10);
+      CHECK(h.read() == 0x11);
+      CHECK(h.read() == 0x12);
+    });
+
+    h.fifo->clear(0);
+    h.replay(loc, tvm::Direction::Forward);
+
+    REQUIRE(h.fifo->input().size() == 3);
+    CHECK(h.fifo->input().at(0) == 0x10);
+    CHECK(h.fifo->input().at(1) == 0x11);
+    CHECK(h.fifo->input().at(2) == 0x12);
+    CHECK(h.peek() == 0x00); // the whole run is queued, and the read position is past all of it
+  }
+
+  SECTION("A write is ignored, and records nothing") {
+    auto h = make_harness(FIFORegister::Direction::Input);
+    const auto before = h.recorded_bytes();
+
+    auto loc = h.instruction([&] { h.write(0x5A); });
+
+    CHECK(h.recorded_bytes() == before);
+    CHECK(h.fifo->output().empty());
+    h.replay(loc, tvm::Direction::Forward);
+    CHECK(h.fifo->output().empty()); // nothing to replay, so nothing appears
+  }
+
+  SECTION("A read that runs out of input records nothing") {
+    // Under RaiseError the read throws before consuming anything, so there is nothing to undo. This also checks the
+    // throw left no half-built record behind: commit() has to produce a runnable program either way.
+    auto h = make_harness(FIFORegister::Direction::Input, FailPolicy::RaiseError);
+    const auto before = h.recorded_bytes();
+
+    h.tb().begin(CPU);
+    CHECK_THROWS_AS(h.read(), Error);
+    auto loc = h.tb().commit(CPU);
+
+    CHECK(h.recorded_bytes() == before);
+    h.replay(loc, tvm::Direction::Backward); // and the empty program still runs to its HALT
+  }
+
+  SECTION("An exhausted read under yield_default still records") {
+    auto h = make_harness(FIFORegister::Direction::Input, FailPolicy::YieldDefaultValue, 0xFE);
+    const auto before = h.recorded_bytes();
+
+    h.instruction([&] { CHECK(h.read() == 0xFE); });
+
+    CHECK(h.recorded_bytes() - before == RECORD_BYTES);
+  }
+}
+
+TEST_CASE("trace::Recorder: MMIO on an output-only FIFO", "[scope:core][scope:core.dbg][kind:unit][arch:pep10]") {
+  auto h = make_harness(FIFORegister::Direction::Output);
+
+  SECTION("A recorded write replays forward, then undoes itself") {
+    auto loc = h.instruction([&] { h.write(0x5A); });
+    REQUIRE(h.fifo->output().size() == 1);
+
+    h.replay(loc, tvm::Direction::Backward);
+    CHECK(h.fifo->output().empty());
+
+    h.replay(loc, tvm::Direction::Forward);
+    REQUIRE(h.fifo->output().size() == 1);
+    CHECK(h.fifo->output().latest_or(0) == 0x5A);
+  }
+
+  SECTION("A read records nothing") {
+    // Reading an output register hands back the most recent value written. Nothing is consumed, so there is nothing
+    // to put back, and a record here would replay as a second push.
+    h.instruction([&] { h.write(0x5A); });
+    const auto before = h.recorded_bytes();
+
+    auto loc = h.instruction([&] { CHECK(h.read() == 0x5A); });
+
+    CHECK(h.recorded_bytes() == before);
+    h.replay(loc, tvm::Direction::Backward);
+    CHECK(h.fifo->output().size() == 1); // the write's own record is in a different program
+  }
+}
+
+TEST_CASE("trace::Recorder: MMIO records are filtered like every other trace",
+          "[scope:core][scope:core.dbg][kind:unit][arch:pep10]") {
+  auto h = make_harness(BIDI);
+
+  SECTION("An untraced device records nothing") {
+    h.tbdev->trace(h.fifo->id(), false);
+    CHECK_FALSE(h.fifo->traced());
+    h.fifo->input().push(0xAB);
+
+    auto loc = h.instruction([&] {
+      CHECK(h.read() == 0xAB);
+      h.write(0x5A);
+    });
+
+    h.replay(loc, tvm::Direction::Backward);
+    CHECK(h.fifo->output().size() == 1); // the write happened, but nothing recorded it, so nothing undid it
+  }
+
+  SECTION("Application accesses neither consume nor record") {
+    h.fifo->input().push(0xAB);
+    const auto before = h.recorded_bytes();
+
+    h.instruction([&] {
+      CHECK(h.read(app_op) == 0xAB);
+      CHECK(h.read(app_op) == 0xAB); // still the same byte
+      h.write(0x5A, app_op);
+    });
+
+    CHECK(h.recorded_bytes() == before);
+    CHECK(h.fifo->output().empty());
+  }
+
+  SECTION("BufferInternal accesses are not recorded") {
+    h.fifo->input().push(0xAB);
+    const auto before = h.recorded_bytes();
+
+    h.instruction([&] {
+      CHECK(h.read(internal_op) == 0xAB);
+      h.write(0x5A, internal_op);
+    });
+
+    CHECK(h.recorded_bytes() == before);
+  }
+
+  SECTION("An access with no recording open is dropped, not asserted") {
+    // Device init and UI pokes between instructions both land here.
+    CHECK_FALSE(h.tb().is_recording(CPU));
+    h.write(0x11);
+    CHECK(h.recorded_bytes() == 0);
+
+    // And the recorder still works afterwards, so the dropped access left no half-built state behind.
+    auto loc = h.instruction([&] { h.write(0x22); });
+    REQUIRE(h.fifo->output().size() == 2);
+
+    h.replay(loc, tvm::Direction::Backward);
+    REQUIRE(h.fifo->output().size() == 1);
+    CHECK(h.fifo->output().latest_or(0) == 0x11); // only the recorded write came back out
+  }
+
+  SECTION("An access whose initiator has no recording open is dropped") {
+    constexpr Device::ID OTHER{2};
+    const Operation from_other(Operation::Type::Standard, Operation::Kind::data, OTHER);
+    const auto before = h.recorded_bytes();
+
+    auto loc = h.instruction([&] { h.write(0x5A, from_other); });
+
+    CHECK(h.recorded_bytes() == before);
+    h.replay(loc, tvm::Direction::Backward);
+    CHECK(h.fifo->output().size() == 1);
+  }
+
+  SECTION("Records are filed under the initiator, not the emitting device") {
+    // Two initiators recording at once, both writing the one port. Each write belongs to its own program: if they had
+    // both landed in CPU's, the first undo below would empty the queue instead of taking one byte off it.
+    constexpr Device::ID OTHER{2};
+    const Operation from_other(Operation::Type::Standard, Operation::Kind::data, OTHER);
+
+    h.tb().begin(CPU);
+    h.tb().begin(OTHER);
+    h.write(0x11);
+    h.write(0x22, from_other);
+    auto cpu_loc = h.tb().commit(CPU);
+    auto other_loc = h.tb().commit(OTHER);
+    REQUIRE(h.fifo->output().size() == 2);
+
+    h.replay(other_loc, tvm::Direction::Backward);
+    CHECK(h.fifo->output().size() == 1);
+
+    h.replay(cpu_loc, tvm::Direction::Backward);
+    CHECK(h.fifo->output().empty());
+  }
+}

--- a/test/core/sim/memory/mm.cpp
+++ b/test/core/sim/memory/mm.cpp
@@ -160,3 +160,80 @@ TEST_CASE("(new) MemoryMappedReg storage out-of-bounds access",
     REQUIRE_THROWS_AS(dev.read(0x17, {tmp, 1}, op), Error);
   }
 }
+
+TEST_CASE("(new) MemoryMappedReg clear and dump", "[scope:core][scope:core.sim][kind:int][arch:*]") {
+  auto span = AddressSpan(0x17, 0x17);
+  auto cfg = FIFORegister::Configuration{Device::Configuration{base_desc}};
+  cfg.span = span, cfg.fill = 0xFE, cfg.id = {};
+  u8 tmp = 0;
+
+  SECTION("clear() empties the queues rather than just blanking them") {
+    // size() is the queue's write index, so clearing the backing store without resetting it would leave the queue
+    // reporting its old length over zeroed pages -- an emptied input would hand back 0x00 forever instead of
+    // reaching the fail policy.
+    auto local = cfg;
+    local.direction = FIFORegister::Direction::Input;
+    FIFORegister dev(local);
+    dev.input().push(0x11);
+    dev.input().push(0x22);
+    REQUIRE(dev.input().size() == 2);
+
+    dev.clear(0);
+
+    CHECK(dev.input().size() == 0);
+    CHECK(dev.input().empty());
+    // Nothing is queued, so this read is out of input rather than a read of a zero byte.
+    REQUIRE_THROWS_AS(dev.read(0x17, {&tmp, 1}, op), Error);
+  }
+
+  SECTION("clear() lets a refilled queue read from the front again") {
+    auto local = cfg;
+    local.direction = FIFORegister::Direction::Input;
+    FIFORegister dev(local);
+    dev.input().push(0x11);
+    REQUIRE_NOTHROW(dev.read(0x17, {&tmp, 1}, op));
+    REQUIRE(tmp == 0x11);
+
+    dev.clear(0);
+    dev.input().push(0x33);
+
+    // The read position was reset alongside the queue, so this sees the new byte and not the end of the old one.
+    REQUIRE_NOTHROW(dev.read(0x17, {&tmp, 1}, op));
+    CHECK(tmp == 0x33);
+  }
+
+  SECTION("dump() of an output register reports the most recent value written") {
+    auto local = cfg;
+    local.direction = FIFORegister::Direction::Output;
+    FIFORegister dev(local);
+    const u8 written = 0xCA;
+    REQUIRE_NOTHROW(dev.write(0x17, {&written, 1}, op));
+
+    dev.dump({&tmp, 1});
+    CHECK(tmp == 0xCA);
+  }
+
+  SECTION("dump() of an untouched register reports the fill") {
+    auto local = cfg;
+    local.direction = FIFORegister::Direction::Output;
+    FIFORegister dev(local);
+
+    dev.dump({&tmp, 1});
+    CHECK(tmp == 0xFE);
+  }
+
+  SECTION("dump() of an input register reports the byte the next read would consume") {
+    auto local = cfg;
+    local.direction = FIFORegister::Direction::Input;
+    FIFORegister dev(local);
+    dev.input().push(0x11);
+    dev.input().push(0x22);
+
+    dev.dump({&tmp, 1});
+    CHECK(tmp == 0x11);
+
+    REQUIRE_NOTHROW(dev.read(0x17, {&tmp, 1}, op));
+    dev.dump({&tmp, 1});
+    CHECK(tmp == 0x22); // dump follows the read position
+  }
+}


### PR DESCRIPTION
This required a special trace opcode because the same memory address (`OFFSET`) is modified on both read and write.
This opcode shares a shape with `SETMEMDX` to increase the opportunities for templatization/deduplication.