### PR TITLE
Expose performance counters to debugger & compress traces

### DIFF
--- a/core/core/sim/cores/cpu/pep_isa.cpp
+++ b/core/core/sim/cores/cpu/pep_isa.cpp
@@ -144,13 +144,13 @@ void PepISA3CPU::initialize(System *sys) {
                   .loc = Address(0)});
   const auto cpuid = id();
   // Expose call depth, which is useful for implementing step modes.
-  scan->expose(SR{.byte_width = 2,
-                  .access = RO,
-                  .type = SR::Type::Counter,
-                  .target = cpuid,
-                  .order = bits::hostOrder(),
-                  .name = "call_depth",
-                  .loc = &_count.call_depth});
+  _ref_call_depth = scan->expose(SR{.byte_width = 2,
+                                    .access = RO,
+                                    .type = SR::Type::Counter,
+                                    .target = cpuid,
+                                    .order = bits::hostOrder(),
+                                    .name = "call_depth",
+                                    .loc = &_count.call_depth});
   scan->expose(SR{.byte_width = 2,
                   .access = RO,
                   .trace_mode = SR::Tracing::Checkpoint,
@@ -224,12 +224,12 @@ void PepISA3CPU::trace(bool enabled) {
 
 void PepISA3CPU::increment_call_depth() {
   _count.call_depth += 1;
-  // TODO: emit a register write packet to TB
+  _trace.emit_incr_register(op_data(), &_ref_call_depth, 1);
 }
 
 void PepISA3CPU::decrement_call_depth() {
   _count.call_depth -= 1;
-  // TODO: emit a register write packet to TB
+  _trace.emit_incr_register(op_data(), &_ref_call_depth, -1);
 }
 
 // The CSR bank stores one flag per byte, in CSR enum order: N at 0, Z at 1, V at 2, C at 3. Both of these move all

--- a/core/core/sim/cores/cpu/pep_isa.cpp
+++ b/core/core/sim/cores/cpu/pep_isa.cpp
@@ -192,14 +192,22 @@ void PepISA3CPU::clock_tick(PulseSchedule::PulseIndex idx, u64 tick) {
   // Take PC out of the register bank for the duration of this instruction. Everything below moves it through _pc,
   // and the single store after handle() is the only version the trace ever sees. See read_pc().
   _pc = read_register_uncached(isa::Pep10::Register::PC);
+  const auto init_pc = _pc;
   // TODO: Should probably be an instruction access?
   u8 is = _target->read<u8, false>(_pc, op_data()).second;
   _pc += 1;
   write_register(isa::Pep10::Register::IS, is);
-  handle(_opcodes[is]);
   // Defer PC writeback until end of instruction to avoid ~3 updates on a BR (1 for to fetch IS, 1 to fetch OS, 1 for
   // the branch).
-  write_register_uncached(isa::Pep10::Register::PC, _pc);
+  handle(_opcodes[is]);
+  // Change in PC is range [1, 3] which is the normal increment amount and probably not from a branch.
+  // Since all instructions other than branches have a fixed PC increment, we can use a specialized increment encoding
+  // to save ~2B/instruction in the trace. We do not use the normal encoding for calls/branches, as those can have
+  // data-dependence for the branch target.
+  const auto pc_delta = _pc - init_pc;
+  if ((pc_delta & 0b11) == pc_delta) {
+    _regbank->write_increment<u16, bits::host_is_le>(static_cast<u8>(isa::Pep10::Register::PC) * 2, _pc, op_data());
+  } else write_register_uncached(isa::Pep10::Register::PC, _pc);
   // TODO: handle breakpoints, debug info, etc
   record.commit();
   _count.instructions += 1;
@@ -224,12 +232,13 @@ void PepISA3CPU::trace(bool enabled) {
 
 void PepISA3CPU::increment_call_depth() {
   _count.call_depth += 1;
-  _trace.emit_incr_register(op_data(), &_ref_call_depth, 1);
+  // Ordering does not matter here the way it does for a write since the prior is constant.
+  _trace.emit_incr_register(op_data(), _ref_call_depth, 1);
 }
 
 void PepISA3CPU::decrement_call_depth() {
   _count.call_depth -= 1;
-  _trace.emit_incr_register(op_data(), &_ref_call_depth, -1);
+  _trace.emit_incr_register(op_data(), _ref_call_depth, -1);
 }
 
 // The CSR bank stores one flag per byte, in CSR enum order: N at 0, Z at 1, V at 2, C at 3. Both of these move all

--- a/core/core/sim/cores/cpu/pep_isa.cpp
+++ b/core/core/sim/cores/cpu/pep_isa.cpp
@@ -151,7 +151,8 @@ void PepISA3CPU::initialize(System *sys) {
                                     .order = bits::hostOrder(),
                                     .name = "call_depth",
                                     .loc = &_count.call_depth});
-  scan->expose(SR{.byte_width = 2,
+  // Width must match the storage it points at: the pointer visitors compare sizeof(T) against byte_width.
+  scan->expose(SR{.byte_width = 4,
                   .access = RO,
                   .trace_mode = SR::Tracing::Checkpoint,
                   .type = SR::Type::Counter,

--- a/core/core/sim/cores/cpu/pep_isa.cpp
+++ b/core/core/sim/cores/cpu/pep_isa.cpp
@@ -108,16 +108,22 @@ void PepISA3CPU::initialize(System *sys) {
   static const auto BE = bits::Order::BigEndian;
   static const auto LE = bits::Order::LittleEndian;
   static const auto RW = RegisterScan::Register::ReadWrite;
+  static const auto RO = RegisterScan::Register::Access::Read;
   // Core registers
   using R = isa::Pep10::Register;
   const auto rid = _regbank->id();
   static const auto r2i = [](const R &r) -> u16 { return static_cast<u16>(r) * 2; };
-  scan->expose(SR{.order = BE, .byte_width = 2, .access = RW, .target = rid, .offset = r2i(R::A), .name = "A"});
-  scan->expose(SR{.order = BE, .byte_width = 2, .access = RW, .target = rid, .offset = r2i(R::X), .name = "X"});
-  scan->expose(SR{.order = BE, .byte_width = 2, .access = RW, .target = rid, .offset = r2i(R::PC), .name = "PC"});
-  scan->expose(SR{.order = BE, .byte_width = 2, .access = RW, .target = rid, .offset = r2i(R::SP), .name = "SP"});
-  scan->expose(SR{.order = BE, .byte_width = 1, .access = RW, .target = rid, .offset = r2i(R::IS) + 1, .name = "IS"});
-  scan->expose(SR{.order = BE, .byte_width = 2, .access = RW, .target = rid, .offset = r2i(R::OS), .name = "OS"});
+  scan->expose(SR{.byte_width = 2, .access = RW, .target = rid, .order = BE, .name = "A", .loc = r2i(R::A)});
+  scan->expose(SR{.byte_width = 2, .access = RW, .target = rid, .order = BE, .name = "X", .loc = r2i(R::X)});
+  scan->expose(SR{.byte_width = 2, .access = RW, .target = rid, .order = BE, .name = "PC", .loc = r2i(R::PC)});
+  scan->expose(SR{.byte_width = 2, .access = RW, .target = rid, .order = BE, .name = "SP", .loc = r2i(R::SP)});
+  scan->expose(SR{.byte_width = 1,
+                  .access = RW,
+                  .target = rid,
+                  .order = BE,
+                  .name = "IS",
+                  .loc = static_cast<Address>(r2i(R::IS) + 1)});
+  scan->expose(SR{.byte_width = 2, .access = RW, .target = rid, .order = BE, .name = "OS", .loc = r2i(R::OS)});
   // CSRs / Flags
   using C = isa::Pep10::CSR;
   const auto cid = _csrs->id();
@@ -129,8 +135,30 @@ void PepISA3CPU::initialize(System *sys) {
   auto z = F{.access = RW, .bit_offset = 16, .bit_width = 1, .name = "Z"};
   auto v = F{.access = RW, .bit_offset = 8, .bit_width = 1, .name = "V"};
   auto c = F{.access = RW, .bit_offset = 0, .bit_width = 1, .name = "C"};
-  scan->expose(SR{
-      .order = BE, .byte_width = 4, .access = RW, .target = cid, .offset = 0, .name = "NZVC", .fields = {n, z, v, c}});
+  scan->expose(SR{.byte_width = 4,
+                  .access = RW,
+                  .target = cid,
+                  .order = BE,
+                  .name = "NZVC",
+                  .fields = {n, z, v, c},
+                  .loc = Address(0)});
+  const auto cpuid = id();
+  // Expose call depth, which is useful for implementing step modes.
+  scan->expose(SR{.byte_width = 2,
+                  .access = RO,
+                  .type = SR::Type::Counter,
+                  .target = cpuid,
+                  .order = bits::hostOrder(),
+                  .name = "call_depth",
+                  .loc = &_count.call_depth});
+  scan->expose(SR{.byte_width = 2,
+                  .access = RO,
+                  .trace_mode = SR::Tracing::Checkpoint,
+                  .type = SR::Type::Counter,
+                  .target = cpuid,
+                  .order = bits::hostOrder(),
+                  .name = "icount",
+                  .loc = &_count.instructions});
 }
 
 const Device::Configuration &PepISA3CPU::config() const { return _config; }
@@ -174,6 +202,7 @@ void PepISA3CPU::clock_tick(PulseSchedule::PulseIndex idx, u64 tick) {
   write_register_uncached(isa::Pep10::Register::PC, _pc);
   // TODO: handle breakpoints, debug info, etc
   record.commit();
+  _count.instructions += 1;
 }
 
 void PepISA3CPU::set_clock_source(const ClockSource *src) { _clk = src; }
@@ -194,11 +223,13 @@ void PepISA3CPU::trace(bool enabled) {
 }
 
 void PepISA3CPU::increment_call_depth() {
-  // TODO:
+  _count.call_depth += 1;
+  // TODO: emit a register write packet to TB
 }
 
 void PepISA3CPU::decrement_call_depth() {
-  // TODO:
+  _count.call_depth -= 1;
+  // TODO: emit a register write packet to TB
 }
 
 // The CSR bank stores one flag per byte, in CSR enum order: N at 0, Z at 1, V at 2, C at 3. Both of these move all

--- a/core/core/sim/cores/cpu/pep_isa.cpp
+++ b/core/core/sim/cores/cpu/pep_isa.cpp
@@ -80,8 +80,9 @@ PepISA3CPU::PepISA3CPU(Configuration cfg, System *sys) : _config(cfg) {
     Dense::Configuration cfg;
     cfg.basename = "csrs";
     cfg.fill = 0;
-    // N, Z, V, C
-    cfg.span = {0, 3};
+    // One byte holding NZVC in its low nibble, N at bit 3 down to C at bit 0. A byte per flag would cost 4 payload
+    // bytes in every trace record that touches the flags, to carry 4 bits.
+    cfg.span = {0, 0};
     cfg.skip_serialize = true;
     self->_csrs = sys->make_device<Dense>(parent, cfg);
   };
@@ -129,13 +130,12 @@ void PepISA3CPU::initialize(System *sys) {
   const auto cid = _csrs->id();
   using F = SR::Field;
   // Should really be 4 separate fields, but I want to test that my fields work as expected.
-  // When moving to 4 fields, no need for bit offsets.
-  // Bit 31 is MSB, 0 is LSB. Considering these are 4 consecutive bytes, the offsets make sense.
-  auto n = F{.guest_access = RW, .bit_offset = 24, .bit_width = 1, .name = "N"};
-  auto z = F{.guest_access = RW, .bit_offset = 16, .bit_width = 1, .name = "Z"};
-  auto v = F{.guest_access = RW, .bit_offset = 8, .bit_width = 1, .name = "V"};
+  // Bit 7 is MSB, 0 is LSB. The flags occupy the low nibble in CSR enum order, so N is bit 3 and C is bit 0.
+  auto n = F{.guest_access = RW, .bit_offset = 3, .bit_width = 1, .name = "N"};
+  auto z = F{.guest_access = RW, .bit_offset = 2, .bit_width = 1, .name = "Z"};
+  auto v = F{.guest_access = RW, .bit_offset = 1, .bit_width = 1, .name = "V"};
   auto c = F{.guest_access = RW, .bit_offset = 0, .bit_width = 1, .name = "C"};
-  scan->expose(SR{.byte_width = 4,
+  scan->expose(SR{.byte_width = 1,
                   .guest_access = RW,
                   .target = cid,
                   .order = BE,
@@ -244,24 +244,14 @@ void PepISA3CPU::decrement_call_depth() {
   _trace.emit_incr_register(op_data(), _ref_call_depth, -1);
 }
 
-// The CSR bank stores one flag per byte, in CSR enum order: N at 0, Z at 1, V at 2, C at 3. Both of these move all
-// four in a single access rather than one per flag. Perform as a single batched read/write to reduce the # of traces
-// emitted for this operation.
+// The CSR bank is one byte holding all four flags, N at bit 3 through C at bit 0, matching the packing at the ISA
+// layer. One access also means one trace record byte rather than 4
 u8 PepISA3CPU::read_packed_csr() {
-  std::array<u8, 4> nzvc{};
-  ((Target *)_csrs)->read(0, {nzvc.data(), nzvc.size()}, op_data());
-  return static_cast<u8>((nzvc[0] ? 1 << 3 : 0) | (nzvc[1] ? 1 << 2 : 0) | (nzvc[2] ? 1 << 1 : 0) |
-                         (nzvc[3] ? 1 << 0 : 0));
+  return static_cast<u8>(((Target *)_csrs)->read<u8, false>(0, op_data()).second & CSR_MASK);
 }
 
 void PepISA3CPU::write_packed_csr(u8 value) {
-  const std::array<u8, 4> nzvc{
-      static_cast<u8>((value >> 3) & 1),
-      static_cast<u8>((value >> 2) & 1),
-      static_cast<u8>((value >> 1) & 1),
-      static_cast<u8>((value >> 0) & 1),
-  };
-  ((Target *)_csrs)->write(0, {nzvc.data(), nzvc.size()}, op_data());
+  ((Target *)_csrs)->write<u8, false>(0, static_cast<u8>(value & CSR_MASK), op_data());
 }
 
 void PepISA3CPU::handle(Op opcode) {

--- a/core/core/sim/cores/cpu/pep_isa.cpp
+++ b/core/core/sim/cores/cpu/pep_isa.cpp
@@ -113,17 +113,17 @@ void PepISA3CPU::initialize(System *sys) {
   using R = isa::Pep10::Register;
   const auto rid = _regbank->id();
   static const auto r2i = [](const R &r) -> u16 { return static_cast<u16>(r) * 2; };
-  scan->expose(SR{.byte_width = 2, .access = RW, .target = rid, .order = BE, .name = "A", .loc = r2i(R::A)});
-  scan->expose(SR{.byte_width = 2, .access = RW, .target = rid, .order = BE, .name = "X", .loc = r2i(R::X)});
-  scan->expose(SR{.byte_width = 2, .access = RW, .target = rid, .order = BE, .name = "PC", .loc = r2i(R::PC)});
-  scan->expose(SR{.byte_width = 2, .access = RW, .target = rid, .order = BE, .name = "SP", .loc = r2i(R::SP)});
+  scan->expose(SR{.byte_width = 2, .guest_access = RW, .target = rid, .order = BE, .name = "A", .loc = r2i(R::A)});
+  scan->expose(SR{.byte_width = 2, .guest_access = RW, .target = rid, .order = BE, .name = "X", .loc = r2i(R::X)});
+  scan->expose(SR{.byte_width = 2, .guest_access = RW, .target = rid, .order = BE, .name = "PC", .loc = r2i(R::PC)});
+  scan->expose(SR{.byte_width = 2, .guest_access = RW, .target = rid, .order = BE, .name = "SP", .loc = r2i(R::SP)});
   scan->expose(SR{.byte_width = 1,
-                  .access = RW,
+                  .guest_access = RW,
                   .target = rid,
                   .order = BE,
                   .name = "IS",
                   .loc = static_cast<Address>(r2i(R::IS) + 1)});
-  scan->expose(SR{.byte_width = 2, .access = RW, .target = rid, .order = BE, .name = "OS", .loc = r2i(R::OS)});
+  scan->expose(SR{.byte_width = 2, .guest_access = RW, .target = rid, .order = BE, .name = "OS", .loc = r2i(R::OS)});
   // CSRs / Flags
   using C = isa::Pep10::CSR;
   const auto cid = _csrs->id();
@@ -131,12 +131,12 @@ void PepISA3CPU::initialize(System *sys) {
   // Should really be 4 separate fields, but I want to test that my fields work as expected.
   // When moving to 4 fields, no need for bit offsets.
   // Bit 31 is MSB, 0 is LSB. Considering these are 4 consecutive bytes, the offsets make sense.
-  auto n = F{.access = RW, .bit_offset = 24, .bit_width = 1, .name = "N"};
-  auto z = F{.access = RW, .bit_offset = 16, .bit_width = 1, .name = "Z"};
-  auto v = F{.access = RW, .bit_offset = 8, .bit_width = 1, .name = "V"};
-  auto c = F{.access = RW, .bit_offset = 0, .bit_width = 1, .name = "C"};
+  auto n = F{.guest_access = RW, .bit_offset = 24, .bit_width = 1, .name = "N"};
+  auto z = F{.guest_access = RW, .bit_offset = 16, .bit_width = 1, .name = "Z"};
+  auto v = F{.guest_access = RW, .bit_offset = 8, .bit_width = 1, .name = "V"};
+  auto c = F{.guest_access = RW, .bit_offset = 0, .bit_width = 1, .name = "C"};
   scan->expose(SR{.byte_width = 4,
-                  .access = RW,
+                  .guest_access = RW,
                   .target = cid,
                   .order = BE,
                   .name = "NZVC",
@@ -144,8 +144,10 @@ void PepISA3CPU::initialize(System *sys) {
                   .loc = Address(0)});
   const auto cpuid = id();
   // Expose call depth, which is useful for implementing step modes.
+  // Read-only to the guest: hand-editing a derived counter is nonsense. host_access defaults to ReadWrite, which is
+  // what lets Tracing::Automatic restore it on a step backwards.
   _ref_call_depth = scan->expose(SR{.byte_width = 2,
-                                    .access = RO,
+                                    .guest_access = RO,
                                     .type = SR::Type::Counter,
                                     .target = cpuid,
                                     .order = bits::hostOrder(),
@@ -153,7 +155,7 @@ void PepISA3CPU::initialize(System *sys) {
                                     .loc = &_count.call_depth});
   // Width must match the storage it points at: the pointer visitors compare sizeof(T) against byte_width.
   scan->expose(SR{.byte_width = 4,
-                  .access = RO,
+                  .guest_access = RO,
                   .trace_mode = SR::Tracing::Checkpoint,
                   .type = SR::Type::Counter,
                   .target = cpuid,

--- a/core/core/sim/cores/cpu/pep_isa.hpp
+++ b/core/core/sim/cores/cpu/pep_isa.hpp
@@ -72,6 +72,10 @@ public:
   // Same as above, but does not redirect PC access.
   template <typename RegisterType> u16 read_register_uncached(RegisterType reg);
   template <typename RegisterType> void write_register_uncached(RegisterType reg, u16 value);
+  // The flags occupy the low nibble of the CSR bank's single byte, N at bit 3 through C at bit 0.
+  static constexpr u8 CSR_MASK = 0x0F;
+  // Which bit of that nibble a given flag is.
+  template <typename CSRType> static constexpr u8 csr_bit(CSRType csr);
   template <typename CSRType> bool read_csr(CSRType csr);
   template <typename CSRType> void write_csr(CSRType csr, bool value);
   u8 read_packed_csr();
@@ -125,10 +129,18 @@ template <typename RegisterType> inline u16 PepISA3CPU::read_register_uncached(R
   return ((Target *)_regbank)->read<u16, bits::host_is_le>(static_cast<u8>(reg) * 2, op_data()).second;
 }
 
+// All four flags live in one byte, so a single flag is a bit of it rather than a byte of its own. The enum runs
+// N, Z, V, C and the packing puts N highest, so the flag's index counts down from the top of the nibble.
+template <typename CSRType> constexpr u8 PepISA3CPU::csr_bit(CSRType csr) {
+  return static_cast<u8>(1 << (3 - static_cast<u8>(csr)));
+}
+
 template <typename CSRType> inline void PepISA3CPU::write_csr(CSRType csr, bool value) {
-  ((Target *)_csrs)->write<u8, bits::host_is_le>(static_cast<u8>(csr), (u8)value, op_data());
+  // Read-modify-write: the other three flags share the byte and must survive.
+  const u8 bit = csr_bit(csr), packed = read_packed_csr();
+  write_packed_csr(static_cast<u8>(value ? (packed | bit) : (packed & ~bit)));
 }
 
 template <typename CSRType> inline bool PepISA3CPU::read_csr(CSRType csr) {
-  return ((Target *)_csrs)->read<u8, bits::host_is_le>(static_cast<u8>(csr), op_data()).second != 0;
+  return (read_packed_csr() & csr_bit(csr)) != 0;
 }

--- a/core/core/sim/cores/cpu/pep_isa.hpp
+++ b/core/core/sim/cores/cpu/pep_isa.hpp
@@ -87,6 +87,10 @@ public:
   void write_pc(u16 value) { _pc = value; }
 
 private:
+  struct PerfCounters {
+    i16 call_depth = 0;
+    u32 instructions = 0;
+  } _count = {};
   // Only meaningful between the start and end of clock_tick. See read_pc().
   // Coalescing these reads saves 1-2 register writes on most instructions.
   u16 _pc = 0;

--- a/core/core/sim/cores/cpu/pep_isa.hpp
+++ b/core/core/sim/cores/cpu/pep_isa.hpp
@@ -6,7 +6,9 @@
 #include "core/sim/api/device.hpp"
 #include "core/sim/api/memory.hpp"
 #include "core/sim/api/trace.hpp"
+#include "core/sim/debugger/register_scanner.hpp"
 #include "core/sim/debugger/trace_recorder.hpp"
+
 class Dense;
 
 /*
@@ -91,6 +93,7 @@ private:
     i16 call_depth = 0;
     u32 instructions = 0;
   } _count = {};
+  RegisterScan::RegisterRef _ref_call_depth = {};
   // Only meaningful between the start and end of clock_tick. See read_pc().
   // Coalescing these reads saves 1-2 register writes on most instructions.
   u16 _pc = 0;

--- a/core/core/sim/debugger/register_scanner.cpp
+++ b/core/core/sim/debugger/register_scanner.cpp
@@ -66,77 +66,114 @@ u8 RegisterScan::bit_width(RegisterRef r) const {
   else return field->bit_width;
 }
 
+struct ReadVisit {
+  RegisterScan::Register *reg;
+  bits::span<u8> out;
+  void operator()(std::monostate) { throw std::runtime_error("Register has no storage location"); }
+  void operator()(Address addr) { throw std::runtime_error("Device is not a target"); }
+  template <typename T> void operator()(const T *ptr) {
+    if (sizeof(T) != out.size()) throw std::runtime_error("Register width mismatch");
+    std::memcpy(out.data(), ptr, sizeof(T));
+  }
+};
+
 bits::Order RegisterScan::read(Register *reg, Register::Field *field, bits::span<u8> dest, Byteswap bswap) {
+  return read(reg, field, dest, bswap, rw);
+}
+bits::Order RegisterScan::read(Register *reg, Register::Field *field, bits::span<u8> dest, Byteswap bswap,
+                               Operation access) {
   using namespace bits;
   if (!reg) throw std::runtime_error("Register not found");
-  else if (auto dev = _sys->find_by_id(reg->target); !dev) throw std::runtime_error("Device not found");
+  else if (std::holds_alternative<std::monostate>(reg->loc))
+    throw std::runtime_error("Register has no storage location");
+
+  // Trim the destination to the size of the register, in case the caller provided a buffer larger than the width.
+  // ave to choose first/last based on host endianness so that later copy/swaps will work (e.g., 0-padding is on the
+  // right end). Only work on this trimmed view.
+  if (dest.size() < reg->byte_width) throw std::runtime_error("Destination is narrower than the register");
+  const auto out = bits::host_is_le ? dest.last(reg->byte_width) : dest.first(reg->byte_width);
+
+  if (!std::holds_alternative<Address>(reg->loc)) {
+    std::visit(ReadVisit{.reg = reg, .out = out}, reg->loc);
+  } else if (auto dev = _sys->find_by_id(reg->target); !dev) throw std::runtime_error("Device not found");
   else if (auto target = dev->capability<Target>(); !target) throw std::runtime_error("Device is not a Target");
   else {
     if (!any(reg->access & Register::Access::Read)) throw std::runtime_error("Register is not readable");
-    // Trim the destination to the size of the register, in case the caller provided a buffer larger than the width.
-    // ave to choose first/last based on host endianness so that later copy/swaps will work (e.g., 0-padding is on the
-    // right end). Only work on this trimmed view.
-    if (dest.size() < reg->byte_width) throw std::runtime_error("Destination is narrower than the register");
-    const auto out = bits::host_is_le ? dest.last(reg->byte_width) : dest.first(reg->byte_width);
-    target->read(reg->offset, out, rw);
-    if (field) {
-      if (!any(field->access & Register::Access::Read)) throw std::runtime_error("Field is not readable");
-      // Must convert to host-order so that bitmasking operations work
-      auto copy = bits::memcpy_endian<u64>(out, reg->order);
-      // Shift the field down so least-significant bit is at [0], and mask out bits beyond width
-      copy = (copy >> field->bit_offset) & ((1ULL << field->bit_width) - 1);
-      // Copy back into dest, converting back to the register's order.
-      bits::memcpy_endian(out, reg->order, copy);
-    }
-    const bool should_swap =
-        (bswap == Byteswap::Always) || (bswap == Byteswap::IfHostMismatch && reg->order != bits::hostOrder());
-    if (should_swap) bits::bytereverse(out);
-    return reg->order;
+    target->read(std::get<Address>(reg->loc), out, access);
   }
+
+  if (field) {
+    if (!any(field->access & Register::Access::Read)) throw std::runtime_error("Field is not readable");
+    // Must convert to host-order so that bitmasking operations work
+    auto copy = bits::memcpy_endian<u64>(out, reg->order);
+    // Shift the field down so least-significant bit is at [0], and mask out bits beyond width
+    copy = (copy >> field->bit_offset) & ((1ULL << field->bit_width) - 1);
+    // Copy back into dest, converting back to the register's order.
+    bits::memcpy_endian(out, reg->order, copy);
+  }
+  const bool should_swap =
+      (bswap == Byteswap::Always) || (bswap == Byteswap::IfHostMismatch && reg->order != bits::hostOrder());
+  if (should_swap) bits::bytereverse(out);
+  return reg->order;
 }
+
+struct WriteVisit {
+  RegisterScan::Register *reg;
+  bits::span<const u8> src;
+  void operator()(std::monostate) { throw std::runtime_error("Register has no storage location"); }
+  void operator()(Address addr) { throw std::runtime_error("Device is not a target"); }
+  template <typename T> void operator()(T *ptr) {
+    if (sizeof(T) != src.size()) throw std::runtime_error("Register width mismatch");
+    std::memcpy(ptr, src.data(), sizeof(T));
+  }
+};
 
 void RegisterScan::write(Register *reg, Register::Field *field, bits::span<const u8> src, Byteswap bswap, bool force) {
   using namespace bits;
   if (!reg) throw std::runtime_error("Register not found");
-  else if (auto dev = _sys->find_by_id(reg->target); !dev) throw std::runtime_error("Device not found");
-  else if (auto target = dev->capability<Target>(); !target) throw std::runtime_error("Device is not a Target");
+  else if (std::holds_alternative<std::monostate>(reg->loc))
+    throw std::runtime_error("Register has no storage location");
+
+  const size_t width = std::min<size_t>(reg->byte_width, sizeof(u64));
+
+  // Byteswap describes src here, mirroring how it describes the destination in read().
+  Order src_order = reg->order;
+  switch (bswap) {
+  case Byteswap::Never: break;
+  case Byteswap::Always: src_order = reg->order == Order::BigEndian ? Order::LittleEndian : Order::BigEndian; break;
+  case Byteswap::IfHostMismatch: src_order = hostOrder(); break;
+  }
+  // Promote to a fixed-sized type to make byte-reversal operations easier to understand.
+  // memcpy_endian truncates or 0-pads when src isn't the register's width.
+  u64 value = memcpy_endian<u64>(src, src_order);
+
+  if (field) {
+    if (!force && !any(field->access & Register::Access::Write)) throw std::runtime_error("Field is not writable");
+    // Read-modify-write: the bits outside this field may belong to other fields siblings and must be unchanged.
+    // Create a copy in whole, then mask out the field's previous bits before inserting the result.
+    // Ensure data is in host order before masking & shifting.
+    u64 whole = 0;
+    auto cur = span<u8>{reinterpret_cast<u8 *>(&whole), width};
+    // Avoid MMIO on this access if it is memory-mapped.
+    read(reg, nullptr, cur, Byteswap::Never, rw_buf);
+    whole = memcpy_endian<u64>(cur, reg->order);
+    const u64 mask = field->bit_width >= 64 ? ~0ULL : (1ULL << field->bit_width) - 1;
+    value = (whole & ~(mask << field->bit_offset)) | ((value & mask) << field->bit_offset);
+  }
+
+  // Convert in place: memcpy_endian takes its integral source by value, so it has already copied `value` before it
+  // writes, and using value's own storage as the destination cannot alias. Which bytes of the u64 these are does
+  // not matter -- memcpy_endian defines dest's contents outright, so no host-order assumption leaks in.
+  auto out = span<u8>{reinterpret_cast<u8 *>(&value), width};
+  memcpy_endian(out, reg->order, value);
+
+  if (auto dev = _sys->find_by_id(reg->target); !dev) throw std::runtime_error("Device not found");
+  else if (!std::holds_alternative<Address>(reg->loc)) {
+    std::visit(WriteVisit{.reg = reg, .src = out}, reg->loc);
+  } else if (auto target = dev->capability<Target>(); !target) throw std::runtime_error("Device is not a Target");
   else {
-    // `force` ignores reset value, useful in clear.
     if (!force && !any(reg->access & Register::Access::Write)) throw std::runtime_error("Register is not writable");
-    const size_t width = std::min<size_t>(reg->byte_width, sizeof(u64));
-
-    // Byteswap describes src here, mirroring how it describes the destination in read().
-    Order src_order = reg->order;
-    switch (bswap) {
-    case Byteswap::Never: break;
-    case Byteswap::Always: src_order = reg->order == Order::BigEndian ? Order::LittleEndian : Order::BigEndian; break;
-    case Byteswap::IfHostMismatch: src_order = hostOrder(); break;
-    }
-    // Promote to a fixed-sized type to make byte-reversal operations easier to understand.
-    // memcpy_endian truncates or 0-pads when src isn't the register's width.
-    u64 value = memcpy_endian<u64>(src, src_order);
-
-    if (field) {
-      if (!force && !any(field->access & Register::Access::Write))
-        throw std::runtime_error("Field is not writable");
-      // Read-modify-write: the bits outside this field may belong to other fields siblings and must be unchanged.
-      // Create a copy in whole, then mask out the field's previous bits before inserting the result.
-      // Ensure data is in host order before masking & shifting.
-      u64 whole = 0;
-      auto cur = span<u8>{reinterpret_cast<u8 *>(&whole), width};
-      // Avoid MMIO on this access if it is memory-mapped.
-      target->read(reg->offset, cur, rw_buf);
-      whole = memcpy_endian<u64>(cur, reg->order);
-      const u64 mask = field->bit_width >= 64 ? ~0ULL : (1ULL << field->bit_width) - 1;
-      value = (whole & ~(mask << field->bit_offset)) | ((value & mask) << field->bit_offset);
-    }
-
-    // Convert in place: memcpy_endian takes its integral source by value, so it has already copied `value` before it
-    // writes, and using value's own storage as the destination cannot alias. Which bytes of the u64 these are does
-    // not matter -- memcpy_endian defines dest's contents outright, so no host-order assumption leaks in.
-    auto out = span<u8>{reinterpret_cast<u8 *>(&value), width};
-    memcpy_endian(out, reg->order, value);
-    target->write(reg->offset, out, force ? rw_buf : rw);
+    target->write(std::get<Address>(reg->loc), out, force ? rw_buf : rw);
   }
 }
 

--- a/core/core/sim/debugger/register_scanner.cpp
+++ b/core/core/sim/debugger/register_scanner.cpp
@@ -1,12 +1,28 @@
 #include "register_scanner.hpp"
+#include <stdexcept>
 #include "core/math/bitmanip/copy.hpp"
 #include "core/sim/system.hpp"
 
 namespace {
 static const Operation rw(Operation::Type::Application, Operation::Kind::data);
 static const Operation rw_buf(Operation::Type::BufferInternal, Operation::Kind::data);
+
+// A pointer-backed register must declare the width of the storage it points at, because that is what the access
+// visitors compare against on every read and write. Checked once at expose() so a mistake fails where the register is
+// declared, rather than as an exception out of the middle of some later read. An Address has no size to check.
+struct WidthCheck {
+  const RegisterScan::Register &reg;
+  void operator()(std::monostate) const {}
+  void operator()(Address) const {}
+  template <typename T> void operator()(const T *) const {
+    if (sizeof(T) != reg.byte_width)
+      throw std::logic_error("Register " + reg.name + " declares " + std::to_string(reg.byte_width) +
+                             " bytes but points at storage of " + std::to_string(sizeof(T)));
+  }
+};
 } // namespace
 RegisterScan::Register::Reference RegisterScan::expose(const Register &n) {
+  std::visit(WidthCheck{n}, n.loc);
   auto id = next_id();
   _regs[id] = std::make_unique<Register>(n);
   _exposed[n.target].push_back(id);

--- a/core/core/sim/debugger/register_scanner.cpp
+++ b/core/core/sim/debugger/register_scanner.cpp
@@ -5,7 +5,7 @@
 namespace {
 static const Operation rw(Operation::Type::Application, Operation::Kind::data);
 static const Operation rw_buf(Operation::Type::BufferInternal, Operation::Kind::data);
-}
+} // namespace
 RegisterScan::Register::Reference RegisterScan::expose(const Register &n) {
   auto id = next_id();
   _regs[id] = std::make_unique<Register>(n);
@@ -13,15 +13,15 @@ RegisterScan::Register::Reference RegisterScan::expose(const Register &n) {
   return Register::Reference{.reg = id};
 }
 
-void RegisterScan::write(const RegisterRef &ref, bits::span<const u8> src, Byteswap bswap) {
+void RegisterScan::write(const RegisterRef &ref, bits::span<const u8> src, Byteswap bswap, Level level) {
   using namespace bits;
   auto [reg, field] = resolve(ref);
-  return write(reg, field, src, bswap);
+  return write(reg, field, src, bswap, level);
 }
 
-bits::Order RegisterScan::read(const RegisterRef &ref, bits::span<u8> dest, Byteswap bswap) {
+bits::Order RegisterScan::read(const RegisterRef &ref, bits::span<u8> dest, Byteswap bswap, Level level) {
   auto [reg, field] = resolve(ref);
-  return read(reg, field, dest, bswap);
+  return read(reg, field, dest, bswap, level);
 }
 
 void RegisterScan::clear(const RegisterRef &r) {
@@ -29,7 +29,9 @@ void RegisterScan::clear(const RegisterRef &r) {
   static const u64 zero = 0;
   static const auto zspan = bits::span<const u8>{reinterpret_cast<const u8 *>(&zero), sizeof(zero)};
   if (!reg) throw std::runtime_error("Register not found");
-  write(reg, field, zspan, Byteswap::Never, true);
+  // A reset brings the register back to its default value, simulating a power-cycle of the device. This should allow a
+  // RO register (from the guest side) to be written.
+  write(reg, field, zspan, Byteswap::Never, Level::Host);
 }
 
 std::pair<RegisterScan::Register *, RegisterScan::Register::Field *> RegisterScan::resolve(RegisterRef r) {
@@ -78,11 +80,25 @@ struct ReadVisit {
   }
 };
 
-bits::Order RegisterScan::read(Register *reg, Register::Field *field, bits::span<u8> dest, Byteswap bswap) {
-  return read(reg, field, dest, bswap, rw);
+RegisterScan::Access RegisterScan::granted(const Register &reg, Level level) {
+  return level == Level::Host ? reg.host_access : reg.guest_access;
 }
+
+RegisterScan::Access RegisterScan::granted(const Register::Field &field, Level level) {
+  return level == Level::Host ? field.host_access : field.guest_access;
+}
+
+void RegisterScan::load(Register *reg, bits::span<u8> out, Operation access) {
+  // The device is only consulted for Address-backed storage; a pointer needs nothing from the system.
+  if (!std::holds_alternative<Address>(reg->loc)) {
+    std::visit(ReadVisit{.reg = reg, .out = out}, reg->loc);
+  } else if (auto dev = _sys->find_by_id(reg->target); !dev) throw std::runtime_error("Device not found");
+  else if (auto target = dev->capability<Target>(); !target) throw std::runtime_error("Device is not a Target");
+  else target->read(std::get<Address>(reg->loc), out, access);
+}
+
 bits::Order RegisterScan::read(Register *reg, Register::Field *field, bits::span<u8> dest, Byteswap bswap,
-                               Operation access) {
+                               Level level) {
   using namespace bits;
   if (!reg) throw std::runtime_error("Register not found");
   else if (std::holds_alternative<std::monostate>(reg->loc))
@@ -94,17 +110,13 @@ bits::Order RegisterScan::read(Register *reg, Register::Field *field, bits::span
   if (dest.size() < reg->byte_width) throw std::runtime_error("Destination is narrower than the register");
   const auto out = bits::host_is_le ? dest.last(reg->byte_width) : dest.first(reg->byte_width);
 
-  if (!std::holds_alternative<Address>(reg->loc)) {
-    std::visit(ReadVisit{.reg = reg, .out = out}, reg->loc);
-  } else if (auto dev = _sys->find_by_id(reg->target); !dev) throw std::runtime_error("Device not found");
-  else if (auto target = dev->capability<Target>(); !target) throw std::runtime_error("Device is not a Target");
-  else {
-    if (!any(reg->access & Register::Access::Read)) throw std::runtime_error("Register is not readable");
-    target->read(std::get<Address>(reg->loc), out, access);
-  }
+  // Access control is first enforced at a per-register level before accessing.
+  if (!any(granted(*reg, level) & Register::Access::Read)) throw std::runtime_error("Register is not readable");
+
+  load(reg, out, level == Level::Guest ? rw : rw_buf);
 
   if (field) {
-    if (!any(field->access & Register::Access::Read)) throw std::runtime_error("Field is not readable");
+    if (!any(granted(*field, level) & Register::Access::Read)) throw std::runtime_error("Field is not readable");
     // Must convert to host-order so that bitmasking operations work
     auto copy = bits::memcpy_endian<u64>(out, reg->order);
     // Shift the field down so least-significant bit is at [0], and mask out bits beyond width
@@ -129,11 +141,13 @@ struct WriteVisit {
   }
 };
 
-void RegisterScan::write(Register *reg, Register::Field *field, bits::span<const u8> src, Byteswap bswap, bool force) {
+void RegisterScan::write(Register *reg, Register::Field *field, bits::span<const u8> src, Byteswap bswap, Level level) {
   using namespace bits;
   if (!reg) throw std::runtime_error("Register not found");
   else if (std::holds_alternative<std::monostate>(reg->loc))
     throw std::runtime_error("Register has no storage location");
+  // Ibid read(): the declaration binds whatever the storage is, and which half of it applies depends on the level.
+  else if (!any(granted(*reg, level) & Register::Access::Write)) throw std::runtime_error("Register is not writable");
 
   const size_t width = std::min<size_t>(reg->byte_width, sizeof(u64));
 
@@ -149,41 +163,37 @@ void RegisterScan::write(Register *reg, Register::Field *field, bits::span<const
   u64 value = memcpy_endian<u64>(src, src_order);
 
   if (field) {
-    if (!force && !any(field->access & Register::Access::Write)) throw std::runtime_error("Field is not writable");
-    // Read-modify-write: the bits outside this field may belong to other fields siblings and must be unchanged.
-    // Create a copy in whole, then mask out the field's previous bits before inserting the result.
+    if (!any(granted(*field, level) & Register::Access::Write)) throw std::runtime_error("Field is not writable");
+    // Read-modify-write. Bits outside this field belong to other fields siblings and must be unchanged.
+    // Create a copy which is masked and shifted to the individual field.
     // Ensure data is in host order before masking & shifting.
     u64 whole = 0;
     auto cur = span<u8>{reinterpret_cast<u8 *>(&whole), width};
-    // Avoid MMIO on this access if it is memory-mapped.
-    read(reg, nullptr, cur, Byteswap::Never, rw_buf);
+    // Avoid mmio and do not require guest-read permission
+    load(reg, cur, rw_buf);
     whole = memcpy_endian<u64>(cur, reg->order);
     const u64 mask = field->bit_width >= 64 ? ~0ULL : (1ULL << field->bit_width) - 1;
     value = (whole & ~(mask << field->bit_offset)) | ((value & mask) << field->bit_offset);
   }
 
-  // Convert in place: memcpy_endian takes its integral source by value, so it has already copied `value` before it
-  // writes, and using value's own storage as the destination cannot alias. Which bytes of the u64 these are does
-  // not matter -- memcpy_endian defines dest's contents outright, so no host-order assumption leaks in.
+  // Ensure working copy has been transformed t the register's order.
   auto out = span<u8>{reinterpret_cast<u8 *>(&value), width};
   memcpy_endian(out, reg->order, value);
 
-  if (auto dev = _sys->find_by_id(reg->target); !dev) throw std::runtime_error("Device not found");
-  else if (!std::holds_alternative<Address>(reg->loc)) {
+  if (!std::holds_alternative<Address>(reg->loc)) {
     std::visit(WriteVisit{.reg = reg, .src = out}, reg->loc);
-  } else if (auto target = dev->capability<Target>(); !target) throw std::runtime_error("Device is not a Target");
-  else {
-    if (!force && !any(reg->access & Register::Access::Write)) throw std::runtime_error("Register is not writable");
-    target->write(std::get<Address>(reg->loc), out, force ? rw_buf : rw);
-  }
+  } else if (auto dev = _sys->find_by_id(reg->target); !dev) throw std::runtime_error("Device not found");
+  else if (auto target = dev->capability<Target>(); !target) throw std::runtime_error("Device is not a Target");
+  // Only a guest write is an Application access; the host's own writes must not trace themselves.
+  else target->write(std::get<Address>(reg->loc), out, level == Level::Guest ? rw : rw_buf);
 }
 
-RegisterScan::Register::Access RegisterScan::access(RegisterRef r) const {
+RegisterScan::Register::Access RegisterScan::access(RegisterRef r, Level level) const {
   auto [reg, field] = resolve(r);
   if (!reg) {
     throw std::runtime_error("Register not found");
-  } else if (!field) return reg->access;
-  else return field->access;
+  } else if (!field) return granted(*reg, level);
+  else return granted(*field, level);
 }
 
 RegisterScan::Register::ID RegisterScan::next_id() { return next++; }

--- a/core/core/sim/debugger/register_scanner.cpp
+++ b/core/core/sim/debugger/register_scanner.cpp
@@ -6,10 +6,11 @@ namespace {
 static const Operation rw(Operation::Type::Application, Operation::Kind::data);
 static const Operation rw_buf(Operation::Type::BufferInternal, Operation::Kind::data);
 }
-void RegisterScan::expose(const Register &n) {
+RegisterScan::Register::Reference RegisterScan::expose(const Register &n) {
   auto id = next_id();
   _regs[id] = std::make_unique<Register>(n);
   _exposed[n.target].push_back(id);
+  return Register::Reference{.reg = id};
 }
 
 void RegisterScan::write(const RegisterRef &ref, bits::span<const u8> src, Byteswap bswap) {

--- a/core/core/sim/debugger/register_scanner.hpp
+++ b/core/core/sim/debugger/register_scanner.hpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <variant>
 #include "core/math/bitmanip/copy.hpp"
 #include "core/sim/api/device.hpp"
 #include "core/sim/api/memory.hpp"
@@ -19,7 +20,27 @@ public:
   struct Register {
     using ID = pepp::OpaqueHandle<struct RegisterID, u16>;
     enum class Access : u8 { None = 0, Read = 1 << 0, Write = 1 << 1 };
-    static constexpr auto ReadWrite = (Access)((u8)Access::Read | (u8)Access::Write);
+    // Reports how the register interacts with the tracing (undo/redo) system.
+    enum class Tracing : u8 {
+      // The register's value is restored automatically on step backwards.
+      // This is the required mode for registers which are part of the architectural state of the system.
+      Automatic,
+      // The register is not restored automatically, but could be restored with a manual save + restore.
+      // This mode is appropriate for performance counters (like a counter tracking a cache hit rate) which do not
+      // affect the correctness of the system.
+      Checkpoint,
+      // The register can't be restored. Attempting to restore it would break the simulator.
+      // An example would be a register which reports the size of the trace buffer.
+      Monotonic,
+    };
+    enum class Type {
+      Architectural,      // Part of the ISA of the system
+      Microarchitectural, // A microarchitecure detail, but still part of the implementation
+      Counter,            // A performance counter which does not affect the correctness of the system
+    };
+
+    static constexpr auto ReadWrite =
+        static_cast<Access>(static_cast<u8>(Access::Read) | static_cast<u8>(Access::Write));
     struct Field {
       // Starts from 1, not 0! 0 is a reserved value.
       using ID = pepp::OpaqueHandle<struct FieldID, u16>;
@@ -35,19 +56,24 @@ public:
       bool is_register() const { return !is_field(); }
       bool is_field() const { return field.value != 0; }
     };
-    bits::Order order;
     u8 byte_width; // Width in BYTES.
     Access access = ReadWrite;
+    Tracing trace_mode = Tracing::Automatic;
+    Type type = Type::Architectural;
     Device::ID target;
-    Address offset;
+    bits::Order order;
     std::string name;
     std::vector<Field> fields;
+    // if Address, then fetch the target from a system, cast to Target* and call the appropirate method.
+    // Otherwise read/write the pointer directly.
+    using StorageLocation = std::variant<std::monostate, Address, i8 *, u8 *, i16 *, u16 *, i32 *, u32 *, i64 *, u64 *>;
+    StorageLocation loc = std::monostate{};
   };
   using RegisterRef = Register::Reference;
 
   RegisterScan(System *sys) : _sys(sys) {}
   void expose(const Register &n);
-  // Copy
+
   enum class Byteswap {
     Always,        // Always perform a byteswap, even when host/guest match.
     Never,         // Never perform a byteswap, even when host/guest mismatch.
@@ -71,6 +97,7 @@ public:
 
 private:
   bits::Order read(Register *, Register::Field *, bits::span<u8> dest, Byteswap bswap);
+  bits::Order read(Register *, Register::Field *, bits::span<u8> dest, Byteswap bswap, Operation access);
   void write(Register *, Register::Field *, bits::span<const u8> src, Byteswap bswap, bool force = false);
   Register::ID next_id();
 

--- a/core/core/sim/debugger/register_scanner.hpp
+++ b/core/core/sim/debugger/register_scanner.hpp
@@ -13,12 +13,13 @@
 // Corresponds to an AddressSpan in some Target.
 
 // A class that acts a bit like the scanchain of a JTAG debugger, allowing named entries to be exposed
-// Devices call expose(...) as part of scan_debug_hardware(...), registering locations which can be read and written by
+// Devices call expose(...) as part of initialize(...), registering locations which can be read and written by
 // a debugger.
 class RegisterScan {
 public:
   struct Register {
     using ID = pepp::OpaqueHandle<struct RegisterID, u16>;
+    // Operations allowed on a register or field.
     enum class Access : u8 { None = 0, Read = 1 << 0, Write = 1 << 1 };
     // Reports how the register interacts with the tracing (undo/redo) system.
     enum class Tracing : u8 {
@@ -44,7 +45,8 @@ public:
     struct Field {
       // Starts from 1, not 0! 0 is a reserved value.
       using ID = pepp::OpaqueHandle<struct FieldID, u16>;
-      Access access = ReadWrite;
+      Access guest_access = ReadWrite;
+      Access host_access = ReadWrite;
       u8 bit_offset = 0;
       u8 bit_width = 0;
       std::string name;
@@ -57,7 +59,10 @@ public:
       bool is_field() const { return field.value != 0; }
     };
     u8 byte_width; // Width in BYTES.
-    Access access = ReadWrite;
+    // Separate guest access from host access. A debugger may need access to a register/counter (e.g., call_depth) that
+    // should either be invisible to the guest or read-only.
+    Access guest_access = ReadWrite;
+    Access host_access = ReadWrite;
     Tracing trace_mode = Tracing::Automatic;
     Type type = Type::Architectural;
     Device::ID target;
@@ -70,9 +75,17 @@ public:
     StorageLocation loc = std::monostate{};
   };
   using RegisterRef = Register::Reference;
+  using Access = Register::Access;
 
   RegisterScan(System *sys) : _sys(sys) {}
   RegisterScan::Register::Reference expose(const Register &n);
+
+  // Where does the access originate from? Both techincally come from within this process, but distringuishing simulated
+  // traffic from the simulators' infrastructure's traffic is important.
+  enum class Level : u8 {
+    Guest, // The system/device tree under test.
+    Host,  // All other traffic not originating from a guest program.
+  };
 
   enum class Byteswap {
     Always,        // Always perform a byteswap, even when host/guest match.
@@ -80,25 +93,32 @@ public:
     IfHostMismatch // If the register's order does not match the host order, byteswap in dest before returning.
   };
 
-  void write(const RegisterRef &n, bits::span<const u8> src, Byteswap bswap = Byteswap::Never);
-  bits::Order read(const RegisterRef &n, bits::span<u8> dest, Byteswap bswap = Byteswap::Never);
+  void write(const RegisterRef &n, bits::span<const u8> src, Byteswap bswap = Byteswap::Never,
+             Level level = Level::Guest);
+  bits::Order read(const RegisterRef &n, bits::span<u8> dest, Byteswap bswap = Byteswap::Never,
+                   Level level = Level::Guest);
 
   std::optional<RegisterRef> find(std::string_view name);
   // Helper which returns the value of a register as an integral type
-  template <std::integral I> I read(const RegisterRef &n);
+  template <std::integral I> I read(const RegisterRef &n, Level level = Level::Guest);
   // Helper which writes an integral value to a register.
-  template <std::integral I> void write(const RegisterRef &n, I value);
+  template <std::integral I> void write(const RegisterRef &n, I value, Level level = Level::Guest);
+  // A reset rather than a write, so it goes in at Level::Host: a register the guest may not write still resets.
   void clear(const RegisterRef &n);
 
   std::pair<Register *, Register::Field *> resolve(RegisterRef r);
   std::pair<const Register *, const Register::Field *> resolve(RegisterRef r) const;
-  Register::Access access(RegisterRef r) const;
+  Register::Access access(RegisterRef r, Level level = Level::Guest) const;
   u8 bit_width(RegisterRef r) const;
 
 private:
-  bits::Order read(Register *, Register::Field *, bits::span<u8> dest, Byteswap bswap);
-  bits::Order read(Register *, Register::Field *, bits::span<u8> dest, Byteswap bswap, Operation access);
-  void write(Register *, Register::Field *, bits::span<const u8> src, Byteswap bswap, bool force = false);
+  bits::Order read(Register *, Register::Field *, bits::span<u8> dest, Byteswap bswap, Level level);
+  // Fetch a register's bytes out of whatever backs it without checking for guest-read access permission.
+  void load(Register *reg, bits::span<u8> out, Operation access);
+  void write(Register *, Register::Field *, bits::span<const u8> src, Byteswap bswap, Level level);
+  // What this register/field grants at `level`.
+  static Access granted(const Register &reg, Level level);
+  static Access granted(const Register::Field &field, Level level);
   Register::ID next_id();
 
   System *_sys;
@@ -108,18 +128,18 @@ private:
   std::unordered_map<Register::ID, std::unique_ptr<Register>, pepp::handle_hash<Register::ID>> _regs;
 };
 
-template <std::integral I> I RegisterScan::read(const RegisterRef &n) {
+template <std::integral I> I RegisterScan::read(const RegisterRef &n, Level level) {
   auto p = resolve(n);
   if (!p.first) throw std::runtime_error("Register not found");
   // Read into a fixed-size buffer so that we know where the bytes will land before we convert to host order.
   // this avoids a posibility where we read the wrong "part" of a register and therefore return 0.
   const size_t width = std::min<size_t>(p.first->byte_width, sizeof(u64));
   std::array<u8, sizeof(u64)> buf{};
-  const auto order = read(p.first, p.second, bits::span<u8>{buf.data(), width}, Byteswap::Never);
+  const auto order = read(p.first, p.second, bits::span<u8>{buf.data(), width}, Byteswap::Never, level);
   return (I)bits::memcpy_endian<u64>(bits::span<const u8>{buf.data(), width}, order);
 }
 
-template <std::integral I> void RegisterScan::write(const RegisterRef &n, I value) {
+template <std::integral I> void RegisterScan::write(const RegisterRef &n, I value, Level level) {
   auto p = resolve(n);
   if (!p.first) throw std::runtime_error("Register not found");
   // Serialize into the register's own order up front, so the write path has nothing left to convert. This mirrors
@@ -129,7 +149,7 @@ template <std::integral I> void RegisterScan::write(const RegisterRef &n, I valu
   auto buf = bits::span<u8>{reinterpret_cast<u8 *>(&raw), width};
   // Cast sign-extends according to the rules of I.
   bits::memcpy_endian(buf, p.first->order, (u64)value);
-  write(p.first, p.second, buf, Byteswap::Never);
+  write(p.first, p.second, buf, Byteswap::Never, level);
 }
 
 consteval void is_bitflags(RegisterScan::Register::Access);

--- a/core/core/sim/debugger/register_scanner.hpp
+++ b/core/core/sim/debugger/register_scanner.hpp
@@ -80,11 +80,13 @@ public:
   RegisterScan(System *sys) : _sys(sys) {}
   RegisterScan::Register::Reference expose(const Register &n);
 
-  // Where does the access originate from? Both techincally come from within this process, but distringuishing simulated
-  // traffic from the simulators' infrastructure's traffic is important.
+  // Where does the access originate from? Both techincally come from within this process, but distinguishing simulated
+  // traffic from the simulators' infrastructure's traffic is important. If the access is made on the machines behalf
+  // (e.g., a debugger poking a register to display it), the access should be Guest. Trying to reset a VM to a
+  // clean/default state or replaying a trace would be Host. The default is Guest, which is the least-permissive.
   enum class Level : u8 {
-    Guest, // The system/device tree under test.
-    Host,  // All other traffic not originating from a guest program.
+    Guest, // The system/device tree under test, and anything reaching into it on a user's behalf.
+    Host,  // The simulator's own infrastructure: replaying a trace, resetting a device, restoring a checkpoint.
   };
 
   enum class Byteswap {

--- a/core/core/sim/debugger/register_scanner.hpp
+++ b/core/core/sim/debugger/register_scanner.hpp
@@ -72,7 +72,7 @@ public:
   using RegisterRef = Register::Reference;
 
   RegisterScan(System *sys) : _sys(sys) {}
-  void expose(const Register &n);
+  RegisterScan::Register::Reference expose(const Register &n);
 
   enum class Byteswap {
     Always,        // Always perform a byteswap, even when host/guest match.

--- a/core/core/sim/debugger/trace_recorder.cpp
+++ b/core/core/sim/debugger/trace_recorder.cpp
@@ -1,9 +1,15 @@
 #include "core/sim/debugger/trace_recorder.hpp"
 #include <algorithm>
+#include <array>
 #include <utility>
 #include "core/math/bitmanip/copy.hpp"
 #include "core/sim/debugger/tvm_encoding.hpp"
 #include "core/sim/debugger/tvm_tracebuffer.hpp"
+
+namespace {
+// STEPMEM's MOD1.hi: nonzero says the destination is big-endian. See Opcode::STEPMEM.
+constexpr u16 STEP_BIG_ENDIAN = 1;
+} // namespace
 
 namespace trace {
 
@@ -57,6 +63,55 @@ void Recorder::emit_write(const Operation &op, Address address, bits::span<const
   emit_write(op, address, now.first(len), [&](bits::span<u8> tmp) { bits::memcpy(tmp, prior.first(len)); });
 }
 
+void Recorder::emit_write_increment(const Operation &op, Address address, bits::span<const u8> prior,
+                                    bits::span<const u8> now) {
+  const std::size_t len = now.size();
+  if (len == 0) return;       // A write with no data is meaningless.
+  else if (!traced()) return; // Don't record for untraced.
+  else if (op.type == Operation::Type::BufferInternal)
+    return; // Access related to TB or UI. Filter or we'll loop infinitely.
+  // The delta is computed in a u64, and the packet's payload words are sized at compile time, so only the widths
+  // switched over below can take this form. Anything else still has to be recorded or the trace stops being
+  // reversible, so hand it to the XOR encoding, which is width-agnostic.
+  else if (len != 1 && len != 2 && len != 4 && len != 8) return emit_write(op, address, now, prior);
+  const auto rec = _tb->find_recording(op.initiator);
+  // begin() never called for that initiator.
+  if (rec == nullptr) return;
+
+  // The previous contents land on the stack rather than in the data chain, because unlike emit_write this record
+  // carries its payload as code and touches the data chain not at all.
+  std::array<u8, sizeof(u64)> scratch{};
+
+  // Both sides are read big-endian because the targets this is aimed at are. Reading them in the wrong order would
+  // still replay correctly -- bytes to integer and back is a bijection either way, so the sum reproduces `now`'s
+  // bytes exactly -- but the delta would stop being the same number every time the moment a carry crossed a byte
+  // boundary. A body that is not byte-identical between executions cannot be promoted to a stencil, and that
+  // promotion is the entire reason this form carries its payload as code.
+  const u64 before = bits::memcpy_endian<u64>(prior, bits::Order::BigEndian);
+  const u64 after = bits::memcpy_endian<u64>(now, bits::Order::BigEndian);
+  const u64 delta = after - before;
+
+  const auto off = tvm::SegmentPair{.hi = (u16)(address >> 16), .lo = (u16)(address & 0xFFFF)};
+  // STEPMEM reads one size for both the delta and the destination, so the payload is emitted at the width of the
+  // write. TraceBuffer::address_in_payload has no say here: there is no D variant of this opcode, and the caller
+  // asking for a step is asking for a body that stands alone.
+  const auto emit = [&]<std::size_t N>() {
+    std::array<u8, N> payload{};
+    bits::memcpy_endian(bits::span<u8>{payload.data(), N}, bits::Order::LittleEndian, delta);
+    const auto step = tvm::EncodedOp::StepMem<6>(op.as_u16(), _emitter.value, off, STEP_BIG_ENDIAN).encode(payload);
+    _tb->emit_body(*rec, {step.data(), step.size()});
+  };
+  switch (len) {
+  case 1: emit.operator()<1>(); break;
+  case 2: emit.operator()<2>(); break;
+  case 4: emit.operator()<4>(); break;
+  case 8: emit.operator()<8>(); break;
+  default: break; // Unreachable: the width guard above admits nothing else.
+  }
+  // Deliberately no emit_dp_update and no append_data. An immediate payload leaves DP and DS exactly as they were,
+  // which is also what lets a following emit_write in the same recording step from the anchor it expects.
+}
+
 void Recorder::emit_write(const Operation &op, Address address, bits::span<const u8> now, PriorFiller fill_prior) {
   const std::size_t len = now.size();
   if (len == 0) return;       // A write with no data is meaningless.
@@ -105,8 +160,28 @@ void Recorder::emit_mm_read(const Operation &op, Address address, u8 popped) {
   return emit_mm(op, address, popped, false);
 }
 
-void Recorder::emit_incr_register(const Operation &op, void *reg, i16 value) {
-  // TODO!
+void Recorder::emit_incr_register(const Operation &op, RegisterScan::RegisterRef ref, i16 value) {
+  if (value == 0) return;     // A step of nothing replays to nothing in either direction.
+  else if (!traced()) return; // Don't record for untraced.
+  else if (op.type == Operation::Type::BufferInternal)
+    return; // Access related to TB or UI. Filter or we'll loop infinitely.
+  // Register 0 is never handed out by RegisterScan::expose, so this is a device that never exposed the counter it is
+  // trying to step. Drop it here rather than letting the replay hard-stop on RegisterInvalid.
+  else if (ref.reg.value == 0) return;
+  const auto rec = _tb->find_recording(op.initiator);
+  // begin() never called for that initiator.
+  if (rec == nullptr) return;
+
+  // Nothing is appended and no DP update is emitted: the payload is immediate, so DP and DS come out as they went in.
+  // The register's width and byte order stay STEPREG's business, since the scan reports both -- which is why the
+  // delta may be narrower than the counter it steps.
+  const auto emit = [&](auto payload) {
+    const auto step = tvm::EncodedOp::StepReg<4>(op.as_u16(), ref.reg.value, ref.field.value).encode(payload);
+    _tb->emit_body(*rec, {step.data(), step.size()});
+  };
+  // Payloads are little-endian and signed. One byte covers the +-1 steps this exists for; the rest take two.
+  if (value >= -128 && value <= 127) emit(std::array<u8, 1>{(u8)value});
+  else emit(std::array<u8, 2>{(u8)(value & 0xFF), (u8)((value >> 8) & 0xFF)});
 }
 
 void Recorder::emit_mm(const Operation &op, Address address, u8 pushed, bool read_write) {

--- a/core/core/sim/debugger/trace_recorder.cpp
+++ b/core/core/sim/debugger/trace_recorder.cpp
@@ -73,14 +73,10 @@ void Recorder::emit_write_increment(const Operation &op, Address address, bits::
   // The delta is computed in a u64, and the packet's payload words are sized at compile time, so only the widths
   // switched over below can take this form. Anything else still has to be recorded or the trace stops being
   // reversible, so hand it to the XOR encoding, which is width-agnostic.
-  else if (len != 1 && len != 2 && len != 4 && len != 8) return emit_write(op, address, now, prior);
+  else if (len != 1 && len != 2 && len != 4 && len != 8) return emit_write(op, address, prior, now);
   const auto rec = _tb->find_recording(op.initiator);
   // begin() never called for that initiator.
   if (rec == nullptr) return;
-
-  // The previous contents land on the stack rather than in the data chain, because unlike emit_write this record
-  // carries its payload as code and touches the data chain not at all.
-  std::array<u8, sizeof(u64)> scratch{};
 
   // Both sides are read big-endian because the targets this is aimed at are. Reading them in the wrong order would
   // still replay correctly -- bytes to integer and back is a bijection either way, so the sum reproduces `now`'s

--- a/core/core/sim/debugger/trace_recorder.cpp
+++ b/core/core/sim/debugger/trace_recorder.cpp
@@ -105,6 +105,10 @@ void Recorder::emit_mm_read(const Operation &op, Address address, u8 popped) {
   return emit_mm(op, address, popped, false);
 }
 
+void Recorder::emit_incr_register(const Operation &op, void *reg, i16 value) {
+  // TODO!
+}
+
 void Recorder::emit_mm(const Operation &op, Address address, u8 pushed, bool read_write) {
   static constexpr u16 len = 1; // MMIO data payload is one byte.
   if (!traced()) return;        // Don't record for untraced.

--- a/core/core/sim/debugger/trace_recorder.hpp
+++ b/core/core/sim/debugger/trace_recorder.hpp
@@ -87,6 +87,8 @@ public:
   // record that value, otherwise we cannot undo this action.
   void emit_mm_read(const Operation &op, Address address, u8 popped);
 
+  void emit_incr_register(const Operation &op, void *reg, i16 value);
+
   // A helper class which which helps open & close a recording for a single instruction.
   class Instruction {
   public:

--- a/core/core/sim/debugger/trace_recorder.hpp
+++ b/core/core/sim/debugger/trace_recorder.hpp
@@ -6,6 +6,9 @@
 #include "core/math/bitmanip/span.hpp"
 #include "core/sim/api/device.hpp"
 #include "core/sim/api/memory.hpp"
+// For RegisterScan::RegisterRef, which emit_incr_register takes by value. It is a pair of 16-bit handles, and being a
+// nested type there is no forward declaring it.
+#include "core/sim/debugger/register_scanner.hpp"
 
 namespace tvm {
 class DataSlot;
@@ -72,6 +75,18 @@ public:
   // Prefer this overload if you don't have to allocate a temp buffer to access the old value, such as with a Dense
   // device.
   void emit_write(const Operation &op, Address address, bits::span<const u8> prior, bits::span<const u8> now);
+  // Record the same write as STEPMEM, whose payload is `now - prior` rather than `now ^ prior`.
+  //
+  // Both the address/offset and the delta are encoded in the instruction packet, which means this does not impact the
+  // data chain. For memory locations which are updated by a fixed increment each instruction (program counter, cycle
+  // counter), this produces a byte-identical instruction where a SETMEMX encoding would not.
+  // For a per-cycle PC update, this saves ~2B per instruction, which is a 10% footprint savings.
+  // In all other cases (writes to main-memory), I expect STEPMEM to be worse than SETMEMX because of the presence of
+  // offset in the packet.
+  //
+  // The values are read big-endian, matching the targets this exists for. Writes whose width is not 1, 2, 4, or 8
+  // bytes fall back to emit_write.
+  void emit_write_increment(const Operation &op, Address address, bits::span<const u8> prior, bits::span<const u8> now);
 
   // Same, for a device whose previous contents are not sitting in contiguous memory, such as Sparse or a bus.
   // fill_prior is a function reference which writes the prior bytes into a provided span. That provided span is in the
@@ -87,7 +102,19 @@ public:
   // record that value, otherwise we cannot undo this action.
   void emit_mm_read(const Operation &op, Address address, u8 popped);
 
-  void emit_incr_register(const Operation &op, void *reg, i16 value);
+  // Record a signed step of a scan-exposed register: the STEPREG sibling of emit_write_increment.
+  //
+  // The register reference and the delta both ride in the instruction packet, so this writes nothing to the data
+  // chain and leaves DP and DS alone. A counter that moves by the same amount every time -- +-1 on a call depth, +1
+  // on a cycle count -- emits a byte-identical body, which promotes to a stencil and collapses the whole record to a
+  // CALL carrying no payload at all.
+  //
+  // Unlike emit_write this never reads the register, so it does not have to be called ahead of the update the way
+  // the write-ahead rule above demands; either side of the increment is fine. A zero step records nothing.
+  //
+  // Whether a given counter is worth recording at all is the caller's decision, not this one's: a Checkpoint or
+  // Monotonic register (see RegisterScan::Register::Tracing) should not be handed to it.
+  void emit_incr_register(const Operation &op, RegisterScan::RegisterRef ref, i16 value);
 
   // A helper class which which helps open & close a recording for a single instruction.
   class Instruction {

--- a/core/core/sim/debugger/tvm_apply_backend.cpp
+++ b/core/core/sim/debugger/tvm_apply_backend.cpp
@@ -1,6 +1,7 @@
 #include "core/sim/debugger/tvm_apply_backend.hpp"
 #include <cstring>
 #include <stdexcept>
+#include "core/math/bitmanip/copy.hpp"
 #include "core/sim/api/memory.hpp"
 #include "core/sim/memory/errors.hpp"
 #include "core/sim/memory/io/fifo.hpp"
@@ -36,11 +37,14 @@ ApplyBackend::ApplyBackend(std::shared_ptr<pepp::bts::BufferManager> mgr, System
   else _scan = nullptr;
 }
 
-void ApplyBackend::on_setmem(MachineState &state, const tvm::DecodedOp::SetMem &op) {
+void ApplyBackend::on_deltamem(MachineState &state, const tvm::DecodedOp::DeltaMem &op) {
   using StopCause = tvm::StopCause;
   // Not in register mode or there is no system. Either way, comparsion will fail.
   if (state.csrs.TR == 1) return state.hard_stop(StopCause::WrongTR);
   else if (_system == nullptr) return state.hard_stop(StopCause::MissingSystem);
+  // Add does its arithmetic in a u64, so neither the operand nor the delta may be wider than one. This is a property
+  // of the instruction rather than of the machine, so it is checked before anything is resolved.
+  else if (op.kind == tvm::Delta::Add && op.size > sizeof(u64)) return state.hard_stop(StopCause::StepWidthIllegal);
 
   // Attempt to convert our ID to a target;
   auto dev = _system->find_by_id(op.target);
@@ -55,11 +59,14 @@ void ApplyBackend::on_setmem(MachineState &state, const tvm::DecodedOp::SetMem &
 
   bits::span<const u8> data = dbuff->span().subspan(op.data.lo, op.size);
 
-  // The read-xor-write is one logical access: if the read fails there is nothing meaningful to write back.
+  // Perform read-modify-write in a try block so we can catch exceptions and set F accordingly.
   const bool ok = try_access([&] {
     bits::span<const u8> payload = data;
-    // If xor-encoded, perform extract data into temporary buffer and ^ our data into that temp
-    if (op.xor_encoded) {
+    switch (op.kind) {
+    // The payload is the destination's new contents already.
+    case tvm::Delta::Assign: break;
+    // Extract the current contents into a temporary buffer and ^ our data into that temp.
+    case tvm::Delta::Xor: {
       if (_tmp.size() < op.size) _tmp.resize(op.size);
       bits::span<u8> tmp(_tmp.data(), op.size);
       // Lie about access type for this access to avoid side effects.
@@ -67,9 +74,21 @@ void ApplyBackend::on_setmem(MachineState &state, const tvm::DecodedOp::SetMem &
       bits::inplace_xor(tmp, data);
       // "swap" temp buffer into data
       payload = tmp;
+      break;
     }
-    // Not op.access: see Backend::effective_access. The record states what the CPU did; undoing it must not restate
-    // it as something that happened again.
+    case tvm::Delta::Add: {
+      if (_tmp.size() < op.size) _tmp.resize(op.size);
+      bits::span<u8> tmp(_tmp.data(), op.size);
+      target->read(op.offset, tmp, rw_cmp);
+      // memcpy_endian keeps the low-order bytes in either direction, so a sum that overflows the operand wraps
+      // within it rather than spilling into a neighbour.
+      const u64 sum = bits::memcpy_endian<u64>(tmp, op.order) + directed_delta(signed_le(data));
+      bits::memcpy_endian(tmp, op.order, sum);
+      payload = tmp;
+      break;
+    }
+    }
+    // When undoing, we must switch our access type, otherwise we create additional spurious traces.
     target->write(op.offset, payload, effective_access(op.access));
   });
   state.csrs.F = ok ? 0 : 1;
@@ -123,7 +142,7 @@ void ApplyBackend::on_clrmem(MachineState &state, const tvm::DecodedOp::ClrMem &
   state.csrs.F = try_access([&] { target->clear(op.data); }) ? 0 : 1;
 }
 
-void ApplyBackend::on_setreg(MachineState &state, const tvm::DecodedOp::SetReg &op) {
+void ApplyBackend::on_deltareg(MachineState &state, const tvm::DecodedOp::DeltaReg &op) {
   using StopCause = tvm::StopCause;
   // Not in register mode or there is no system. Either way, comparsion will fail.
   if (state.csrs.TR == 0) return state.hard_stop(StopCause::WrongTR);
@@ -134,46 +153,36 @@ void ApplyBackend::on_setreg(MachineState &state, const tvm::DecodedOp::SetReg &
   if (pair.first == nullptr) return state.hard_stop(StopCause::RegisterInvalid);
   // Manually unpack to make debugging easier.
   auto reg = pair.first;
-  auto field = pair.second;
 
   // Prevent access to invalid dbuff / past its end
   auto dbuff = _mgr->find((pepp::bts::Buffer::ID)op.data.hi);
   if (!dbuff) return state.hard_stop(StopCause::InvalidDBuffer);
   else if ((size_t)op.data.lo + op.size > dbuff->span().size()) return state.hard_stop(StopCause::InvalidDBuffer);
 
-  // If size mismatch, then we would have to do a partial write, and we'd need to compute host/guest endianness
-  // mismatch. That sounds annoying, so skip.
-  if (reg->byte_width != op.size) return state.hard_stop(StopCause::RegisterSizeMismatch);
-  const auto dat = (pepp::bts::Buffer::ID)op.data.hi;
-  u64 expected = 0;
-  switch (reg->byte_width) {
-  case 1: expected = read16(*_mgr, state, dat, op.data.lo) & 0xff; break;
-  case 2: expected = read16(*_mgr, state, dat, op.data.lo); break;
-  case 4:
-    expected = ((u32)read16(*_mgr, state, dat, op.data.lo + 2) << 16) | read16(*_mgr, state, dat, op.data.lo);
-    break;
-  default: return state.hard_stop(StopCause::RegisterWidthIllegal);
-  }
   bits::span<const u8> data = dbuff->span().subspan(op.data.lo, op.size);
 
+  // Everything below goes through 64 accessors, which apply the register's own byte order and mask to a field.
+  if (reg->byte_width == 0 || reg->byte_width > sizeof(u64)) return state.hard_stop(StopCause::RegisterWidthIllegal);
+  // STEPREG can have a smaller size than the register. Other operations must match size exactly.
+  else if (op.kind != tvm::Delta::Add && reg->byte_width != op.size)
+    return state.hard_stop(StopCause::RegisterSizeMismatch);
+  // Addition uses C++ primitives, so we are limited to the maximum size of an integer.
+  else if (op.kind == tvm::Delta::Add && op.size > sizeof(u64)) return state.hard_stop(StopCause::StepWidthIllegal);
+
+  // Immediates are little-endian throughout this ISA.
+  const u64 payload = bits::memcpy_endian<u64>(data, bits::Order::LittleEndian);
+
   const bool ok = try_access([&] {
-    // If data is XOR-encoded, we first need to extract the current register value.
-    // TODO: this should be a BufferInternal read, not a normal one!
-    if (op.xor_encoded) {
-      switch (reg->byte_width) {
-      case 1: expected ^= _scan->read<u8>(op.reg); break;
-      case 2: expected ^= _scan->read<u16>(op.reg); break;
-      case 4: expected ^= _scan->read<u32>(op.reg); break;
-      default: break;
-      }
+    u64 value = 0;
+    switch (op.kind) {
+    // The payload is the register's new contents already.
+    case tvm::Delta::Assign: value = payload; break;
+    // TODO: these should be BufferInternal reads, not normal ones!
+    case tvm::Delta::Xor: value = payload ^ _scan->read<u64>(op.reg); break;
+    case tvm::Delta::Add: value = _scan->read<u64>(op.reg) + directed_delta(signed_le(data)); break;
     }
     // RegisterScanner handles field vs register writes.
-    switch (reg->byte_width) {
-    case 1: _scan->write<u8>(op.reg, (u8)expected); break;
-    case 2: _scan->write<u16>(op.reg, (u16)expected); break;
-    case 4: _scan->write<u32>(op.reg, (u32)expected); break;
-    default: break;
-    }
+    _scan->write<u64>(op.reg, value);
   });
   state.csrs.F = !ok;
 }

--- a/core/core/sim/debugger/tvm_apply_backend.cpp
+++ b/core/core/sim/debugger/tvm_apply_backend.cpp
@@ -177,12 +177,14 @@ void ApplyBackend::on_deltareg(MachineState &state, const tvm::DecodedOp::DeltaR
     switch (op.kind) {
     // The payload is the register's new contents already.
     case tvm::Delta::Assign: value = payload; break;
-    // TODO: these should be BufferInternal reads, not normal ones!
-    case tvm::Delta::Xor: value = payload ^ _scan->read<u64>(op.reg); break;
-    case tvm::Delta::Add: value = _scan->read<u64>(op.reg) + directed_delta(signed_le(data)); break;
+    case tvm::Delta::Xor: value = payload ^ _scan->read<u64>(op.reg, RegisterScan::Level::Host); break;
+    case tvm::Delta::Add:
+      value = _scan->read<u64>(op.reg, RegisterScan::Level::Host) + directed_delta(signed_le(data));
+      break;
     }
-    // RegisterScanner handles field vs register writes.
-    _scan->write<u64>(op.reg, value);
+    // RegisterScanner handles field vs register writes. Level::Host because this is the machinery restoring state,
+    // not the user editing it: a counter may be read-only to the guest and still land here.
+    _scan->write<u64>(op.reg, value, RegisterScan::Level::Host);
   });
   state.csrs.F = !ok;
 }
@@ -222,9 +224,9 @@ void ApplyBackend::on_cmpreg(MachineState &state, const tvm::DecodedOp::CmpReg &
   u64 actual = 0;
   const bool ok = try_access([&] {
     switch (reg->byte_width) {
-    case 1: actual = _scan->read<u8>(op.reg); break;
-    case 2: actual = _scan->read<u16>(op.reg); break;
-    case 4: actual = _scan->read<u32>(op.reg); break;
+    case 1: actual = _scan->read<u8>(op.reg, RegisterScan::Level::Host); break;
+    case 2: actual = _scan->read<u16>(op.reg, RegisterScan::Level::Host); break;
+    case 4: actual = _scan->read<u32>(op.reg, RegisterScan::Level::Host); break;
     default: break;
     }
   });

--- a/core/core/sim/debugger/tvm_apply_backend.hpp
+++ b/core/core/sim/debugger/tvm_apply_backend.hpp
@@ -25,10 +25,10 @@ public:
 
   System *system() const { return _system; }
 
-  void on_setmem(MachineState &state, const tvm::DecodedOp::SetMem &op) override;
+  void on_deltamem(MachineState &state, const tvm::DecodedOp::DeltaMem &op) override;
   void on_cmpmem(MachineState &state, const tvm::DecodedOp::CmpMem &op) override;
   void on_clrmem(MachineState &state, const tvm::DecodedOp::ClrMem &op) override;
-  void on_setreg(MachineState &state, const tvm::DecodedOp::SetReg &op) override;
+  void on_deltareg(MachineState &state, const tvm::DecodedOp::DeltaReg &op) override;
   void on_cmpreg(MachineState &state, const tvm::DecodedOp::CmpReg &op) override;
   void on_clrreg(MachineState &state, const tvm::DecodedOp::ClrReg &op) override;
   void on_traddr(MachineState &state, const tvm::DecodedOp::TRADDR &op) override;

--- a/core/core/sim/debugger/tvm_backend.cpp
+++ b/core/core/sim/debugger/tvm_backend.cpp
@@ -1,4 +1,5 @@
 #include "core/sim/debugger/tvm_backend.hpp"
+#include <algorithm>
 #include <bit>
 #include <variant>
 #include "core/sim/debugger/tvm_tracebuffer.hpp"
@@ -19,10 +20,10 @@ struct Dispatch {
   void operator()(const tvm::DecodedOp::ISyn &op) const { self->on_isyn(*state, op); }
   void operator()(const tvm::DecodedOp::LMR &op) const { self->on_lmr(*state, op); }
   void operator()(const tvm::DecodedOp::BR &op) const { self->on_br(*state, op); }
-  void operator()(const tvm::DecodedOp::SetMem &op) const { self->on_setmem(*state, op); }
+  void operator()(const tvm::DecodedOp::DeltaMem &op) const { self->on_deltamem(*state, op); }
   void operator()(const tvm::DecodedOp::CmpMem &op) const { self->on_cmpmem(*state, op); }
   void operator()(const tvm::DecodedOp::ClrMem &op) const { self->on_clrmem(*state, op); }
-  void operator()(const tvm::DecodedOp::SetReg &op) const { self->on_setreg(*state, op); }
+  void operator()(const tvm::DecodedOp::DeltaReg &op) const { self->on_deltareg(*state, op); }
   void operator()(const tvm::DecodedOp::CmpReg &op) const { self->on_cmpreg(*state, op); }
   void operator()(const tvm::DecodedOp::ClrReg &op) const { self->on_clrreg(*state, op); }
   void operator()(const tvm::DecodedOp::TRADDR &op) const { self->on_traddr(*state, op); }
@@ -38,6 +39,17 @@ void Backend::dispatch(MachineState &state, const tvm::DecodedOp::OpChoice &deco
   // Dispatch on the variant's own discriminant rather than re-deriving it from regs.IS via a switch.
   // Failure to handle a valid opcode cause compile-time error.
   std::visit(Dispatch{this, &state}, decoded);
+}
+
+i64 Backend::signed_le(bits::span<const u8> bytes) {
+  const std::size_t width = std::min<std::size_t>(bytes.size(), sizeof(u64));
+  u64 raw = 0;
+  for (std::size_t i = 0; i < width; ++i) raw |= (u64)bytes[i] << (8 * i);
+  if (width > 0 && width < sizeof(u64)) {
+    const u64 bits = 8 * (u64)width;
+    if (raw & (u64(1) << (bits - 1))) raw |= ~((u64(1) << bits) - 1);
+  }
+  return (i64)raw;
 }
 
 void Backend::on_halt(MachineState &state, const tvm::DecodedOp::Halt &op) {

--- a/core/core/sim/debugger/tvm_backend.hpp
+++ b/core/core/sim/debugger/tvm_backend.hpp
@@ -75,10 +75,10 @@ public:
   virtual void on_dpincr(MachineState &state, const tvm::DecodedOp::DPIncr &op);
 
   // Ops that involve the target under test.
-  virtual void on_setmem(MachineState &state, const tvm::DecodedOp::SetMem &op) = 0;
+  virtual void on_deltamem(MachineState &state, const tvm::DecodedOp::DeltaMem &op) = 0;
   virtual void on_cmpmem(MachineState &state, const tvm::DecodedOp::CmpMem &op) = 0;
   virtual void on_clrmem(MachineState &state, const tvm::DecodedOp::ClrMem &op) = 0;
-  virtual void on_setreg(MachineState &state, const tvm::DecodedOp::SetReg &op) = 0;
+  virtual void on_deltareg(MachineState &state, const tvm::DecodedOp::DeltaReg &op) = 0;
   virtual void on_cmpreg(MachineState &state, const tvm::DecodedOp::CmpReg &op) = 0;
   virtual void on_clrreg(MachineState &state, const tvm::DecodedOp::ClrReg &op) = 0;
   virtual void on_traddr(MachineState &state, const tvm::DecodedOp::TRADDR &op) = 0;
@@ -89,6 +89,14 @@ protected:
     if (_access_mode == AccessMode::AsTraced) return recorded;
     return Operation(Operation::Type::BufferInternal, recorded.kind, recorded.initiator);
   }
+
+  // A Delta::Add payload is a signed little-endian integer, the same convention ISYN's delta uses. Fewer than 8 bytes
+  // still means the whole number, so it is sign-extended rather than zero-padded. Bytes beyond 8 are ignored.
+  static i64 signed_le(bits::span<const u8> bytes);
+  // That delta as the current replay direction should apply it. Addition is not its own inverse the way Delta::Xor
+  // is, so undoing a step means subtracting it. Negating through u64 because the most negative delta has no positive
+  // counterpart to negate to.
+  u64 directed_delta(i64 delta) const { return is_forward() ? (u64)delta : (u64)0 - (u64)delta; }
 
   tvm::TraceBuffer *_tb = nullptr;
   AccessMode _access_mode = AccessMode::AsTraced;

--- a/core/core/sim/debugger/tvm_backend.hpp
+++ b/core/core/sim/debugger/tvm_backend.hpp
@@ -53,7 +53,10 @@ public:
   Direction direction() const { return _floor < 0 ? Direction::Backward : Direction::Forward; }
 
   // Allow replacing the recorded access type with BufferInternal, which allows the trace VM to avoid creating
-  // additional traces when "undo"ing
+  // additional traces when "undo"ing.
+  //
+  // Applies to the ops that reach a Target directly. Register ops go through RegisterScan, which picks the access
+  // from the privilege level it is handed and is always internal there, so this does not reach them.
   void set_access_mode(AccessMode m) { _access_mode = m; }
   AccessMode access_mode() const { return _access_mode; }
 

--- a/core/core/sim/debugger/tvm_decoder.cpp
+++ b/core/core/sim/debugger/tvm_decoder.cpp
@@ -51,10 +51,12 @@ void Decoder::decode() {
   case Opcode::SETMEM: [[fallthrough]]; // Difference between SETMEM/X is in execution, not decoding
   case Opcode::SETMEMX: _decoded = decode_setmem(ibp, iop); break;
   case Opcode::SETMEMDX: _decoded = decode_setmemdx(ibp, iop); break;
+  case Opcode::STEPMEM: _decoded = decode_stepmem(ibp, iop); break;
   case Opcode::CMPMEM: _decoded = decode_cmpmem(ibp, iop); break;
   case Opcode::CLRMEM: _decoded = decode_clrmem(ibp, iop); break;
-  case Opcode::SETREG: [[fallthrough]]; // Difference between SETREG/X is in execution, not decoding
-  case Opcode::SETREGX: _decoded = decode_setreg(ibp, iop); break;
+  case Opcode::SETREG: [[fallthrough]]; // All three register ops share a packet layout; only the Delta differs.
+  case Opcode::SETREGX: [[fallthrough]];
+  case Opcode::STEPREG: _decoded = decode_deltareg(ibp, iop); break;
   case Opcode::CMPREG: _decoded = decode_cmpreg(ibp, iop); break;
   case Opcode::CLRREG: _decoded = decode_clrreg(ibp, iop); break;
   case Opcode::TRADDR: _decoded = decode_traddr(ibp, iop); break;
@@ -222,10 +224,10 @@ tvm::DecodedOp::BR Decoder::decode_br(pepp::bts::Buffer::ID ibp, u16 iop) {
   return ret;
 }
 
-tvm::DecodedOp::SetMem Decoder::decode_setmem(pepp::bts::Buffer::ID ibp, u16 iop) {
-  tvm::DecodedOp::SetMem ret;
+tvm::DecodedOp::DeltaMem Decoder::decode_setmem(pepp::bts::Buffer::ID ibp, u16 iop) {
+  tvm::DecodedOp::DeltaMem ret;
   auto &regs = _state.regs;
-  ret.xor_encoded = (regs.IS.ocpode == (u8)tvm::Opcode::SETMEMX);
+  ret.kind = (regs.IS.ocpode == (u8)tvm::Opcode::SETMEMX) ? tvm::Delta::Xor : tvm::Delta::Assign;
   _state.csrs.TR = 0; // Enter target mode.
   // Unless (5) is provided, data is DP relative rather than immediate
   ret.data = regs.DP;
@@ -255,11 +257,11 @@ tvm::DecodedOp::SetMem Decoder::decode_setmem(pepp::bts::Buffer::ID ibp, u16 iop
   return ret;
 }
 
-tvm::DecodedOp::SetMem Decoder::decode_setmemdx(pepp::bts::Buffer::ID ibp, u16 iop) {
-  tvm::DecodedOp::SetMem ret;
+tvm::DecodedOp::DeltaMem Decoder::decode_setmemdx(pepp::bts::Buffer::ID ibp, u16 iop) {
+  tvm::DecodedOp::DeltaMem ret;
   auto &regs = _state.regs;
   // No non-XOR form of this opcode exists; see Opcode::SETMEMDX.
-  ret.xor_encoded = true;
+  ret.kind = tvm::Delta::Xor;
   _state.csrs.TR = 0; // Enter target mode.
   ret.size = regs.DS;
 
@@ -285,6 +287,46 @@ tvm::DecodedOp::SetMem Decoder::decode_setmemdx(pepp::bts::Buffer::ID ibp, u16 i
   ret.access = Operation(regs.ACCESS);
   ret.target = (Device::ID)regs.ID.lo;
   ret.offset = regs.OFF.as_u32();
+
+  return ret;
+}
+
+tvm::DecodedOp::DeltaMem Decoder::decode_stepmem(pepp::bts::Buffer::ID ibp, u16 iop) {
+  tvm::DecodedOp::DeltaMem ret;
+  auto &regs = _state.regs;
+  ret.kind = tvm::Delta::Add;
+  _state.csrs.TR = 0; // Enter target mode.
+  // Unless (6) is provided, the delta is DP relative rather than immediate.
+  ret.data = regs.DP;
+  ret.size = regs.DS;
+  ret.order = bits::Order::LittleEndian;
+
+  switch (regs.IS.word_len) {
+  default: [[fallthrough]];
+  case 6:
+    // If MOD1/MOD2 are set, then read from them rather than the data registers.
+    // This allows "immediate" versions to avoid clobbering DP regs.
+    regs.MOD1.lo = read(ibp, iop + 10);
+    regs.MOD2.hi = regs.IP.hi;
+    regs.MOD2.lo = iop + 12;
+    _state.csrs.M2 = 1;
+    ret.data = regs.MOD2;
+    ret.size = regs.MOD1.lo;
+    [[fallthrough]];
+  case 5:
+    regs.MOD1.hi = read(ibp, iop + 8), _state.csrs.M1 = 1;
+    ret.order = regs.MOD1.hi ? bits::Order::BigEndian : bits::Order::LittleEndian;
+    [[fallthrough]];
+  case 4: regs.OFF.lo = read(ibp, iop + 6); [[fallthrough]];
+  case 3: regs.OFF.hi = read(ibp, iop + 4); [[fallthrough]];
+  case 2: regs.ID.lo = read(ibp, iop + 2); [[fallthrough]];
+  case 1: regs.ACCESS = read(ibp, iop + 0); [[fallthrough]];
+  case 0: break;
+  }
+  ret.access = Operation(regs.ACCESS);
+  ret.target = (Device::ID)regs.ID.lo;
+  ret.offset = regs.OFF.as_u32();
+
   return ret;
 }
 
@@ -334,10 +376,14 @@ tvm::DecodedOp::ClrMem Decoder::decode_clrmem(pepp::bts::Buffer::ID ibp, u16 iop
   return ret;
 }
 
-tvm::DecodedOp::SetReg Decoder::decode_setreg(pepp::bts::Buffer::ID ibp, u16 iop) {
-  tvm::DecodedOp::SetReg ret;
+tvm::DecodedOp::DeltaReg Decoder::decode_deltareg(pepp::bts::Buffer::ID ibp, u16 iop) {
+  tvm::DecodedOp::DeltaReg ret;
   auto &regs = _state.regs;
-  ret.xor_encoded = (regs.IS.ocpode == (u8)tvm::Opcode::SETREGX);
+  switch ((tvm::Opcode)regs.IS.ocpode) {
+  case tvm::Opcode::SETREGX: ret.kind = tvm::Delta::Xor; break;
+  case tvm::Opcode::STEPREG: ret.kind = tvm::Delta::Add; break;
+  default: ret.kind = tvm::Delta::Assign; break;
+  }
   _state.csrs.TR = 1; // Enter register mode.
   // Unless (4) is provided, data is DP relative rather than immediate
   ret.data = regs.DP;
@@ -361,8 +407,8 @@ tvm::DecodedOp::SetReg Decoder::decode_setreg(pepp::bts::Buffer::ID ibp, u16 iop
   case 0: break;
   }
   ret.access = Operation(regs.ACCESS);
-  ret.reg = RegisterScan::RegisterRef{RegisterScan::Register::ID{regs.ID.hi},
-                                      RegisterScan::Register::Field::ID{regs.ID.lo}};
+  ret.reg =
+      RegisterScan::RegisterRef{RegisterScan::Register::ID{regs.ID.hi}, RegisterScan::Register::Field::ID{regs.ID.lo}};
   return ret;
 }
 
@@ -390,8 +436,8 @@ tvm::DecodedOp::CmpReg Decoder::decode_cmpreg(pepp::bts::Buffer::ID ibp, u16 iop
   case 1: regs.ID.hi = read(ibp, iop + 0); [[fallthrough]];
   case 0: break;
   }
-  ret.reg = RegisterScan::RegisterRef{RegisterScan::Register::ID{regs.ID.hi},
-                                      RegisterScan::Register::Field::ID{regs.ID.lo}};
+  ret.reg =
+      RegisterScan::RegisterRef{RegisterScan::Register::ID{regs.ID.hi}, RegisterScan::Register::Field::ID{regs.ID.lo}};
   return ret;
 }
 
@@ -405,8 +451,8 @@ tvm::DecodedOp::ClrReg Decoder::decode_clrreg(pepp::bts::Buffer::ID ibp, u16 iop
   case 1: regs.ID.hi = read(ibp, iop + 0); [[fallthrough]];
   case 0: break;
   }
-  ret.reg = RegisterScan::RegisterRef{RegisterScan::Register::ID{regs.ID.hi},
-                                      RegisterScan::Register::Field::ID{regs.ID.lo}};
+  ret.reg =
+      RegisterScan::RegisterRef{RegisterScan::Register::ID{regs.ID.hi}, RegisterScan::Register::Field::ID{regs.ID.lo}};
   return ret;
 }
 

--- a/core/core/sim/debugger/tvm_decoder.cpp
+++ b/core/core/sim/debugger/tvm_decoder.cpp
@@ -405,7 +405,8 @@ tvm::DecodedOp::DeltaReg Decoder::decode_deltareg(pepp::bts::Buffer::ID ibp, u16
   case 1: regs.ACCESS = read(ibp, iop + 0); [[fallthrough]];
   case 0: break;
   }
-  ret.access = Operation(regs.ACCESS);
+  // regs.ACCESS is still programmed above for whatever later instruction retains it; it just has no bearing on a
+  // register op, which reaches its device through RegisterScan rather than through a Target of its own.
   ret.reg =
       RegisterScan::RegisterRef{RegisterScan::Register::ID{regs.ID.hi}, RegisterScan::Register::Field::ID{regs.ID.lo}};
   return ret;

--- a/core/core/sim/debugger/tvm_decoder.cpp
+++ b/core/core/sim/debugger/tvm_decoder.cpp
@@ -299,13 +299,12 @@ tvm::DecodedOp::DeltaMem Decoder::decode_stepmem(pepp::bts::Buffer::ID ibp, u16 
   // Unless (6) is provided, the delta is DP relative rather than immediate.
   ret.data = regs.DP;
   ret.size = regs.DS;
-  ret.order = bits::Order::LittleEndian;
+  // If MOD1 is not set, then choose LE by default.
+  ret.order = (_state.csrs.M1 && regs.MOD1.hi) ? bits::Order::BigEndian : bits::Order::LittleEndian;
 
   switch (regs.IS.word_len) {
   default: [[fallthrough]];
   case 6:
-    // If MOD1/MOD2 are set, then read from them rather than the data registers.
-    // This allows "immediate" versions to avoid clobbering DP regs.
     regs.MOD1.lo = read(ibp, iop + 10);
     regs.MOD2.hi = regs.IP.hi;
     regs.MOD2.lo = iop + 12;

--- a/core/core/sim/debugger/tvm_decoder.hpp
+++ b/core/core/sim/debugger/tvm_decoder.hpp
@@ -48,14 +48,18 @@ private:
   // This is because the shift/extract logic is somewhat complex -- and really belongs in the execute stage.
   tvm::DecodedOp::LMR decode_lmr(pepp::bts::Buffer::ID ibp, u16 iop);
   tvm::DecodedOp::BR decode_br(pepp::bts::Buffer::ID ibp, u16 iop);
-  tvm::DecodedOp::SetMem decode_setmem(pepp::bts::Buffer::ID ibp, u16 iop);
-  // Resolves to the same DecodedOp::SetMem as decode_setmem -- the only difference is where the offset came from, and
-  // by the time a backend sees it that distinction has already been resolved away. That is why there is no matching
-  // on_setmemdx handler and no new variant alternative.
-  tvm::DecodedOp::SetMem decode_setmemdx(pepp::bts::Buffer::ID ibp, u16 iop);
+  // SETMEM and SETMEMX, which differ only in the Delta they resolve to.
+  tvm::DecodedOp::DeltaMem decode_setmem(pepp::bts::Buffer::ID ibp, u16 iop);
+  // Resolves to the same DecodedOp::DeltaMem as decode_setmem. The only difference is where the offset came from,
+  // and by the time a backend sees it that distinction has already been resolved away.
+  tvm::DecodedOp::DeltaMem decode_setmemdx(pepp::bts::Buffer::ID ibp, u16 iop);
+  // STEPMEM has to carry a endianness bit.
+  tvm::DecodedOp::DeltaMem decode_stepmem(pepp::bts::Buffer::ID ibp, u16 iop);
   tvm::DecodedOp::CmpMem decode_cmpmem(pepp::bts::Buffer::ID ibp, u16 iop);
   tvm::DecodedOp::ClrMem decode_clrmem(pepp::bts::Buffer::ID ibp, u16 iop);
-  tvm::DecodedOp::SetReg decode_setreg(pepp::bts::Buffer::ID ibp, u16 iop);
+  // SETREG, SETREGX and STEPREG all at once: unlike their memory counterparts the three share a packet layout
+  // exactly.
+  tvm::DecodedOp::DeltaReg decode_deltareg(pepp::bts::Buffer::ID ibp, u16 iop);
   tvm::DecodedOp::CmpReg decode_cmpreg(pepp::bts::Buffer::ID ibp, u16 iop);
   tvm::DecodedOp::ClrReg decode_clrreg(pepp::bts::Buffer::ID ibp, u16 iop);
   tvm::DecodedOp::TRADDR decode_traddr(pepp::bts::Buffer::ID ibp, u16 iop);

--- a/core/core/sim/debugger/tvm_encoding.hpp
+++ b/core/core/sim/debugger/tvm_encoding.hpp
@@ -285,6 +285,63 @@ template <bool X> struct SetReg<X, 4> : ImmediateEncoder<SetRegOp<X>, SetReg<X, 
   template <typename F> constexpr auto apply_prefix(F &&f) const { return f(access, reg, field); }
 };
 
+template <std::size_t> struct StepMem;
+template <> struct StepMem<1> {
+  u16 access;
+  constexpr auto encode() const { return encode_op<Opcode::STEPMEM, true>(access); }
+};
+template <> struct StepMem<2> {
+  u16 access, dev;
+  constexpr auto encode() const { return encode_op<Opcode::STEPMEM, true>(access, dev); }
+};
+template <> struct StepMem<3> {
+  u16 access, dev, off_hi;
+  constexpr auto encode() const { return encode_op<Opcode::STEPMEM, true>(access, dev, off_hi); }
+};
+template <> struct StepMem<4> {
+  u16 access, dev;
+  SegmentPair off;
+  constexpr auto encode() const { return encode_op<Opcode::STEPMEM, true>(access, dev, off.hi, off.lo); }
+};
+template <> struct StepMem<5> {
+  u16 access, dev;
+  SegmentPair off;
+  u16 order;
+  constexpr auto encode() const { return encode_op<Opcode::STEPMEM, true>(access, dev, off.hi, off.lo, order); }
+};
+
+// Deriving from ImmediateEncoder prevents designated initializers, so it spells out a constructor like CmpReg<3>
+// The size word is not a member: ImmediateEncoder emits it from the payload it is handed.
+template <> struct StepMem<6> : ImmediateEncoder<Opcode::STEPMEM, StepMem<6>> {
+  constexpr StepMem<6>(u16 access, u16 dev, SegmentPair off, u16 order)
+      : access(access), dev(dev), off(off), order(order) {}
+  u16 access, dev;
+  SegmentPair off;
+  u16 order;
+  template <typename F> constexpr auto apply_prefix(F &&f) const { return f(access, dev, off.hi, off.lo, order); }
+};
+
+// Same packet as SetReg, minus the X variant: a register reports its own width and byte order, so there is nothing
+// for the instruction to say about the destination.
+template <std::size_t> struct StepReg;
+template <> struct StepReg<1> {
+  u16 access;
+  constexpr auto encode() const { return encode_op<Opcode::STEPREG, true>(access); }
+};
+template <> struct StepReg<2> {
+  u16 access, reg;
+  constexpr auto encode() const { return encode_op<Opcode::STEPREG, true>(access, reg); }
+};
+template <> struct StepReg<3> {
+  u16 access, reg, field;
+  constexpr auto encode() const { return encode_op<Opcode::STEPREG, true>(access, reg, field); }
+};
+template <> struct StepReg<4> : ImmediateEncoder<Opcode::STEPREG, StepReg<4>> {
+  constexpr StepReg<4>(u16 access, u16 reg, u16 field) : access(access), reg(reg), field(field) {}
+  u16 access, reg, field;
+  template <typename F> constexpr auto apply_prefix(F &&f) const { return f(access, reg, field); }
+};
+
 // SETMEMX with the offset carried in the payload rather than the packet, so a body that stores to a different
 // address every time still encodes identically. See Opcode::SETMEMDX for the data layout.
 template <std::size_t> struct SetMemDX;
@@ -417,11 +474,24 @@ struct BR {
   tvm::ConditionCode condition = (tvm::ConditionCode)0;
   SegmentPair displacement{};
 };
-struct SetMem {
-  bool xor_encoded = false;
+// A shared decoding strucutre between all operations which modify memory (SETMEM, SETMEMX, SETMEMDX, STEPMEM). e the
+// things that Their only difference is in how data is combined with the destination.
+struct DeltaMem {
+  tvm::Delta kind = tvm::Delta::Assign;
   Operation access{};
   Device::ID target{};
   u32 offset = 0;
+  // Where the payload lives and how many bytes of it there are. For Add this is a signed little-endian integer which
+  // is usually narrower than `width`; for the other kinds it is the destination's bytes verbatim.
+  SegmentPair data{};
+  u16 size = 0;
+  bits::Order order = bits::Order::LittleEndian;
+};
+
+struct DeltaReg {
+  tvm::Delta kind = tvm::Delta::Assign;
+  Operation access{};
+  RegisterScan::RegisterRef reg{};
   SegmentPair data{};
   u16 size = 0;
 };
@@ -434,13 +504,6 @@ struct CmpMem {
 struct ClrMem {
   Device::ID target{};
   u8 data = 0;
-};
-struct SetReg {
-  bool xor_encoded = false;
-  Operation access{};
-  RegisterScan::RegisterRef reg{};
-  SegmentPair data{};
-  u16 size = 0;
 };
 struct CmpReg {
   RegisterScan::RegisterRef reg{};
@@ -472,7 +535,7 @@ struct MMIO {
   u32 offset = 0;
 };
 
-using OpChoice = std::variant<Halt, Ret, Call, InvCall, InvRet, ASyn, ISyn, LMR, BR, SetMem, CmpMem, ClrMem, SetReg,
+using OpChoice = std::variant<Halt, Ret, Call, InvCall, InvRet, ASyn, ISyn, LMR, BR, DeltaMem, CmpMem, ClrMem, DeltaReg,
                               CmpReg, ClrReg, TRADDR, LDP, DPIncr, MMIO>;
 } // namespace DecodedOp
 } // namespace tvm

--- a/core/core/sim/debugger/tvm_encoding.hpp
+++ b/core/core/sim/debugger/tvm_encoding.hpp
@@ -489,9 +489,9 @@ struct DeltaMem {
   bits::Order order = bits::Order::LittleEndian;
 };
 
+// Same for register ops. Drops both access and order, which are managed through the RegisterScan.
 struct DeltaReg {
   tvm::Delta kind = tvm::Delta::Assign;
-  Operation access{};
   RegisterScan::RegisterRef reg{};
   SegmentPair data{};
   u16 size = 0;

--- a/core/core/sim/debugger/tvm_encoding.hpp
+++ b/core/core/sim/debugger/tvm_encoding.hpp
@@ -474,17 +474,18 @@ struct BR {
   tvm::ConditionCode condition = (tvm::ConditionCode)0;
   SegmentPair displacement{};
 };
-// A shared decoding strucutre between all operations which modify memory (SETMEM, SETMEMX, SETMEMDX, STEPMEM). e the
-// things that Their only difference is in how data is combined with the destination.
+// A shared decoding structure for every operation which modifies memory (SETMEM, SETMEMX, SETMEMDX, STEPMEM). Their
+// only difference is how the payload is combined with the destination, described by `kind`
 struct DeltaMem {
   tvm::Delta kind = tvm::Delta::Assign;
   Operation access{};
   Device::ID target{};
   u32 offset = 0;
-  // Where the payload lives and how many bytes of it there are. For Add this is a signed little-endian integer which
-  // is usually narrower than `width`; for the other kinds it is the destination's bytes verbatim.
+  // Where the payload lives.
   SegmentPair data{};
+  // Size is the number of bytes of data at the data pointer as well as the size of the destination.
   u16 size = 0;
+  // For non-bitwise operations, how to interpret the contents at the destination.
   bits::Order order = bits::Order::LittleEndian;
 };
 

--- a/core/core/sim/debugger/tvm_opcodes.hpp
+++ b/core/core/sim/debugger/tvm_opcodes.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "core/integers.h"
+#include "core/math/bitmanip/order.hpp"
 
 // The system class from core/sim/system.hpp
 class System;
@@ -19,6 +20,9 @@ enum class StopCause {
   RegisterInvalid,
   RegisterSizeMismatch,
   RegisterWidthIllegal,
+  // Step* operations perform arithmetic as an i64. If the target is wider than 8 bytes, we don't know which bytes to
+  // touch.
+  StepWidthIllegal,
   TargetInvalid,
   TargetNotMemory,
   // Can't apply MMIO opcode to a non-FIFO target.
@@ -29,6 +33,17 @@ enum class StopCause {
   // A legal opcode this backend does not implement. Distinct from IllegalOpcode, which means the decoder did not
   // recognise the encoding at all: this one says the program is well-formed but aimed at the wrong backend.
   Unimplemented,
+};
+
+// How a payload of a SET* operation combines with what is already at the destination.
+enum class Delta : u8 {
+  // Overwrite the destination with the payload. See: SETMEM, SETREG.
+  Assign,
+  // Read-xor-write, which has the benefit of being its own inverse. See: SETMEMX, SETREGX.
+  Xor,
+  // Read-add-write, with the payload to the destination as a signed integer, subtracting instead on a backward replay.
+  // STEP*.
+  Add,
 };
 
 // Must fit into 6 bits because of the OpWord struct.
@@ -202,8 +217,18 @@ enum class Opcode : u8 {
   // Data pointer contains: (4)OFFSET, (1)DATA.
   // Packet registers: ACCESS, ID.lo, MOD1.lo = rd^wr
   MMIO = 0b01'1111,
+  // STEP* are similar to SET*X in that they perform a read-modify-write of a memory location. The difference is that
+  // the modification operation is signed addition rather than XOR. This is useful for (program) counters.
+  // It share the same immediate semantics with SETMEM.
+  // If MOD1.hi is 0, then the target location should be interpreted as a LE number; if 1, BE.
+  // read-modify-written. Packet registers should remain LE.
+  //
+  // Packet registers: ACCESS, ID.lo, OFF.hi, OFF.lo, MOD1.hi, MOD1.lo
+  STEPMEM = 0b10'0000,
+  // Packet registers: ACCESS, ID.hi, ID.lo, MOD1.lo
+  STEPREG = 0b10'0010,
   // Must always be 1 greater than the last opcode. Used to size the decoder table at compile-time.
-  MAX = ((u8)MMIO) + 1,
+  MAX = ((u8)STEPREG) + 1,
 };
 
 // (4) OFFSET

--- a/core/core/sim/memory/ram/dense.cpp
+++ b/core/core/sim/memory/ram/dense.cpp
@@ -103,6 +103,19 @@ Target::Result Dense::write(Address address, bits::span<const u8> src, Operation
   return {};
 }
 
+Target::Result Dense::write_increment(Address address, bits::span<const u8> src, Operation op) {
+  using E = Error;
+  auto span = _config.span;
+  // Length is 1-indexed, address are 0, so must offset by -1.
+  const auto max_addr = (address + std::max<Address>(0, src.size() - 1));
+  if (address < span.lower() || max_addr > span.upper()) throw E(E::Type::OOBAccess, address);
+  const auto offset = address - span.lower();
+  auto dest = bits::span<u8>{_data.data(), std::size_t(_data.size())}.subspan(offset);
+  _trace.emit_write_increment(op, address, dest.first(src.size()), src);
+  bits::memcpy(dest, src);
+  return {};
+}
+
 void Dense::clear(u8 fill) {
   // TODO: emit a "clear" trace to TB.
   _config.fill = fill;

--- a/core/core/sim/memory/ram/dense.hpp
+++ b/core/core/sim/memory/ram/dense.hpp
@@ -57,6 +57,11 @@ public:
   AddressSpan span() const override;
   Result read(Address address, bits::span<u8> dest, Operation op) const override;
   Result write(Address address, bits::span<const u8> src, Operation op) override;
+  // Overloads which emit traces using an increment/offset encoding.
+  // When Dense is used to hold registers, this can be a more efficient encoding than a full write.
+  Result write_increment(Address address, bits::span<const u8> src, Operation op);
+  template <std::integral I, bool byteswap> Result write_increment(Address address, I src, Operation op);
+
   void clear(u8 fill) override;
   void dump(bits::span<u8> dest) const override;
 
@@ -65,3 +70,9 @@ private:
   std::vector<u8> _data;
   trace::Recorder _trace;
 };
+
+template <std::integral I, bool byteswap>
+inline Target::Result Dense::write_increment(Address address, I src, Operation op) {
+  if constexpr (byteswap) src = bits::byteswap(src);
+  return write_increment(address, bits::span<const u8>(reinterpret_cast<const u8 *>(&src), sizeof(I)), op);
+}

--- a/docs/research/trace_footprint.md
+++ b/docs/research/trace_footprint.md
@@ -43,17 +43,23 @@ fixed-address store  : 26.1 B/instr over 3000 (inlined: 83.3) | ratio 3.190
                        code 24172  templates 196  data 30006  locations 24000 | 3 templates, 0 pending
 walking-address store: 26.7 B/instr over 3000 (inlined: 87.5) | ratio 3.281
                        code 24244  templates 276  data 31506  locations 24000 | 4 templates, 0 pending
+STEPMEM-for-PC
+fixed-address store :  24.8 B/instr over 3000 instrs (inlined: 82.7) | ratio 3.335 
+                       code 24174 stencils 198 data 26004 locations 24000 | 3 stencils promoted, 0 hashes pending | 256 KiB reserved
+walking-address store: 25.2 B/instr over 3000 instrs (inlined: 87.0) | ratio 3.456 
+                       code 24248 stencils 280 data 27004 locations 24000 | 4 stencils promoted, 0 hashes pending | 256 KiB reserved
+PACK-NZVC               
+fixed-address store :  23.8 B/instr over 3000 instrs (inlined: 81.7) | ratio 3.433 
+                       code 24174 stencils 198 data 23001 locations 24000 | 3 stencils promoted, 0 hashes pending | 256 KiB reserved
+walking-address store: 23.7 B/instr over 3000 instrs (inlined: 85.5) | ratio 3.612 
+                       code 24248 stencils 280 data 22501 locations 24000 | 4 stencils promoted, 0 hashes pending | 256 KiB reserved
 ```
 
-Progress on the fixed loop. Note the middle column: `locations` was a real per-instruction cost from the beginning
-and simply was not being counted, so the early "reported" figures understated the truth by 4 B/instr.
+Progress on the fixed loop.
+Note the `locations` is a per-instruction cost from the beginning that was incorrectly counted on the first two rows.
+STEPMEM-for-PC uses a more efficient encoding for non-branch PC updates.
+PACK-NZVC adjusts the layout of the CSRs in host memory to fit in 1 byte rather than 4.
 
-| stage | reported | true |
-|---|---:|---:|
-| baseline | 33.5 | **37.5** |
-| after ISYN-to-body, lazy location buffers, CSR coalescing, `SETMEMDX` | 28.8 | **32.8** |
-| after moving the data pointer into the location buffer | — | **28.8** |
-| after PC coalescing | 26.1 | **26.1** |
 
 ### Allocation breakdown
 

--- a/test/core/sim/core/pep/instr/monadic_shifts.cpp
+++ b/test/core/sim/core/pep/instr/monadic_shifts.cpp
@@ -114,7 +114,7 @@ void inner_rol(PepISA3CPU::ISA isa, Register target_reg, Register other_reg, Mne
     cpu->registers()->clear(0);
     cpu->csrs()->clear(0);
     cpu->write_register(target_reg, init_reg);
-    ((Target *)cpu->csrs())->write<u8>(static_cast<u8>(CSR::C), carry, rw);
+    cpu->write_csr(CSR::C, carry != 0);
 
     REQUIRE_NOTHROW(mem->write(0, {program.data(), program.size()}, rw));
     REQUIRE_NOTHROW(cpu->clock_tick(PulseSchedule::PulseIndex{0}, 0));
@@ -154,7 +154,7 @@ void inner_ror(PepISA3CPU::ISA isa, Register target_reg, Register other_reg, Mne
     cpu->registers()->clear(0);
     cpu->csrs()->clear(0);
     cpu->write_register(target_reg, init_reg);
-    ((Target *)cpu->csrs())->write<u8>(static_cast<u8>(CSR::C), carry, rw);
+    cpu->write_csr(CSR::C, carry != 0);
 
     REQUIRE_NOTHROW(mem->write(0, {program.data(), program.size()}, rw));
     REQUIRE_NOTHROW(cpu->clock_tick(PulseSchedule::PulseIndex{0}, 0));

--- a/test/core/sim/core/pep/pep_register_blast.cpp
+++ b/test/core/sim/core/pep/pep_register_blast.cpp
@@ -34,7 +34,6 @@ TEST_CASE("Access registers from tvm::Interpreter", "[scope:core][scope:core.dbg
 
   SECTION("Validate that a system-created tvm::Interpreter works") {
     auto blaster = sys->make_trace_interpreter();
-    auto before = tb.cursor();
 
     tb.begin(S);
     body(LDMOD1Lo{0x1234}.encode());
@@ -56,7 +55,6 @@ TEST_CASE("Access registers from tvm::Interpreter", "[scope:core][scope:core.dbg
     cpu->write_register(isa::Pep10::Register::A, 0xFEED);
     auto ref = *scan->find("A");
 
-    auto before = tb.cursor();
     tb.begin(S);
     body(CmpReg<3>(ref.reg.value, ref.field.value).encode(0xFEED));
     auto loc = tb.commit(S);
@@ -175,7 +173,7 @@ RegisterScan::RegisterRef expose_wide(System &sys, Dense &mem) {
   wide.byte_width = 4;
   wide.access = RegisterScan::Register::ReadWrite;
   wide.target = mem.id();
-  wide.offset = WIDE_OFFSET;
+  wide.loc = WIDE_OFFSET;
   wide.name = "WIDE";
   sys.register_scan()->expose(wide);
   mem.write(WIDE_OFFSET, {WIDE_BE.data(), WIDE_BE.size()}, rw);
@@ -204,7 +202,7 @@ void expose_synthetics(System &sys, Dense &mem) {
     r.byte_width = s.byte_width;
     r.access = RegisterScan::Register::ReadWrite;
     r.target = mem.id();
-    r.offset = s.offset;
+    r.loc = s.offset;
     r.name = s.name;
     sys.register_scan()->expose(r);
   }
@@ -248,7 +246,7 @@ RegisterScan::RegisterRef expose_readonly(System &sys, Dense &mem) {
   r.byte_width = 4;
   r.access = RegisterScan::Register::Access::Read;
   r.target = mem.id();
-  r.offset = READONLY_OFFSET;
+  r.loc = READONLY_OFFSET;
   r.name = "ro4";
   sys.register_scan()->expose(r);
   return *sys.register_scan()->find("ro4");
@@ -516,6 +514,10 @@ TEST_CASE("Clearing registers", "[scope:core][scope:core.dbg][kind:unit][arch:pe
     CHECK(scan->read<u8>(*scan->find("Z")) == 1);
     CHECK(scan->read<u8>(*scan->find("C")) == 1);
     CHECK(scan->read<u32>(whole) == 0x0101'0001);
+  }
+  SECTION("Can inspect call_depth") {
+    auto depth = *scan->find("call_depth");
+    CHECK(scan->read<u16>(depth) == 0);
   }
 
   SECTION("CLRREG zeroes a whole register") {

--- a/test/core/sim/core/pep/pep_register_blast.cpp
+++ b/test/core/sim/core/pep/pep_register_blast.cpp
@@ -171,7 +171,7 @@ RegisterScan::RegisterRef expose_wide(System &sys, Dense &mem) {
   RegisterScan::Register wide{};
   wide.order = bits::Order::BigEndian;
   wide.byte_width = 4;
-  wide.access = RegisterScan::Register::ReadWrite;
+  wide.guest_access = RegisterScan::Register::ReadWrite;
   wide.target = mem.id();
   wide.loc = WIDE_OFFSET;
   wide.name = "WIDE";
@@ -200,7 +200,7 @@ void expose_synthetics(System &sys, Dense &mem) {
     RegisterScan::Register r{};
     r.order = s.order;
     r.byte_width = s.byte_width;
-    r.access = RegisterScan::Register::ReadWrite;
+    r.guest_access = RegisterScan::Register::ReadWrite;
     r.target = mem.id();
     r.loc = s.offset;
     r.name = s.name;
@@ -244,7 +244,7 @@ RegisterScan::RegisterRef expose_readonly(System &sys, Dense &mem) {
   RegisterScan::Register r{};
   r.order = bits::Order::BigEndian;
   r.byte_width = 4;
-  r.access = RegisterScan::Register::Access::Read;
+  r.guest_access = RegisterScan::Register::Access::Read;
   r.target = mem.id();
   r.loc = READONLY_OFFSET;
   r.name = "ro4";
@@ -272,8 +272,7 @@ TEST_CASE("Expose a 4-byte register", "[scope:core][scope:core.dbg][kind:unit][a
 
 // The 4-byte case has to assemble its two halves little-endian, matching its own 1- and 2-byte cases (see the LE data
 // in "Compare accumulator / X (DP)" above) and every other immediate in the ISA.
-TEST_CASE("CMPREG compares a 4-byte register little-endian",
-          "[scope:core][scope:core.dbg][kind:unit][arch:pep10]") {
+TEST_CASE("CMPREG compares a 4-byte register little-endian", "[scope:core][scope:core.dbg][kind:unit][arch:pep10]") {
   using namespace tvm::EncodedOp;
   constexpr Device::ID S{1};
   auto [sys, mem, cpu] = make_cpu(PepISA3CPU::ISA::Pep10);
@@ -560,6 +559,49 @@ TEST_CASE("Clearing registers", "[scope:core][scope:core.dbg][kind:unit][arch:pe
     CHECK(scan->read<u32>(ro) == 0);
   }
 
+  SECTION("The two levels are permitted independently") {
+    // The shape a derived counter wants: nonsense for the guest to hand-edit, but the host has to be able to put it
+    // back on a step backwards.
+    RegisterScan::Register r{};
+    r.order = bits::Order::BigEndian;
+    r.byte_width = 2;
+    r.guest_access = RegisterScan::Register::Access::Read;
+    r.host_access = RegisterScan::Register::ReadWrite;
+    r.target = mem->id();
+    r.loc = Address{0x170};
+    r.name = "counter";
+    scan->expose(r);
+    auto ref = *scan->find("counter");
+
+    CHECK_THROWS(scan->write<u16>(ref, 0xBEEF));
+    CHECK(scan->read<u16>(ref) == 0);
+
+    CHECK_NOTHROW(scan->write<u16>(ref, 0xBEEF, RegisterScan::Level::Host));
+    CHECK(scan->read<u16>(ref) == 0xBEEF);
+
+    // A reset is a host write, so it goes through for the same reason.
+    CHECK_NOTHROW(scan->clear(ref));
+    CHECK(scan->read<u16>(ref) == 0);
+  }
+
+  SECTION("A register the host may not write refuses the host") {
+    // Level is a lookup, not a bypass: deny the host and even replay is refused.
+    RegisterScan::Register r{};
+    r.order = bits::Order::BigEndian;
+    r.byte_width = 2;
+    r.guest_access = RegisterScan::Register::Access::Read;
+    r.host_access = RegisterScan::Register::Access::Read;
+    r.target = mem->id();
+    r.loc = Address{0x180};
+    r.name = "frozen";
+    scan->expose(r);
+    auto ref = *scan->find("frozen");
+
+    CHECK_THROWS(scan->write<u16>(ref, 1, RegisterScan::Level::Host));
+    // And a reset cannot bypass it either, which is what Tracing::Monotonic would want.
+    CHECK_THROWS(scan->clear(ref));
+  }
+
   SECTION("CLRREG bypasses the read-only check") {
     auto ro = expose_readonly(*sys, *mem);
     constexpr std::array<u8, 4> seed{0x11, 0x22, 0x33, 0x44};
@@ -685,8 +727,8 @@ TEST_CASE("Setting registers", "[scope:core][scope:core.dbg][kind:unit][arch:pep
     scan->write<u32>(whole, 0x0000'0000);
 
     auto blaster = run([&](tvm::TraceBuffer &tb) {
-      auto enc = SetReg<false, 4>{.access = rw.as_u16(), .reg = v.reg.value, .field = v.field.value}
-                     .encode(std::array<u8, 4>{0x01, 0x00, 0x00, 0x00});
+      auto enc = SetReg<false, 4>{.access = rw.as_u16(), .reg = v.reg.value, .field = v.field.value}.encode(
+          std::array<u8, 4>{0x01, 0x00, 0x00, 0x00});
       tb.emit_body(S, {enc.data(), enc.size()});
     });
 
@@ -699,8 +741,8 @@ TEST_CASE("Setting registers", "[scope:core][scope:core.dbg][kind:unit][arch:pep
     auto ref = *scan->find("be4");
     auto blaster = run([&](tvm::TraceBuffer &tb) {
       // Two bytes of data for a four-byte register.
-      auto enc = SetReg<false, 4>{.access = rw.as_u16(), .reg = ref.reg.value, .field = 0}
-                     .encode(std::array<u8, 2>{0xAA, 0xBB});
+      auto enc = SetReg<false, 4>{.access = rw.as_u16(), .reg = ref.reg.value, .field = 0}.encode(
+          std::array<u8, 2>{0xAA, 0xBB});
       tb.emit_body(S, {enc.data(), enc.size()});
     });
 
@@ -711,8 +753,8 @@ TEST_CASE("Setting registers", "[scope:core][scope:core.dbg][kind:unit][arch:pep
 
   SECTION("An unknown register id hard stops") {
     auto blaster = run([&](tvm::TraceBuffer &tb) {
-      auto enc = SetReg<false, 4>{.access = rw.as_u16(), .reg = 0xBEEF, .field = 0}
-                     .encode(std::array<u8, 2>{0xAA, 0xBB});
+      auto enc =
+          SetReg<false, 4>{.access = rw.as_u16(), .reg = 0xBEEF, .field = 0}.encode(std::array<u8, 2>{0xAA, 0xBB});
       tb.emit_body(S, {enc.data(), enc.size()});
     });
 

--- a/test/core/sim/core/pep/pep_register_blast.cpp
+++ b/test/core/sim/core/pep/pep_register_blast.cpp
@@ -400,22 +400,22 @@ TEST_CASE("NZVC fields pack independently", "[scope:core][scope:core.dbg][kind:u
   auto [sys, mem, cpu] = make_cpu(PepISA3CPU::ISA::Pep10);
   auto *scan = sys->register_scan();
 
-  // The four flags are 1-bit fields of one 4-byte big-endian register, one flag per byte (bit offsets 24/16/8/0).
-  // Writing a field is a read-modify-write, so the interesting question is not whether the bit lands -- it is what
-  // happens to every bit the write does not address.
+  // The four flags are 1-bit fields of one byte, N at bit 3 down to C at bit 0. Writing a field is a read-modify-
+  // write, so the interesting question is not whether the bit lands -- it is what happens to every bit the write
+  // does not address, including the four spare bits of the high nibble.
   constexpr const char *FLAGS[] = {"N", "Z", "V", "C"};
-  constexpr u32 PACKED[] = {0x0100'0000, 0x0001'0000, 0x0000'0100, 0x0000'0001};
+  constexpr u8 PACKED[] = {0b1000, 0b0100, 0b0010, 0b0001};
 
   auto whole = *scan->find("NZVC");
   auto flag = [&](size_t i) { return *scan->find(FLAGS[i]); };
 
-  SECTION("A flag set in isolation packs into its own byte") {
+  SECTION("A flag set in isolation packs into its own bit") {
     for (size_t i = 0; i < 4; ++i) {
       INFO("setting " << FLAGS[i]);
-      scan->write<u32>(whole, 0);
+      scan->write<u8>(whole, 0);
       scan->write<u8>(flag(i), 1);
 
-      CHECK(scan->read<u32>(whole) == PACKED[i]);
+      CHECK(scan->read<u8>(whole) == PACKED[i]);
       for (size_t j = 0; j < 4; ++j) {
         INFO("  reading " << FLAGS[j]);
         CHECK(scan->read<u8>(flag(j)) == (i == j ? 1 : 0));
@@ -426,10 +426,10 @@ TEST_CASE("NZVC fields pack independently", "[scope:core][scope:core.dbg][kind:u
   SECTION("A flag cleared in isolation leaves its siblings set") {
     for (size_t i = 0; i < 4; ++i) {
       INFO("clearing " << FLAGS[i]);
-      scan->write<u32>(whole, 0x0101'0101);
+      scan->write<u8>(whole, 0b1111);
       scan->write<u8>(flag(i), 0);
 
-      CHECK(scan->read<u32>(whole) == (0x0101'0101u & ~PACKED[i]));
+      CHECK(scan->read<u8>(whole) == (0b1111u & ~PACKED[i]));
       for (size_t j = 0; j < 4; ++j) {
         INFO("  reading " << FLAGS[j]);
         CHECK(scan->read<u8>(flag(j)) == (i == j ? 0 : 1));
@@ -438,24 +438,24 @@ TEST_CASE("NZVC fields pack independently", "[scope:core][scope:core.dbg][kind:u
   }
 
   SECTION("A field write touches exactly one bit of the register") {
-    // Seed every bit, including the seven spare bits in each flag's byte that no field claims. A read-modify-write
+    // Seed every bit, including the four spare bits of the high nibble that no field claims. A read-modify-write
     // whose mask is too wide -- or that skips the read entirely -- knocks some of them down.
     for (size_t i = 0; i < 4; ++i) {
       INFO("clearing " << FLAGS[i] << " out of an all-ones register");
-      scan->write<u32>(whole, 0xFFFF'FFFF);
+      scan->write<u8>(whole, 0xFF);
       scan->write<u8>(flag(i), 0);
-      CHECK(scan->read<u32>(whole) == (0xFFFF'FFFFu & ~PACKED[i]));
+      CHECK(scan->read<u8>(whole) == (0xFFu & ~PACKED[i]));
     }
     for (size_t i = 0; i < 4; ++i) {
       INFO("setting " << FLAGS[i] << " out of an all-zeros register");
-      scan->write<u32>(whole, 0);
+      scan->write<u8>(whole, 0);
       scan->write<u8>(flag(i), 1);
-      CHECK(scan->read<u32>(whole) == PACKED[i]);
+      CHECK(scan->read<u8>(whole) == PACKED[i]);
     }
   }
 
   SECTION("A mixed pattern round-trips through the fields") {
-    scan->write<u32>(whole, 0);
+    scan->write<u8>(whole, 0);
     scan->write<u8>(flag(0), 1); // N
     scan->write<u8>(flag(1), 0); // Z
     scan->write<u8>(flag(2), 1); // V
@@ -465,7 +465,7 @@ TEST_CASE("NZVC fields pack independently", "[scope:core][scope:core.dbg][kind:u
     CHECK(scan->read<u8>(flag(1)) == 0);
     CHECK(scan->read<u8>(flag(2)) == 1);
     CHECK(scan->read<u8>(flag(3)) == 0);
-    CHECK(scan->read<u32>(whole) == 0x0100'0100);
+    CHECK(scan->read<u8>(whole) == 0b1010);
   }
 }
 
@@ -504,7 +504,7 @@ TEST_CASE("Clearing registers", "[scope:core][scope:core.dbg][kind:unit][arch:pe
 
   SECTION("clear() zeroes one field and leaves its siblings") {
     auto whole = *scan->find("NZVC");
-    scan->write<u32>(whole, 0x0101'0101);
+    scan->write<u8>(whole, 0b1111);
 
     scan->clear(*scan->find("V"));
 
@@ -512,7 +512,7 @@ TEST_CASE("Clearing registers", "[scope:core][scope:core.dbg][kind:unit][arch:pe
     CHECK(scan->read<u8>(*scan->find("N")) == 1);
     CHECK(scan->read<u8>(*scan->find("Z")) == 1);
     CHECK(scan->read<u8>(*scan->find("C")) == 1);
-    CHECK(scan->read<u32>(whole) == 0x0101'0001);
+    CHECK(scan->read<u8>(whole) == 0b1101);
   }
   SECTION("Can inspect call_depth") {
     auto depth = *scan->find("call_depth");
@@ -542,13 +542,13 @@ TEST_CASE("Clearing registers", "[scope:core][scope:core.dbg][kind:unit][arch:pe
   SECTION("CLRREG zeroes a single field") {
     auto whole = *scan->find("NZVC");
     auto v = *scan->find("V");
-    scan->write<u32>(whole, 0x0101'0101);
+    scan->write<u8>(whole, 0b1111);
 
     auto blaster = run(ClrReg<2>{.reg = v.reg.value, .field = v.field.value}.encode());
 
     CHECK(blaster->stop_cause() == StopCause::None);
     CHECK(blaster->csrs().F == 0);
-    CHECK(scan->read<u32>(whole) == 0x0101'0001);
+    CHECK(scan->read<u8>(whole) == 0b1101);
   }
 
   SECTION("Clearing bypasses the read-only check") {
@@ -731,17 +731,17 @@ TEST_CASE("Setting registers", "[scope:core][scope:core.dbg][kind:unit][arch:pep
   SECTION("SETREG sets a single field and leaves its siblings") {
     auto whole = *scan->find("NZVC");
     auto v = *scan->find("V");
-    scan->write<u32>(whole, 0x0000'0000);
+    scan->write<u8>(whole, 0);
 
     auto blaster = run([&](tvm::TraceBuffer &tb) {
       auto enc = SetReg<false, 4>{.access = rw.as_u16(), .reg = v.reg.value, .field = v.field.value}.encode(
-          std::array<u8, 4>{0x01, 0x00, 0x00, 0x00});
+          std::array<u8, 1>{0x01});
       tb.emit_body(S, {enc.data(), enc.size()});
     });
 
     CHECK(blaster->stop_cause() == StopCause::None);
     CHECK(scan->read<u8>(v) == 1);
-    CHECK(scan->read<u32>(whole) == 0x0000'0100);
+    CHECK(scan->read<u8>(whole) == 0b0010);
   }
 
   SECTION("A payload that is not the register's width hard stops") {
@@ -780,13 +780,15 @@ TEST_CASE("Comparing register fields", "[scope:core][scope:core.dbg][kind:unit][
 
   constexpr const char *FLAGS[] = {"N", "Z", "V", "C"};
   // Where each flag sits when the register is read as a whole -- used only to seed state, never as a payload.
-  constexpr u32 PACKED[] = {0x0100'0000, 0x0001'0000, 0x0000'0100, 0x0000'0001};
+  constexpr u8 PACKED[] = {0b1000, 0b0100, 0b0010, 0b0001};
   auto whole = *scan->find("NZVC");
 
   // Field payloads are LSB-aligned: the value naming "this flag is set" is 1, whatever the flag's bit offset in the
   // containing register happens to be. That matches what the scan hands back when reading a field.
   auto compare = [&](RegisterScan::RegisterRef ref, u32 payload) {
-    std::array<u8, 4> data{(u8)payload, (u8)(payload >> 8), (u8)(payload >> 16), (u8)(payload >> 24)};
+    // One byte, because the payload has to be the containing register's width. Anything above the low byte is
+    // excess the caller supplied on purpose; see the masking section below.
+    std::array<u8, 1> data{(u8)payload};
     auto blaster = sys->make_trace_interpreter();
     tvm::TraceBuffer tb(sys->buffer_manager());
     tb.begin(S);
@@ -801,7 +803,7 @@ TEST_CASE("Comparing register fields", "[scope:core][scope:core.dbg][kind:unit][
   SECTION("A set field compares equal to 1 regardless of its bit offset") {
     for (size_t i = 0; i < 4; ++i) {
       INFO("flag " << FLAGS[i]);
-      scan->write<u32>(whole, PACKED[i]);
+      scan->write<u8>(whole, PACKED[i]);
 
       auto blaster = compare(flag(i), 1);
 
@@ -815,7 +817,7 @@ TEST_CASE("Comparing register fields", "[scope:core][scope:core.dbg][kind:unit][
   SECTION("Each flag compares independently of its siblings") {
     for (size_t i = 0; i < 4; ++i) {
       INFO("only " << FLAGS[i] << " set");
-      scan->write<u32>(whole, PACKED[i]);
+      scan->write<u8>(whole, PACKED[i]);
       for (size_t j = 0; j < 4; ++j) {
         INFO("  comparing " << FLAGS[j]);
         CHECK(compare(flag(j), 1)->csrs().Z == (i == j ? 1 : 0));
@@ -827,7 +829,7 @@ TEST_CASE("Comparing register fields", "[scope:core][scope:core.dbg][kind:unit][
   SECTION("The same payload means different things to a field and to the register") {
     // N and V both set. A payload of 1 matches the V field, because 1 is how an LSB-aligned field says "set". The
     // identical payload against the whole register is the number 1, which 0x01000100 is not.
-    scan->write<u32>(whole, 0x0100'0100);
+    scan->write<u8>(whole, 0b1010);
 
     CHECK(compare(flag(2), 1)->csrs().Z == 1);
     CHECK(compare(whole, 1)->csrs().Z == 0);
@@ -835,28 +837,28 @@ TEST_CASE("Comparing register fields", "[scope:core][scope:core.dbg][kind:unit][
 
   SECTION("A payload wider than the field is masked to the field's width") {
     // Only bit 0 belongs to a 1-bit field; the rest of the payload is excess and must not affect the result.
-    scan->write<u32>(whole, PACKED[2]); // V set
+    scan->write<u8>(whole, PACKED[2]); // V set
     CHECK(compare(flag(2), 0xFFFF'FFFF)->csrs().Z == 1);
     CHECK(compare(flag(2), 0xFFFF'FFFE)->csrs().Z == 0);
   }
 
   SECTION("Field compares report ordering, not just equality") {
-    scan->write<u32>(whole, PACKED[2]); // V set
+    scan->write<u8>(whole, PACKED[2]);  // V set
     auto greater = compare(flag(2), 0); // 1 > 0
     CHECK(greater->csrs().Z == 0);
     CHECK(greater->csrs().N == 0);
 
-    scan->write<u32>(whole, 0);      // V clear
+    scan->write<u8>(whole, 0);       // V clear
     auto less = compare(flag(2), 1); // 0 < 1
     CHECK(less->csrs().Z == 0);
     CHECK(less->csrs().N == 1);
   }
 
   SECTION("A field compares the same way through DP-relative data") {
-    scan->write<u32>(whole, PACKED[1]); // Z set
+    scan->write<u8>(whole, PACKED[1]); // Z set
     auto z = flag(1);
     // Still LSB-aligned, still the register's width -- the size check is against the containing register.
-    auto src = expected_bytes(1, bits::Order::LittleEndian, 4);
+    auto src = expected_bytes(1, bits::Order::LittleEndian, 1);
 
     auto blaster = sys->make_trace_interpreter();
     tvm::TraceBuffer tb(sys->buffer_manager());

--- a/test/core/sim/core/pep/pep_register_blast.cpp
+++ b/test/core/sim/core/pep/pep_register_blast.cpp
@@ -519,6 +519,13 @@ TEST_CASE("Clearing registers", "[scope:core][scope:core.dbg][kind:unit][arch:pe
     CHECK(scan->read<u16>(depth) == 0);
   }
 
+  SECTION("Can inspect icount") {
+    // Reads the counter through the scan, which is what catches a byte_width that disagrees with the storage it
+    // points at -- the whole register throws otherwise.
+    auto count = *scan->find("icount");
+    CHECK(scan->read<u32>(count) == 0);
+  }
+
   SECTION("CLRREG zeroes a whole register") {
     auto ref = *scan->find("be4");
     scan->write<u32>(ref, 0xDEAD'BEEF);

--- a/test/core/sim/hwdbg/register_scan.cpp
+++ b/test/core/sim/hwdbg/register_scan.cpp
@@ -90,6 +90,29 @@ TEST_CASE("Find register by name in HW debugger", "[scope:core][scope:core.sim][
   inner_call<Register, CSR, MN>(PepISA3CPU::ISA::Pep10, MN::CALL);
 }
 
+TEST_CASE("A pointer-backed register must declare its storage's width",
+          "[scope:core][scope:core.sim][kind:unit][arch:pep10]") {
+  auto [sys, mem, cpu] = make_cpu(PepISA3CPU::ISA::Pep10);
+  auto *scan = sys->register_scan();
+  u32 counter = 0;
+
+  RegisterScan::Register r{};
+  r.order = bits::hostOrder();
+  r.target = mem->id();
+  r.name = "counter";
+  r.loc = &counter;
+
+  // The visitors compare sizeof(T) against byte_width on every access, so a mismatch that expose() let through would
+  // only surface as a throw out of the middle of some later read.
+  r.byte_width = 2;
+  CHECK_THROWS_AS(scan->expose(r), std::logic_error);
+
+  r.byte_width = 4;
+  REQUIRE_NOTHROW(scan->expose(r));
+  counter = 0x1122'3344;
+  CHECK(scan->read<u32>(*scan->find("counter")) == 0x1122'3344);
+}
+
 TEST_CASE("Register reads are host-order regardless of the register's order",
           "[scope:core][scope:core.sim][kind:unit][arch:pep10]") {
   auto [sys, mem, cpu] = make_cpu(PepISA3CPU::ISA::Pep10);

--- a/test/core/sim/hwdbg/register_scan.cpp
+++ b/test/core/sim/hwdbg/register_scan.cpp
@@ -108,7 +108,7 @@ TEST_CASE("Register reads are host-order regardless of the register's order",
     RegisterScan::Register r{};
     r.order = order;
     r.byte_width = 4;
-    r.access = RegisterScan::Register::ReadWrite;
+    r.guest_access = RegisterScan::Register::ReadWrite;
     r.target = mem->id();
     r.loc = offset;
     r.name = std::move(name);

--- a/test/core/sim/hwdbg/register_scan.cpp
+++ b/test/core/sim/hwdbg/register_scan.cpp
@@ -110,7 +110,7 @@ TEST_CASE("Register reads are host-order regardless of the register's order",
     r.byte_width = 4;
     r.access = RegisterScan::Register::ReadWrite;
     r.target = mem->id();
-    r.offset = offset;
+    r.loc = offset;
     r.name = std::move(name);
     scan->expose(r);
   };

--- a/test/core/sim/hwdbg/trace_recorder.cpp
+++ b/test/core/sim/hwdbg/trace_recorder.cpp
@@ -356,12 +356,12 @@ TEST_CASE("trace::Recorder: emit_incr_register()", "[scope:core][scope:core.dbg]
   tvm::TraceBuffer tb(sys->buffer_manager());
   constexpr Device::ID CPU{1};
 
-  // A counter living in a plain member, declared the way a CPU declares its own: read-only to the debugger, backed by
-  // a pointer rather than by an address in some target's space.
+  // A counter living in a plain member, declared the way a CPU declares its own: backed by a pointer rather than by
+  // an address in some target's space, and read-only to the guest but restorable by the host.
   i16 counter = 0;
   RegisterScan::Register decl{};
   decl.byte_width = 2;
-  decl.access = RegisterScan::Register::Access::Read;
+  decl.guest_access = RegisterScan::Register::Access::Read;
   decl.type = RegisterScan::Register::Type::Counter;
   decl.target = mem->id();
   decl.order = bits::hostOrder();

--- a/test/core/sim/hwdbg/trace_recorder.cpp
+++ b/test/core/sim/hwdbg/trace_recorder.cpp
@@ -15,9 +15,9 @@
  */
 #include "core/sim/debugger/trace_recorder.hpp"
 #include <array>
+#include <catch.hpp>
 #include "core/sim/api/trace.hpp"
 #include "core/sim/debugger/trace_device.hpp"
-#include <catch.hpp>
 #include "core/sim/debugger/tvm_interpreter.hpp"
 #include "core/sim/debugger/tvm_tracebuffer.hpp"
 #include "core/sim/memory/ram/dense.hpp"
@@ -254,6 +254,223 @@ TEST_CASE("trace::Recorder: emit_write()", "[scope:core][scope:core.dbg][kind:un
   }
 }
 
+TEST_CASE("trace::Recorder: emit_write_increment()", "[scope:core][scope:core.dbg][kind:unit][arch:pep10]") {
+  auto [sys, mem] = make_system();
+  auto mgr = sys->buffer_manager();
+  tvm::TraceBuffer tb(mgr);
+
+  constexpr Device::ID CPU{1};
+  constexpr Address ADDR = 0x1234;
+  // A location that advances by a constant, which is what this encoding exists for.
+  constexpr u16 FIRST = 0x0100, SECOND = 0x0103;
+  const std::array<u8, 2> first_bytes{0x01, 0x00}, second_bytes{0x01, 0x03}, third_bytes{0x01, 0x06};
+
+  trace::Recorder rec(&tb, mem->id());
+  tb.trace(mem->id());
+  const Operation emit_op(Operation::Type::Standard, Operation::Kind::data, CPU);
+
+  SECTION("A recorded step replays forward, then undoes itself") {
+    poke(mem, ADDR, FIRST);
+
+    tb.begin(CPU);
+    rec.emit_write_increment(emit_op, ADDR, first_bytes, second_bytes);
+    auto loc = tb.commit(CPU);
+
+    auto blaster = sys->make_trace_interpreter();
+    blaster->run(loc);
+    CHECK(blaster->stop_cause() == tvm::StopCause::None);
+    CHECK(peek(mem, ADDR) == SECOND);
+
+    // Addition is not its own inverse, so undoing this one means replaying it the other way rather than running it
+    // a second time the way the XOR form does.
+    blaster->backend().set_direction(tvm::Direction::Backward);
+    blaster->run(loc);
+    CHECK(peek(mem, ADDR) == FIRST);
+  }
+
+  SECTION("The record carries nothing in the data chain") {
+    const auto before = tb.footprint();
+
+    tb.begin(CPU);
+    rec.emit_write_increment(emit_op, ADDR, first_bytes, second_bytes);
+    auto loc = tb.commit(CPU);
+
+    // Both the address and the delta ride in the packet, so nothing was appended and there is no payload for run()
+    // to aim DP at. This is what "leaves DP alone" looks like from outside the recorder.
+    CHECK(tb.footprint().data == before.data);
+    CHECK(loc.data.id == pepp::bts::Buffer::ID{0});
+  }
+
+  SECTION("A following write still finds its own payload") {
+    // The risk of leaving DP alone is the record after it: emit_write steps DP from the last payload written, and a
+    // step in between must not have disturbed that anchor.
+    constexpr Address OTHER_ADDR = 0x2000;
+    poke(mem, ADDR, FIRST);
+    poke(mem, OTHER_ADDR, 0x1111);
+    const std::array<u8, 2> other_old{0x11, 0x11}, other_new{0x22, 0x22};
+
+    tb.begin(CPU);
+    rec.emit_write_increment(emit_op, ADDR, first_bytes, second_bytes);
+    rec.emit_write(emit_op, OTHER_ADDR, other_old, other_new);
+    auto loc = tb.commit(CPU);
+
+    sys->make_trace_interpreter()->run(loc);
+    CHECK(peek(mem, ADDR) == SECOND);
+    CHECK(peek(mem, OTHER_ADDR) == 0x2222);
+  }
+
+  SECTION("Two steps of the same size are one stencil") {
+    // The whole reason the payload is code: a location that advances by a constant emits a byte-identical body every
+    // time, and identical bodies collapse into a call.
+    tb.begin(CPU);
+    rec.emit_write_increment(emit_op, ADDR, first_bytes, second_bytes);
+    tb.commit(CPU);
+    CHECK(tb.stencil_count() == 0); // seen once, not yet promoted
+
+    tb.begin(CPU);
+    rec.emit_write_increment(emit_op, ADDR, second_bytes, third_bytes);
+    tb.commit(CPU);
+    CHECK(tb.stencil_count() == 1);
+  }
+
+  SECTION("A width the packet cannot carry falls back to the XOR form") {
+    // Three bytes will not fit the encoding, but the write still has to end up in the trace.
+    const std::array<u8, 3> old3{0x00, 0x01, 0x02}, new3{0x00, 0x01, 0x05};
+    mem->write(ADDR, {old3.data(), old3.size()}, app);
+
+    tb.begin(CPU);
+    rec.emit_write_increment(emit_op, ADDR, old3, new3);
+    auto loc = tb.commit(CPU);
+    // It took the emit_write path, which does reserve a payload.
+    CHECK(loc.data.id != pepp::bts::Buffer::ID{0});
+
+    sys->make_trace_interpreter()->run(loc);
+    std::array<u8, 3> actual{};
+    mem->read(ADDR, {actual.data(), actual.size()}, app);
+    CHECK(actual == new3);
+  }
+}
+
+TEST_CASE("trace::Recorder: emit_incr_register()", "[scope:core][scope:core.dbg][kind:unit][arch:pep10]") {
+  auto [sys, mem] = make_system();
+  tvm::TraceBuffer tb(sys->buffer_manager());
+  constexpr Device::ID CPU{1};
+
+  // A counter living in a plain member, declared the way a CPU declares its own: read-only to the debugger, backed by
+  // a pointer rather than by an address in some target's space.
+  i16 counter = 0;
+  RegisterScan::Register decl{};
+  decl.byte_width = 2;
+  decl.access = RegisterScan::Register::Access::Read;
+  decl.type = RegisterScan::Register::Type::Counter;
+  decl.target = mem->id();
+  decl.order = bits::hostOrder();
+  decl.name = "call_depth";
+  decl.loc = &counter;
+  const auto ref = sys->register_scan()->expose(decl);
+
+  trace::Recorder rec(&tb, mem->id());
+  tb.trace(mem->id());
+  const Operation emit_op(Operation::Type::Standard, Operation::Kind::data, CPU);
+
+  SECTION("A recorded step replays forward, then undoes itself") {
+    tb.begin(CPU);
+    rec.emit_incr_register(emit_op, ref, 1);
+    auto loc = tb.commit(CPU);
+
+    auto blaster = sys->make_trace_interpreter();
+    blaster->run(loc);
+    CHECK(blaster->stop_cause() == tvm::StopCause::None);
+    // Note the counter is Access::Read: a pointer-backed register is written on replay regardless, which is what
+    // makes a read-only counter restorable at all.
+    CHECK(counter == 1);
+
+    blaster->backend().set_direction(tvm::Direction::Backward);
+    blaster->run(loc);
+    CHECK(counter == 0);
+  }
+
+  SECTION("A negative step counts back down") {
+    counter = 5;
+
+    tb.begin(CPU);
+    rec.emit_incr_register(emit_op, ref, -1);
+    auto loc = tb.commit(CPU);
+
+    auto blaster = sys->make_trace_interpreter();
+    blaster->run(loc);
+    CHECK(counter == 4);
+
+    blaster->backend().set_direction(tvm::Direction::Backward);
+    blaster->run(loc);
+    CHECK(counter == 5);
+  }
+
+  SECTION("The record carries nothing in the data chain") {
+    const auto before = tb.footprint();
+
+    tb.begin(CPU);
+    rec.emit_incr_register(emit_op, ref, 1);
+    auto loc = tb.commit(CPU);
+
+    CHECK(tb.footprint().data == before.data);
+    CHECK(loc.data.id == pepp::bts::Buffer::ID{0});
+  }
+
+  SECTION("Two equal steps are one stencil") {
+    tb.begin(CPU);
+    rec.emit_incr_register(emit_op, ref, 1);
+    tb.commit(CPU);
+    CHECK(tb.stencil_count() == 0); // seen once, not yet promoted
+
+    tb.begin(CPU);
+    rec.emit_incr_register(emit_op, ref, 1);
+    tb.commit(CPU);
+    CHECK(tb.stencil_count() == 1);
+  }
+
+  SECTION("A zero step records nothing") {
+    const auto before = tb.footprint();
+
+    tb.begin(CPU);
+    rec.emit_incr_register(emit_op, ref, 0);
+    auto loc = tb.commit(CPU);
+
+    // Only the HALT commit() appends, so the body really was empty.
+    CHECK(tb.footprint().code == before.code + 2);
+
+    counter = 7;
+    sys->make_trace_interpreter()->run(loc);
+    CHECK(counter == 7);
+  }
+
+  SECTION("A register that was never exposed is dropped") {
+    // Handle 0 is never handed out, so this is a device that forgot to expose its counter. Recording it would hard
+    // stop the replay on RegisterInvalid, taking the rest of the trace down with it.
+    const auto before = tb.footprint();
+
+    tb.begin(CPU);
+    rec.emit_incr_register(emit_op, RegisterScan::RegisterRef{}, 1);
+    auto loc = tb.commit(CPU);
+
+    CHECK(tb.footprint().code == before.code + 2);
+    auto blaster = sys->make_trace_interpreter();
+    blaster->run(loc);
+    CHECK(blaster->stop_cause() == tvm::StopCause::None);
+  }
+
+  SECTION("An untraced device records nothing") {
+    tb.trace(mem->id(), false);
+
+    tb.begin(CPU);
+    rec.emit_incr_register(emit_op, ref, 1);
+    auto loc = tb.commit(CPU);
+
+    sys->make_trace_interpreter()->run(loc);
+    CHECK(counter == 0);
+  }
+}
+
 TEST_CASE("trace::BufferDevice: discovery and binding", "[scope:core][scope:core.dbg][kind:unit][arch:pep10]") {
   // Build a system that contains a trace buffer device, so binding happens through System::initialize() rather than
   // by handing a buffer to bind_recorders() by hand.
@@ -302,8 +519,8 @@ TEST_CASE("trace::BufferDevice: discovery and binding", "[scope:core][scope:core
     auto &tb = tbdev->buffer();
     tb.begin(CPU);
     // Go through the device's own write path, so this exercises the Recorder that initialize() bound.
-    ((Target *)mem)->write<u16, bits::host_is_le>(ADDR, NEW, Operation(Operation::Type::Standard,
-                                                                       Operation::Kind::data, CPU));
+    ((Target *)mem)
+        ->write<u16, bits::host_is_le>(ADDR, NEW, Operation(Operation::Type::Standard, Operation::Kind::data, CPU));
     auto loc = tb.commit(CPU);
     CHECK(peek(mem, ADDR) == NEW);
 
@@ -316,8 +533,8 @@ TEST_CASE("trace::BufferDevice: discovery and binding", "[scope:core][scope:core
     auto &tb = tbdev->buffer();
     poke(mem, ADDR, OLD);
     tb.begin(CPU);
-    ((Target *)mem)->write<u16, bits::host_is_le>(ADDR, NEW, Operation(Operation::Type::Standard,
-                                                                       Operation::Kind::data, CPU));
+    ((Target *)mem)
+        ->write<u16, bits::host_is_le>(ADDR, NEW, Operation(Operation::Type::Standard, Operation::Kind::data, CPU));
     auto loc = tb.commit(CPU);
     CHECK(peek(mem, ADDR) == NEW);
 

--- a/test/core/sim/hwdbg/tvm_step.cpp
+++ b/test/core/sim/hwdbg/tvm_step.cpp
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <array>
+#include <catch.hpp>
+
+#include "core/sim/debugger/tvm_interpreter.hpp"
+#include "core/sim/debugger/tvm_tracebuffer.hpp"
+#include "core/sim/memory/ram/dense.hpp"
+#include "core/sim/system.hpp"
+
+namespace {
+
+// A system with nothing in it but one RAM.
+auto make_system() {
+  System::Configuration root_cfg{{.basename = "/", .compatible = System::compatible}};
+  Dense::Configuration mem_cfg{
+      Device::Configuration{.basename = "memory", .compatible = Dense::compatible},
+      0x00,
+      AddressSpan(0x0000, 0xffff),
+  };
+  auto system = std::make_unique<System>(root_cfg);
+  auto *mem = system->make_device<Dense>(mem_cfg);
+  system->initialize();
+  return std::make_tuple(std::move(system), mem);
+}
+
+const Operation app(Operation::Type::Application, Operation::Kind::data);
+
+// Raw bytes straight out of the target. Big-endian assembly is spelled out by hand rather than going through
+// memcpy_endian, so a byte-order bug in STEPMEM cannot hide behind the same bug in the check.
+u16 peek_be(Target *mem, Address at) {
+  std::array<u8, 2> bytes{};
+  mem->read(at, {bytes.data(), bytes.size()}, app);
+  return (u16)(((u16)bytes[0] << 8) | bytes[1]);
+}
+void poke_be(Target *mem, Address at, u16 v) {
+  const std::array<u8, 2> bytes{(u8)(v >> 8), (u8)(v & 0xFF)};
+  mem->write(at, {bytes.data(), bytes.size()}, app);
+}
+u16 peek_le(Target *mem, Address at) {
+  std::array<u8, 2> bytes{};
+  mem->read(at, {bytes.data(), bytes.size()}, app);
+  return (u16)(((u16)bytes[1] << 8) | bytes[0]);
+}
+void poke_le(Target *mem, Address at, u16 v) {
+  const std::array<u8, 2> bytes{(u8)(v & 0xFF), (u8)(v >> 8)};
+  mem->write(at, {bytes.data(), bytes.size()}, app);
+}
+
+// Expose a register over main memory. The Pep cores only ever declare 1- and 2-byte big-endian registers, and a
+// counter is exactly the thing that wants to be wider.
+RegisterScan::RegisterRef expose(System &sys, Dense &mem, const char *name, u8 byte_width, Address at,
+                                 bits::Order order = bits::Order::BigEndian) {
+  RegisterScan::Register r{};
+  r.order = order;
+  r.byte_width = byte_width;
+  r.access = RegisterScan::Register::ReadWrite;
+  r.target = mem.id();
+  r.loc = at;
+  r.name = name;
+  sys.register_scan()->expose(r);
+  return *sys.register_scan()->find(name);
+}
+
+constexpr Device::ID S{1}; // initiator id
+constexpr Address ADDR = 0x1234;
+
+} // namespace
+
+TEST_CASE("tvm::Interpreter: STEPMEM", "[scope:core][scope:core.dbg][kind:unit][arch:pep10]") {
+  using namespace tvm::EncodedOp;
+  using SP = tvm::SegmentPair;
+  auto [sys, mem] = make_system();
+  tvm::TraceBuffer tb(sys->buffer_manager());
+  Target *target = mem;
+  const auto off = SP{.hi = (u16)(ADDR >> 16), .lo = (u16)(ADDR & 0xFFFF)};
+  const u16 access = Operation(Operation::Type::Standard, Operation::Kind::data, S).as_u16();
+
+  auto body = [&](auto enc) { tb.emit_body(S, {enc.data(), enc.size()}); };
+  // MOD1.hi: 0 leaves the destination little-endian, anything else makes it big-endian. The payload itself is always
+  // little-endian, like every other immediate in this ISA.
+  constexpr u16 BE = 1, LE = 0;
+
+  SECTION("A delta carries across the bytes of its destination, and undoes itself") {
+    poke_be(target, ADDR, 0x00FF);
+
+    tb.begin(S);
+    body(StepMem<6>(access, mem->id().value, off, BE).encode(std::array<u8, 2>{0x01, 0x00}));
+    auto loc = tb.commit(S);
+
+    auto blaster = sys->make_trace_interpreter();
+    blaster->run(loc);
+    CHECK(blaster->stop_cause() == tvm::StopCause::None);
+    CHECK(blaster->csrs().F == 0);
+    // A carry out of the low byte lands in the high one, which is what says the destination was treated as one
+    // number rather than as two independent bytes.
+    CHECK(peek_be(target, ADDR) == 0x0100);
+
+    // Backward replay subtracts, so the same record walks the counter back.
+    blaster->backend().set_direction(tvm::Direction::Backward);
+    blaster->run(loc);
+    CHECK(blaster->csrs().F == 0);
+    CHECK(peek_be(target, ADDR) == 0x00FF);
+  }
+
+  SECTION("The delta is signed") {
+    poke_be(target, ADDR, 0x0100);
+
+    tb.begin(S);
+    body(StepMem<6>(access, mem->id().value, off, BE).encode(std::array<u8, 2>{0xFF, 0xFF}));
+    auto loc = tb.commit(S);
+
+    sys->make_trace_interpreter()->run(loc);
+    CHECK(peek_be(target, ADDR) == 0x00FF);
+  }
+
+  SECTION("A one-byte step touches one byte") {
+    poke_be(target, ADDR, 0xFF41);
+
+    tb.begin(S);
+    // the payload's width is the destination's width.
+    body(StepMem<6>(access, mem->id().value, off, BE).encode(std::array<u8, 1>{0x01}));
+    auto loc = tb.commit(S);
+
+    sys->make_trace_interpreter()->run(loc);
+    // The step wrapped inside the first byte instead of borrowing the second.
+    CHECK(peek_be(target, ADDR) == 0x0041);
+  }
+
+  SECTION("The destination wraps within its own width") {
+    poke_be(target, ADDR, 0xFFFF);
+    poke_be(target, ADDR + 2, 0x9999); // a neighbour a carry must not reach
+
+    tb.begin(S);
+    body(StepMem<6>(access, mem->id().value, off, BE).encode(std::array<u8, 2>{0x01, 0x00}));
+    auto loc = tb.commit(S);
+
+    sys->make_trace_interpreter()->run(loc);
+    CHECK(peek_be(target, ADDR) == 0x0000);
+    CHECK(peek_be(target, ADDR + 2) == 0x9999);
+  }
+
+  SECTION("A little-endian destination steps little-endian") {
+    poke_le(target, ADDR, 0x00FF);
+
+    tb.begin(S);
+    body(StepMem<6>(access, mem->id().value, off, LE).encode(std::array<u8, 2>{0x01, 0x00}));
+    auto loc = tb.commit(S);
+
+    sys->make_trace_interpreter()->run(loc);
+    CHECK(peek_le(target, ADDR) == 0x0100);
+    // And the same bytes read big-endian would have been a different number entirely
+    CHECK(peek_be(target, ADDR) == 0x0001);
+  }
+
+  SECTION("The delta can come from DP rather than the packet") {
+    poke_be(target, ADDR, 0x0010);
+
+    tb.begin(S);
+    tb.append_data(S, std::array<u8, 2>{0x05, 0x00});
+    body(LDR<tvm::RegMask::DS>{2}.encode());
+    body(StepMem<5>{.access = access, .dev = mem->id().value, .off = off, .order = BE}.encode());
+    auto loc = tb.commit(S);
+
+    auto blaster = sys->make_trace_interpreter();
+    blaster->run(loc);
+    CHECK(blaster->stop_cause() == tvm::StopCause::None);
+    CHECK(peek_be(target, ADDR) == 0x0015);
+  }
+
+  SECTION("A delta too wide for the arithmetic is refused") {
+    tb.begin(S);
+    // The addition runs in a u64, so nine bytes of payload have nowhere to go.
+    body(StepMem<6>(access, mem->id().value, off, BE).encode(std::array<u8, 9>{0x01, 0, 0, 0, 0, 0, 0, 0, 0}));
+    auto loc = tb.commit(S);
+
+    auto blaster = sys->make_trace_interpreter();
+    blaster->run(loc);
+    CHECK(blaster->stop_cause() == tvm::StopCause::StepWidthIllegal);
+  }
+}
+
+TEST_CASE("tvm::Interpreter: STEPREG", "[scope:core][scope:core.dbg][kind:unit][arch:pep10]") {
+  using namespace tvm::EncodedOp;
+  auto [sys, mem] = make_system();
+  tvm::TraceBuffer tb(sys->buffer_manager());
+  auto *scan = sys->register_scan();
+  const u16 access = Operation(Operation::Type::Standard, Operation::Kind::data, S).as_u16();
+
+  auto body = [&](auto enc) { tb.emit_body(S, {enc.data(), enc.size()}); };
+
+  SECTION("A one-byte delta steps a four-byte counter") {
+    // The register reports its own width and order
+    auto ref = expose(*sys, *mem, "cycles", 4, 0x100);
+    scan->write<u32>(ref, 0x0000'FFFF);
+
+    tb.begin(S);
+    body(StepReg<4>(access, ref.reg.value, ref.field.value).encode(std::array<u8, 1>{0x01}));
+    auto loc = tb.commit(S);
+
+    auto blaster = sys->make_trace_interpreter();
+    blaster->run(loc);
+    CHECK(blaster->stop_cause() == tvm::StopCause::None);
+    CHECK(blaster->csrs().F == 0);
+    CHECK(scan->read<u32>(ref) == 0x0001'0000);
+
+    blaster->backend().set_direction(tvm::Direction::Backward);
+    blaster->run(loc);
+    CHECK(scan->read<u32>(ref) == 0x0000'FFFF);
+  }
+
+  SECTION("A negative delta counts down") {
+    auto ref = expose(*sys, *mem, "cycles", 2, 0x100);
+    scan->write<u16>(ref, 0x0100);
+
+    tb.begin(S);
+    body(StepReg<4>(access, ref.reg.value, ref.field.value).encode(std::array<u8, 1>{0xFF}));
+    auto loc = tb.commit(S);
+
+    sys->make_trace_interpreter()->run(loc);
+    CHECK(scan->read<u16>(ref) == 0x00FF);
+  }
+
+  SECTION("A little-endian register steps little-endian") {
+    auto ref = expose(*sys, *mem, "le", 2, 0x100, bits::Order::LittleEndian);
+    scan->write<u16>(ref, 0x00FF);
+
+    tb.begin(S);
+    body(StepReg<4>(access, ref.reg.value, ref.field.value).encode(std::array<u8, 1>{0x01}));
+    auto loc = tb.commit(S);
+
+    sys->make_trace_interpreter()->run(loc);
+    CHECK(scan->read<u16>(ref) == 0x0100);
+    CHECK(peek_le(mem, 0x100) == 0x0100);
+  }
+
+  SECTION("A field wraps within itself and leaves its siblings alone") {
+    RegisterScan::Register r{};
+    r.order = bits::Order::BigEndian;
+    r.byte_width = 1;
+    r.access = RegisterScan::Register::ReadWrite;
+    r.target = mem->id();
+    r.loc = Address{0x100};
+    r.name = "flags";
+    // Two 4-bit halves, so a carry out of the low one would be visible in the high one.
+    r.fields.push_back({RegisterScan::Register::ReadWrite, 0, 4, "lo"});
+    r.fields.push_back({RegisterScan::Register::ReadWrite, 4, 4, "hi"});
+    scan->expose(r);
+    auto lo = *scan->find("lo");
+    auto hi = *scan->find("hi");
+    scan->write<u8>(lo, 0xF);
+    scan->write<u8>(hi, 0x3);
+
+    tb.begin(S);
+    body(StepReg<4>(access, lo.reg.value, lo.field.value).encode(std::array<u8, 1>{0x01}));
+    auto loc = tb.commit(S);
+
+    auto blaster = sys->make_trace_interpreter();
+    blaster->run(loc);
+    CHECK(blaster->csrs().F == 0);
+    CHECK(scan->read<u8>(lo) == 0x0);
+    CHECK(scan->read<u8>(hi) == 0x3);
+  }
+
+  SECTION("A register the scan refuses to write sets F rather than stopping") {
+    RegisterScan::Register r{};
+    r.order = bits::Order::BigEndian;
+    r.byte_width = 2;
+    r.access = RegisterScan::Register::Access::Read;
+    r.target = mem->id();
+    r.loc = Address{0x100};
+    r.name = "ro";
+    scan->expose(r);
+    auto ref = *scan->find("ro");
+
+    tb.begin(S);
+    body(StepReg<4>(access, ref.reg.value, ref.field.value).encode(std::array<u8, 1>{0x01}));
+    auto loc = tb.commit(S);
+
+    // A refused register is an F for a following BRF rather than a halt -- but reaching HALT soft-stops, and that
+    // clears F. So step the one instruction instead of running to completion, and read F while it still means
+    // something. The payload is immediate, so this needs no DP and can skip run()'s setup entirely.
+    auto blaster = sys->make_trace_interpreter();
+    blaster->update_ip(loc.code);
+    blaster->step();
+
+    CHECK(!blaster->stopped()); // the machine is still live: the write failed, the program did not
+    CHECK(blaster->csrs().F == 1);
+    // And the refusal really did stop the write from landing.
+    CHECK(scan->read<u16>(ref) == 0x0000);
+  }
+
+  SECTION("An unknown register is refused") {
+    tb.begin(S);
+    body(StepReg<4>(access, 0xFFFF, 0).encode(std::array<u8, 1>{0x01}));
+    auto loc = tb.commit(S);
+
+    auto blaster = sys->make_trace_interpreter();
+    blaster->run(loc);
+    CHECK(blaster->stop_cause() == tvm::StopCause::RegisterInvalid);
+  }
+}

--- a/test/core/sim/hwdbg/tvm_step.cpp
+++ b/test/core/sim/hwdbg/tvm_step.cpp
@@ -67,7 +67,7 @@ RegisterScan::RegisterRef expose(System &sys, Dense &mem, const char *name, u8 b
   RegisterScan::Register r{};
   r.order = order;
   r.byte_width = byte_width;
-  r.access = RegisterScan::Register::ReadWrite;
+  r.guest_access = RegisterScan::Register::ReadWrite;
   r.target = mem.id();
   r.loc = at;
   r.name = name;
@@ -251,13 +251,13 @@ TEST_CASE("tvm::Interpreter: STEPREG", "[scope:core][scope:core.dbg][kind:unit][
     RegisterScan::Register r{};
     r.order = bits::Order::BigEndian;
     r.byte_width = 1;
-    r.access = RegisterScan::Register::ReadWrite;
+    r.guest_access = RegisterScan::Register::ReadWrite;
     r.target = mem->id();
     r.loc = Address{0x100};
     r.name = "flags";
     // Two 4-bit halves, so a carry out of the low one would be visible in the high one.
-    r.fields.push_back({RegisterScan::Register::ReadWrite, 0, 4, "lo"});
-    r.fields.push_back({RegisterScan::Register::ReadWrite, 4, 4, "hi"});
+    r.fields.push_back({RegisterScan::Register::ReadWrite, RegisterScan::Register::ReadWrite, 0, 4, "lo"});
+    r.fields.push_back({RegisterScan::Register::ReadWrite, RegisterScan::Register::ReadWrite, 4, 4, "hi"});
     scan->expose(r);
     auto lo = *scan->find("lo");
     auto hi = *scan->find("hi");
@@ -279,7 +279,10 @@ TEST_CASE("tvm::Interpreter: STEPREG", "[scope:core][scope:core.dbg][kind:unit][
     RegisterScan::Register r{};
     r.order = bits::Order::BigEndian;
     r.byte_width = 2;
-    r.access = RegisterScan::Register::Access::Read;
+    // Denied to the host as well as the guest: replay is a host write, so denying only the guest would let it
+    // through and there would be no refusal to observe.
+    r.guest_access = RegisterScan::Register::Access::Read;
+    r.host_access = RegisterScan::Register::Access::Read;
     r.target = mem->id();
     r.loc = Address{0x100};
     r.name = "ro";


### PR DESCRIPTION
- Expose performance counters via RegisterScanner.
- Change trace encoding for PC updates to reduce cost by 2 bytes per instruction.
- Reduce size of trace encoding for NZVC updates by 3 bytes per instruction.