### PR TITLE
Measure & improve new simulator's performance

### DIFF
--- a/bin/term/commands/throughput.cpp
+++ b/bin/term/commands/throughput.cpp
@@ -19,8 +19,13 @@
 #include <chrono>
 #include <iostream>
 #include "core/integers.h"
+#include "core/sim/cores/cpu/pep_isa.hpp"
+#include "core/sim/memory/bus/simplebus.hpp"
+#include "core/sim/memory/ram/dense.hpp"
+#include "core/sim/system.hpp"
 #include "sim3/cores/pep/traced_pep10_isa3.hpp"
 #include "sim3/subsystems/ram/dense.hpp"
+
 const auto desc_mem = sim::api2::device::Descriptor{
     .id = 1,
     .baseName = "ram",
@@ -35,7 +40,7 @@ const auto desc_cpu = sim::api2::device::Descriptor{
 
 const auto span = sim::api2::memory::AddressSpan<quint16>(0, 0xFFFF);
 
-auto make = []() {
+auto make_sim3() {
   int i = 3;
   sim::api2::device::IDGenerator gen = [&i]() { return i++; };
   auto storage = QSharedPointer<sim::memory::Dense<quint16>>::create(desc_mem, span);
@@ -44,15 +49,57 @@ auto make = []() {
   return std::pair{storage, cpu};
 };
 
-sim::api2::memory::Operation rw = {
-    .type = sim::api2::memory::Operation::Type::Standard,
-    .kind = sim::api2::memory::Operation::Kind::data,
-};
+auto make_core() {
+  static constexpr auto isa = PepISA3CPU::ISA::Pep10;
+  using namespace bits;
+  PepISA3CPU::Configuration cpu_cfg{Device::Configuration{
+                                        .basename = "cpu",
+                                        .compatible = PepISA3CPU::compatible,
+                                    },
+                                    isa, "/memory"};
+  System::Configuration root_cfg{{.basename = "/", .compatible = System::compatible}};
+  Dense::Configuration mem_cfg{
+      Device::Configuration{
+          .basename = "memory",
+          .compatible = Dense::compatible,
+      },
+      0x00,
+      AddressSpan(0x0000, 0xffff),
+  };
+  auto system = std::make_unique<System>(root_cfg);
+  auto *mem = system->make_device<Dense>(mem_cfg);
+  auto *cpu = system->make_device<PepISA3CPU>(cpu_cfg, system.get());
+  system->initialize();
+  return std::make_tuple(std::move(system), mem, cpu);
+}
 
-ThroughputTask::ThroughputTask(QObject *parent) : Task(parent) {}
+ThroughputTask::ThroughputTask(WhichVersion ver, QObject *parent) : Task(parent), _version(ver) {}
 
 void ThroughputTask::run() {
   using namespace Qt::StringLiterals;
+
+  std::chrono::high_resolution_clock::time_point start;
+  switch (_version) {
+  case WhichVersion::Sim3: start = do_sim3(); break;
+  case WhichVersion::Core: start = do_core(); break;
+  }
+  const auto end = std::chrono::high_resolution_clock::now();
+  const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  const auto dt = 1.0 / (ms.count() / 1000.0);
+  const auto locale = std::locale("en_US.UTF-8");
+  fmt::println("Duration: {} ms", ms.count());
+  std::cout << fmt::format(locale, "Instructions: {:L}\n", maxInstr);
+  std::cout << fmt::format(locale, "Throughput: {:L} instructions/second\n", (i32)(dt * maxInstr));
+
+  emit finished(0);
+}
+
+std::chrono::high_resolution_clock::time_point ThroughputTask::do_sim3() {
+  static constexpr sim::api2::memory::Operation rw = {
+      .type = sim::api2::memory::Operation::Type::Standard,
+      .kind = sim::api2::memory::Operation::Kind::data,
+  };
+  fmt::println("Selected: sim3");
   auto env = nullptr;
   // Add some spurious breakpoints which will not be hit
   // auto debugger = std::make_shared<pepp::debug::Debugger>(env);
@@ -65,7 +112,7 @@ void ThroughputTask::run() {
     return;
   }*/
   // debugger->bps->addBP(0 /*, bp.get()*/);
-  auto [mem, cpu] = make();
+  auto [mem, cpu] = make_sim3();
   // cpu->setDebugger(&*debugger);
   cpu->regs()->clear(0);
   cpu->csrs()->clear(0);
@@ -73,15 +120,19 @@ void ThroughputTask::run() {
   const auto program = std::array<quint8, 3>{static_cast<quint8>(isa::Pep10::Mnemonic::BR), 0x00, 0x00};
   mem->write(0, {program.data(), program.size()}, rw);
   const auto start = std::chrono::high_resolution_clock::now();
-  const auto maxInstr = 100'000'000;
   for (int it = 0; it < maxInstr; it++) cpu->clock(it);
-  const auto end = std::chrono::high_resolution_clock::now();
-  const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-  const auto dt = 1.0 / (ms.count() / 1000.0);
-  const auto locale = std::locale("en_US.UTF-8");
-  fmt::println("Duration: {} ms", ms.count());
-  std::cout << fmt::format(locale, "Instructions: {:L}\n", maxInstr);
-  std::cout << fmt::format(locale, "Throughput: {:L} instructions/second\n", (i32)(dt * maxInstr));
+  return start;
+}
 
-  emit finished(0);
+std::chrono::high_resolution_clock::time_point ThroughputTask::do_core() {
+  static constexpr auto rw = Operation{Operation::Type::Standard, Operation::Kind::data};
+  fmt::println("Selected: core");
+  auto [system, mem, cpu] = make_core();
+  cpu->write_register(isa::Pep10::Register::PC, 0x0000);
+  // Infinite looping branch to 0.
+  const auto program = std::array<u8, 3>{static_cast<u8>(isa::Pep10::Mnemonic::BR), 0x00, 0x00};
+  mem->write(0x0000, {program.data(), program.size()}, rw);
+  const auto start = std::chrono::high_resolution_clock::now();
+  for (int it = 0; it < maxInstr; it++) cpu->clock_tick(PulseSchedule::PulseIndex{(u64)it}, it);
+  return start;
 }

--- a/bin/term/commands/throughput.cpp
+++ b/bin/term/commands/throughput.cpp
@@ -132,6 +132,11 @@ std::chrono::high_resolution_clock::time_point ThroughputTask::do_core() {
   // Infinite looping branch to 0.
   const auto program = std::array<u8, 3>{static_cast<u8>(isa::Pep10::Mnemonic::BR), 0x00, 0x00};
   mem->write(0x0000, {program.data(), program.size()}, rw);
+  // We are untraced, provide explicit hints to avoid recording.
+  mem->on_traced_changed(false);
+  cpu->on_traced_changed(false);
+  cpu->csrs()->on_traced_changed(false);
+  cpu->registers()->on_traced_changed(false);
   const auto start = std::chrono::high_resolution_clock::now();
   for (int it = 0; it < maxInstr; it++) cpu->clock_tick(PulseSchedule::PulseIndex{(u64)it}, it);
   return start;

--- a/bin/term/commands/throughput.hpp
+++ b/bin/term/commands/throughput.hpp
@@ -15,23 +15,46 @@
  */
 
 #include <QtCore>
+#include <chrono>
 #include "../shared.hpp"
 #include "../task.hpp"
+#include "CLI11.hpp"
+#include "core/integers.h"
 
 class ThroughputTask : public Task {
   Q_OBJECT
 public:
-  ThroughputTask(QObject *parent = nullptr);
-  ;
+  enum class WhichVersion { Sim3, Core };
+  ThroughputTask(WhichVersion ver, QObject *parent = nullptr);
   ~ThroughputTask() = default;
   void run();
+  // Both should return their "start" time
+  std::chrono::high_resolution_clock::time_point do_sim3();
+  std::chrono::high_resolution_clock::time_point do_core();
+  u64 maxInstr = 100'000'000;
+
+private:
+  WhichVersion _version;
 };
 
 void registerThroughput(auto &app, task_factory_t &task, detail::SharedFlags &flags) {
   static auto instrThruSC = app.add_subcommand("mit", "Measure instruction throughput");
+  static ThroughputTask::WhichVersion version = ThroughputTask::WhichVersion::Sim3;
+  static u64 maxInstr = 100'000'000;
+  auto versionOpt =
+      instrThruSC->add_option("-v,--version", version, "Which version to run")
+          ->transform(CLI::CheckedTransformer(std::map<std::string, ThroughputTask::WhichVersion>{
+              {"sim3", ThroughputTask::WhichVersion::Sim3}, {"core", ThroughputTask::WhichVersion::Core}}));
+
+  static auto maxInstrOpt =
+      instrThruSC->add_option("-n,--max-instr", maxInstr, "Maximum number of instructions to run");
   instrThruSC->group("");
   instrThruSC->callback([&]() {
     flags.kind = detail::SharedFlags::Kind::TERM;
-    task = [](QObject *parent) { return new ThroughputTask(parent); };
+    task = [](QObject *parent) {
+      auto ret = new ThroughputTask(version, parent);
+      ret->maxInstr = maxInstr;
+      return ret;
+    };
   });
 }

--- a/core/core/sim/api/trace.hpp
+++ b/core/core/sim/api/trace.hpp
@@ -37,4 +37,8 @@ public:
   virtual bool traced() const = 0;
   // Toggle the traced state of this device in our TB. If the device cannot generate traces, this must be a no-op.
   virtual void trace(bool enabled) = 0;
+  // Pushed by the TraceBuffer whenever this device's traced bit changes, and once at bind time for the initial value.
+  // A device whose accesses are hot enough to care can mirror it locally and skip the recorder entirely, rather than
+  // asking the buffer on every access.
+  virtual void on_traced_changed(bool enabled) {}
 };

--- a/core/core/sim/cores/cpu/pep_csrbank.cpp
+++ b/core/core/sim/cores/cpu/pep_csrbank.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "core/sim/cores/cpu/pep_csrbank.hpp"
+#include "core/sim/memory/errors.hpp"
+#include "core/sim/system.hpp"
+
+PepCSRBank::PepCSRBank(Configuration config) : Device(), _config(config) {}
+
+void PepCSRBank::initialize(System *sys) {
+  using SR = RegisterScan::Register;
+  using F = SR::Field;
+  auto *scan = sys->register_scan();
+  // Bit 7 is MSB, 0 is LSB. The flags occupy the low nibble in CSR enum order, so N is bit 3 and C is bit 0.
+  auto n = F{.bit_offset = 3, .bit_width = 1, .name = "N"};
+  auto z = F{.bit_offset = 2, .bit_width = 1, .name = "Z"};
+  auto v = F{.bit_offset = 1, .bit_width = 1, .name = "V"};
+  auto c = F{.bit_offset = 0, .bit_width = 1, .name = "C"};
+  SR r{};
+  r.byte_width = sizeof(_nzvc);
+  // Pointer-backed and host order. A single byte has no byte order of its own, but saying host keeps it consistent
+  // with the register bank and stops a byteswap being applied to the fields.
+  r.order = bits::hostOrder();
+  r.target = id();
+  r.name = "NZVC";
+  r.fields = {n, z, v, c};
+  r.loc = &_nzvc;
+  _ref = scan->expose(r);
+}
+
+void PepCSRBank::reset() { _nzvc = 0; }
+
+void PepCSRBank::set_initiator(Device::ID cpu) {
+  _op = Operation(Operation::Type::Standard, Operation::Kind::data, cpu);
+}
+
+void PepCSRBank::store(u8 value, Operation op) {
+  // Masked here so the invariant lives with the data: every path in, including a debugger writing the raw byte,
+  // lands in the low nibble.
+  const auto masked = static_cast<u8>(value & MASK);
+  // Whole-byte record even when one flag moved: SETREGX names a register, and a field write would have to carry the
+  // field id and a mask to say the same thing in more bytes.
+  if (_traced) _trace.emit_write_register(op, _ref, static_cast<u8>(_nzvc ^ masked));
+  _nzvc = masked;
+}
+
+void PepCSRBank::write(CSR csr, bool value) {
+  // Read-modify-write: the other three flags share the byte and must survive.
+  const u8 mask = bit(csr);
+  store(static_cast<u8>(value ? (_nzvc | mask) : (_nzvc & ~mask)), _op);
+}
+
+void PepCSRBank::write_n(bool value) { write(CSR::N, value); }
+void PepCSRBank::write_z(bool value) { write(CSR::Z, value); }
+void PepCSRBank::write_v(bool value) { write(CSR::V, value); }
+void PepCSRBank::write_c(bool value) { write(CSR::C, value); }
+
+void PepCSRBank::write_packed(u8 value) { store(value, _op); }
+
+const Device::Configuration &PepCSRBank::config() const { return _config; }
+const PepCSRBank::Configuration &PepCSRBank::casted_config() const { return _config; }
+const Device::ID PepCSRBank::id() const { return _config.id; }
+
+Device::Type PepCSRBank::type() const {
+  using namespace bits;
+  using T = Device::Type;
+  return T::MemoryTarget | T::Traceable;
+}
+
+std::unique_ptr<DeviceSerializer> PepCSRBank::serializer() const {
+  // Should never be called: the CPU builds this with skip_serialize = true.
+  throw std::logic_error("PepCSRBank is synthetic and has no serialized form");
+}
+
+void PepCSRBank::set_recorder(const trace::Recorder &recorder) { _trace = recorder; }
+bool PepCSRBank::can_generate_traces() const { return true; }
+void PepCSRBank::trace(bool enabled) { _trace.set_traced(enabled); }
+bool PepCSRBank::traced() const { return _traced; }
+void PepCSRBank::on_traced_changed(bool enabled) { _traced = enabled; }
+
+// One byte, the span the Dense covered.
+AddressSpan PepCSRBank::span() const { return AddressSpan(0, 0); }
+
+Target::Result PepCSRBank::read(Address address, bits::span<u8> dest, Operation op) const {
+  using E = Error;
+  const auto bounds = span();
+  const auto max_addr = (address + std::max<Address>(0, dest.size() - 1));
+  if (address < bounds.lower() || max_addr > bounds.upper()) throw E(E::Type::OOBAccess, address);
+  if (dest.size() > 0) dest[0] = _nzvc;
+  return {};
+}
+
+Target::Result PepCSRBank::write(Address address, bits::span<const u8> src, Operation op) {
+  using E = Error;
+  const auto bounds = span();
+  const auto max_addr = (address + std::max<Address>(0, src.size() - 1));
+  if (address < bounds.lower() || max_addr > bounds.upper()) throw E(E::Type::OOBAccess, address);
+  if (src.size() > 0) store(src[0], op);
+  return {};
+}
+
+void PepCSRBank::clear(u8 fill) {
+  // TODO: emit a "clear" trace to TB.
+  // Masked like every other way in, or clear() would be the one path that can leave bits above the flags set.
+  _nzvc = static_cast<u8>(fill & MASK);
+}
+
+void PepCSRBank::dump(bits::span<u8> dest) const {
+  if (dest.size() <= 0) throw std::logic_error("dump requires non-0 size");
+  dest[0] = _nzvc;
+}

--- a/core/core/sim/cores/cpu/pep_csrbank.hpp
+++ b/core/core/sim/cores/cpu/pep_csrbank.hpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+#include <tuple>
+#include "core/arch/pep/isa/pep10.hpp"
+#include "core/sim/api/device.hpp"
+#include "core/sim/api/memory.hpp"
+#include "core/sim/api/trace.hpp"
+#include "core/sim/debugger/register_scanner.hpp"
+#include "core/sim/debugger/trace_recorder.hpp"
+
+// The Pep status flags, held as one packed byte. NZVC occupies the low nibble of a single u8, N at bit 3 down to C at
+// bit 0. Still a Target over the same one-byte address space, presenting the same value, so address-based callers keep
+// working.
+class PepCSRBank final : public Device, public Target, public Traceable {
+public:
+  using CSR = isa::Pep10::CSR;
+  // Fully synthetic: the CPU constructs it, nothing parses one, and it is never written out.
+  struct Configuration : public Device::Configuration {};
+
+  explicit PepCSRBank(Configuration config);
+  ~PepCSRBank() = default;
+  PepCSRBank(const PepCSRBank &) = delete;
+  PepCSRBank &operator=(const PepCSRBank &) = delete;
+
+  // --- Typed access.
+  bool read_n() const { return (_nzvc & bit(CSR::N)) != 0; }
+  bool read_z() const { return (_nzvc & bit(CSR::Z)) != 0; }
+  bool read_v() const { return (_nzvc & bit(CSR::V)) != 0; }
+  bool read_c() const { return (_nzvc & bit(CSR::C)) != 0; }
+
+  void write_n(bool value);
+  void write_z(bool value);
+  void write_v(bool value);
+  void write_c(bool value);
+
+  // All four at once, which is what an ALU result sets. One record rather than four.
+  u8 read_packed() const { return _nzvc; }
+  void write_packed(u8 value);
+
+  // --- Enum dispatch, for callers holding a CSR rather than a name. ---
+  bool read(CSR csr) const { return (_nzvc & bit(csr)) != 0; }
+  void write(CSR csr, bool value);
+  // The scan reference for the packed register. A field of 0 addresses the whole byte; the individual flags are
+  // exposed as fields of it.
+  RegisterScan::RegisterRef ref() const { return _ref; }
+
+  // The flags run N, Z, V, C and the packing puts N highest, so a flag's bit counts down from the top of the nibble.
+  static constexpr u8 bit(CSR csr) { return static_cast<u8>(1 << (3 - static_cast<u8>(csr))); }
+  static constexpr u8 MASK = 0x0F;
+
+  static constexpr u8 pack(bool n, bool z, bool v, bool c) {
+    return static_cast<u8>((n ? bit(CSR::N) : 0) | (z ? bit(CSR::Z) : 0) | (v ? bit(CSR::V) : 0) |
+                           (c ? bit(CSR::C) : 0));
+  }
+  static constexpr std::tuple<bool, bool, bool, bool> unpack(u8 nzvc) {
+    return {(nzvc & bit(CSR::N)) != 0, (nzvc & bit(CSR::Z)) != 0, (nzvc & bit(CSR::V)) != 0,
+            (nzvc & bit(CSR::C)) != 0};
+  }
+
+  // Device interface
+  void initialize(System *) override;
+  void reset() override;
+  const Device::Configuration &config() const override;
+  const Configuration &casted_config() const;
+  const Device::ID id() const override;
+  Device::Type type() const override;
+  std::unique_ptr<DeviceSerializer> serializer() const override;
+
+  // Traceable interface
+  void set_recorder(const trace::Recorder &recorder) override;
+  bool can_generate_traces() const override;
+  void trace(bool enabled) override;
+  bool traced() const override;
+  void on_traced_changed(bool enabled) override;
+
+  // Target interface. The slow, generic path, over the same single byte the Dense covered.
+  using Target::read;
+  using Target::write;
+  AddressSpan span() const override;
+  Result read(Address address, bits::span<u8> dest, Operation op) const override;
+  Result write(Address address, bits::span<const u8> src, Operation op) override;
+  void clear(u8 fill) override;
+  void dump(bits::span<u8> dest) const override;
+
+  // The Operation the typed writers record under. Set once, by the CPU that owns this bank.
+  void set_initiator(Device::ID cpu);
+
+private:
+  // Record the xor if traced, then store. Always a whole-byte record: a single flag is a field of the packed
+  // register, and SETREGX names the register rather than the field.
+  void store(u8 value, Operation op);
+
+  Configuration _config;
+  u8 _nzvc = 0;
+  // Filled in by initialize(). SETREGX names its target by scan id, so a write cannot be recorded without it.
+  RegisterScan::RegisterRef _ref{};
+  trace::Recorder _trace;
+  // Mirror of the buffer's traced bit, pushed via on_traced_changed(). Read on every write.
+  bool _traced = false;
+  Operation _op = Operation(Operation::Type::Standard, Operation::Kind::data, Device::ID{0});
+};

--- a/core/core/sim/cores/cpu/pep_isa.cpp
+++ b/core/core/sim/cores/cpu/pep_isa.cpp
@@ -92,6 +92,8 @@ PepISA3CPU::PepISA3CPU(Configuration cfg, System *sys) : _config(cfg) {
 const Target *PepISA3CPU::target() const { return _target; }
 
 void PepISA3CPU::initialize(System *sys) {
+  _op_data = Operation(Operation::Type::Standard, Operation::Kind::data, id());
+
   using enum isa::SharedOpBehavior;
   auto dev = sys->find_relative(_config.target, _config.fullname);
   if (!dev) throw std::runtime_error("PepISA3CPU: could not find target device " + _config.target);

--- a/core/core/sim/cores/cpu/pep_isa.cpp
+++ b/core/core/sim/cores/cpu/pep_isa.cpp
@@ -223,7 +223,10 @@ void PepISA3CPU::handle(Op opcode) {
   using R = isa::Pep10::Register;
   using BC = BranchCondition;
   using enum isa::SharedOpBehavior;
-  // Monadic
+  const auto operand = [&] { return decode_op_addr(this, opcode.addr); };
+  // One switch over the whole behavior enum rather than two, which is significantly faster than a monadic/dyadic split.
+  // However, we can't preload operand anymore, so we need a small lambda to defer reading it until we've figured out if
+  // the insruction is dyadic or not.
   switch (opcode.behavior) {
   case UNIMPL: return unimpl_handler(this);
   case STOP: throw std::logic_error("Unimplemented instruction: STOP");
@@ -242,35 +245,29 @@ void PepISA3CPU::handle(Op opcode) {
   case ROR: return handle_rorr(this, (R)opcode.target);
   case SCALL: throw std::logic_error("Unimplemented instruction: SCALL");
   case TRAP_CALL: throw std::logic_error("Unimplemented instruction: TRAP_CALL");
-  default: break;
-  }
-
-  // Dyadic
-  u16 op_addr = decode_op_addr(this, opcode.addr);
-  switch (opcode.behavior) {
-  case BR: return handle_unconditional_branch(this, opcode, op_addr);
-  case BRLE: return handle_branch(this, opcode, BC::LE, op_addr);
-  case BRLT: return handle_branch(this, opcode, BC::LT, op_addr);
-  case BREQ: return handle_branch(this, opcode, BC::EQ, op_addr);
-  case BRNE: return handle_branch(this, opcode, BC::NE, op_addr);
-  case BRGE: return handle_branch(this, opcode, BC::GE, op_addr);
-  case BRGT: return handle_branch(this, opcode, BC::GT, op_addr);
-  case BRV: return handle_branch(this, opcode, BC::V, op_addr);
-  case BRC: return handle_branch(this, opcode, BC::C, op_addr);
-  case CALL: return handle_call(this, opcode, op_addr);
-  case ADDSP: return handle_addsp(this, opcode, op_addr);
-  case SUBSP: return handle_subsp(this, opcode, op_addr);
-  case ADD: return handle_addr(this, opcode, op_addr);
-  case SUB: return handle_subr(this, opcode, op_addr);
-  case AND: return handle_bitopr(this, opcode, Bitop::AND, op_addr);
-  case OR: return handle_bitopr(this, opcode, Bitop::OR, op_addr);
-  case XOR: return handle_bitopr(this, opcode, Bitop::XOR, op_addr);
-  case CPW: return handle_cpwr(this, opcode, op_addr);
-  case CPB: return handle_cpbr(this, opcode, op_addr);
-  case LDW: return handle_ldwr(this, opcode, op_addr);
-  case LDB: return handle_ldbr(this, opcode, op_addr);
-  case STW: return handle_stwr(this, opcode, op_addr);
-  case STB: return handle_stbr(this, opcode, op_addr);
+  case BR: return handle_unconditional_branch(this, opcode, operand());
+  case BRLE: return handle_branch(this, opcode, BC::LE, operand());
+  case BRLT: return handle_branch(this, opcode, BC::LT, operand());
+  case BREQ: return handle_branch(this, opcode, BC::EQ, operand());
+  case BRNE: return handle_branch(this, opcode, BC::NE, operand());
+  case BRGE: return handle_branch(this, opcode, BC::GE, operand());
+  case BRGT: return handle_branch(this, opcode, BC::GT, operand());
+  case BRV: return handle_branch(this, opcode, BC::V, operand());
+  case BRC: return handle_branch(this, opcode, BC::C, operand());
+  case CALL: return handle_call(this, opcode, operand());
+  case ADDSP: return handle_addsp(this, opcode, operand());
+  case SUBSP: return handle_subsp(this, opcode, operand());
+  case ADD: return handle_addr(this, opcode, operand());
+  case SUB: return handle_subr(this, opcode, operand());
+  case AND: return handle_bitopr(this, opcode, Bitop::AND, operand());
+  case OR: return handle_bitopr(this, opcode, Bitop::OR, operand());
+  case XOR: return handle_bitopr(this, opcode, Bitop::XOR, operand());
+  case CPW: return handle_cpwr(this, opcode, operand());
+  case CPB: return handle_cpbr(this, opcode, operand());
+  case LDW: return handle_ldwr(this, opcode, operand());
+  case LDB: return handle_ldbr(this, opcode, operand());
+  case STW: return handle_stwr(this, opcode, operand());
+  case STB: return handle_stbr(this, opcode, operand());
   default: throw std::logic_error("Unknown opcode behavior");
   }
 }

--- a/core/core/sim/cores/cpu/pep_isa.cpp
+++ b/core/core/sim/cores/cpu/pep_isa.cpp
@@ -289,7 +289,7 @@ void PepISA3CPU::handle(Op opcode) {
   // Dyadic
   u16 op_addr = decode_op_addr(this, opcode.addr);
   switch (opcode.behavior) {
-  case BR: return handle_branch(this, opcode, BC::UNCONDITIONAL, op_addr);
+  case BR: return handle_unconditional_branch(this, opcode, op_addr);
   case BRLE: return handle_branch(this, opcode, BC::LE, op_addr);
   case BRLT: return handle_branch(this, opcode, BC::LT, op_addr);
   case BREQ: return handle_branch(this, opcode, BC::EQ, op_addr);

--- a/core/core/sim/cores/cpu/pep_isa.cpp
+++ b/core/core/sim/cores/cpu/pep_isa.cpp
@@ -155,7 +155,7 @@ std::unique_ptr<DeviceSerializer> PepISA3CPU::make_serializer() {
 
 void PepISA3CPU::clock_tick(PulseSchedule::PulseIndex idx, u64 tick) {
   // Create a single record for the entire instruction
-  trace::Recorder::Instruction record(_trace, _trace.traced());
+  trace::Recorder::Instruction record(_trace, _may_trace);
   // TODO: when function signature changes, use that tick offset instead of this placeholder.
   record.tick(1);
 
@@ -176,7 +176,8 @@ void PepISA3CPU::clock_tick(PulseSchedule::PulseIndex idx, u64 tick) {
   // data-dependence for the branch target.
   const auto pc_delta = _pc - init_pc;
   if ((pc_delta & 0b11) == pc_delta) {
-    _trace.emit_incr_register(op_data(), _regbank->ref(isa::Pep10::Register::PC), static_cast<i16>(pc_delta));
+    auto r = _regbank->ref(isa::Pep10::Register::PC);
+    if (_may_trace) _trace.emit_incr_register(op_data(), r, static_cast<i16>(pc_delta));
     _regbank->write_pc_untraced(_pc);
   } else write_register_uncached(isa::Pep10::Register::PC, _pc);
   // TODO: handle breakpoints, debug info, etc
@@ -192,7 +193,9 @@ void PepISA3CPU::set_recorder(const trace::Recorder &recorder) { _trace = record
 
 bool PepISA3CPU::can_generate_traces() const { return true; }
 
-bool PepISA3CPU::traced() const { return _trace.traced(); }
+bool PepISA3CPU::traced() const { return _may_trace; }
+
+void PepISA3CPU::on_traced_changed(bool enabled) { _may_trace = enabled; }
 
 void PepISA3CPU::trace(bool enabled) {
   // The CPU is not itself a Target and it holds no state to record, so delegate to the child devices.
@@ -204,12 +207,12 @@ void PepISA3CPU::trace(bool enabled) {
 void PepISA3CPU::increment_call_depth() {
   _count.call_depth += 1;
   // Ordering does not matter here the way it does for a write since the prior is constant.
-  _trace.emit_incr_register(op_data(), _ref_call_depth, 1);
+  if (_may_trace) _trace.emit_incr_register(op_data(), _ref_call_depth, 1);
 }
 
 void PepISA3CPU::decrement_call_depth() {
   _count.call_depth -= 1;
-  _trace.emit_incr_register(op_data(), _ref_call_depth, -1);
+  if (_may_trace) _trace.emit_incr_register(op_data(), _ref_call_depth, -1);
 }
 
 u8 PepISA3CPU::read_packed_csr() const { return _csrs->read_packed(); }

--- a/core/core/sim/cores/cpu/pep_isa.cpp
+++ b/core/core/sim/cores/cpu/pep_isa.cpp
@@ -254,12 +254,10 @@ void PepISA3CPU::decrement_call_depth() {
 
 // The CSR bank is one byte holding all four flags, N at bit 3 through C at bit 0, matching the packing at the ISA
 // layer. One access also means one trace record byte rather than 4
-u8 PepISA3CPU::read_packed_csr() {
-  return static_cast<u8>(((Target *)_csrs)->read<u8, false>(0, op_data()).second & CSR_MASK);
-}
+u8 PepISA3CPU::read_packed_csr() { return static_cast<u8>(_csrs->read<u8, false>(0, op_data()).second & CSR_MASK); }
 
 void PepISA3CPU::write_packed_csr(u8 value) {
-  ((Target *)_csrs)->write<u8, false>(0, static_cast<u8>(value & CSR_MASK), op_data());
+  _csrs->write<u8, false>(0, static_cast<u8>(value & CSR_MASK), op_data());
 }
 
 void PepISA3CPU::handle(Op opcode) {

--- a/core/core/sim/cores/cpu/pep_isa.cpp
+++ b/core/core/sim/cores/cpu/pep_isa.cpp
@@ -155,7 +155,7 @@ std::unique_ptr<DeviceSerializer> PepISA3CPU::make_serializer() {
 
 void PepISA3CPU::clock_tick(PulseSchedule::PulseIndex idx, u64 tick) {
   // Create a single record for the entire instruction
-  trace::Recorder::Instruction record(_trace);
+  trace::Recorder::Instruction record(_trace, _trace.traced());
   // TODO: when function signature changes, use that tick offset instead of this placeholder.
   record.tick(1);
 

--- a/core/core/sim/cores/cpu/pep_isa.cpp
+++ b/core/core/sim/cores/cpu/pep_isa.cpp
@@ -89,8 +89,6 @@ PepISA3CPU::PepISA3CPU(Configuration cfg, System *sys) : _config(cfg) {
   sys->make_deferred(DeferredDevice{.parent = _config.id, .ctor = make_csrs});
 }
 
-const Target *PepISA3CPU::target() const { return _target; }
-
 void PepISA3CPU::initialize(System *sys) {
   _op_data = Operation(Operation::Type::Standard, Operation::Kind::data, id());
 
@@ -317,4 +315,3 @@ void PepISA3CPU::handle(Op opcode) {
   default: throw std::logic_error("Unknown opcode behavior");
   }
 }
-Target *PepISA3CPU::target() { return _target; }

--- a/core/core/sim/cores/cpu/pep_isa.cpp
+++ b/core/core/sim/cores/cpu/pep_isa.cpp
@@ -66,25 +66,19 @@ PepISA3CPU::PepISA3CPU(Configuration cfg, System *sys) : _config(cfg) {
   auto make_regs = [](System *sys, Device::ID parent) {
     auto device = sys->find_by_id(parent);
     auto self = dynamic_cast<PepISA3CPU *>(device);
-    Dense::Configuration cfg;
+    PepRegisterBank::Configuration cfg;
     cfg.basename = "regs";
-    cfg.fill = 0;
-    cfg.span = {0, 31 * sizeof(u16)};
     cfg.skip_serialize = true;
-    self->_regbank = sys->make_device<Dense>(parent, cfg);
+    self->_regbank = sys->make_device<PepRegisterBank>(parent, cfg);
   };
   sys->make_deferred(DeferredDevice{.parent = _config.id, .ctor = make_regs});
   auto make_csrs = [](System *sys, Device::ID parent) {
     auto device = sys->find_by_id(parent);
     auto self = dynamic_cast<PepISA3CPU *>(device);
-    Dense::Configuration cfg;
+    PepCSRBank::Configuration cfg;
     cfg.basename = "csrs";
-    cfg.fill = 0;
-    // One byte holding NZVC in its low nibble, N at bit 3 down to C at bit 0. A byte per flag would cost 4 payload
-    // bytes in every trace record that touches the flags, to carry 4 bits.
-    cfg.span = {0, 0};
     cfg.skip_serialize = true;
-    self->_csrs = sys->make_device<Dense>(parent, cfg);
+    self->_csrs = sys->make_device<PepCSRBank>(parent, cfg);
   };
   sys->make_deferred(DeferredDevice{.parent = _config.id, .ctor = make_csrs});
 }
@@ -104,44 +98,10 @@ void PepISA3CPU::initialize(System *sys) {
   }
 
   auto scan = sys->register_scan();
-  // Scanned register
   using SR = RegisterScan::Register;
-  static const auto BE = bits::Order::BigEndian;
-  static const auto LE = bits::Order::LittleEndian;
-  static const auto RW = RegisterScan::Register::ReadWrite;
   static const auto RO = RegisterScan::Register::Access::Read;
-  // Core registers
-  using R = isa::Pep10::Register;
-  const auto rid = _regbank->id();
-  static const auto r2i = [](const R &r) -> u16 { return static_cast<u16>(r) * 2; };
-  scan->expose(SR{.byte_width = 2, .guest_access = RW, .target = rid, .order = BE, .name = "A", .loc = r2i(R::A)});
-  scan->expose(SR{.byte_width = 2, .guest_access = RW, .target = rid, .order = BE, .name = "X", .loc = r2i(R::X)});
-  scan->expose(SR{.byte_width = 2, .guest_access = RW, .target = rid, .order = BE, .name = "PC", .loc = r2i(R::PC)});
-  scan->expose(SR{.byte_width = 2, .guest_access = RW, .target = rid, .order = BE, .name = "SP", .loc = r2i(R::SP)});
-  scan->expose(SR{.byte_width = 1,
-                  .guest_access = RW,
-                  .target = rid,
-                  .order = BE,
-                  .name = "IS",
-                  .loc = static_cast<Address>(r2i(R::IS) + 1)});
-  scan->expose(SR{.byte_width = 2, .guest_access = RW, .target = rid, .order = BE, .name = "OS", .loc = r2i(R::OS)});
-  // CSRs / Flags
-  using C = isa::Pep10::CSR;
-  const auto cid = _csrs->id();
-  using F = SR::Field;
-  // Should really be 4 separate fields, but I want to test that my fields work as expected.
-  // Bit 7 is MSB, 0 is LSB. The flags occupy the low nibble in CSR enum order, so N is bit 3 and C is bit 0.
-  auto n = F{.guest_access = RW, .bit_offset = 3, .bit_width = 1, .name = "N"};
-  auto z = F{.guest_access = RW, .bit_offset = 2, .bit_width = 1, .name = "Z"};
-  auto v = F{.guest_access = RW, .bit_offset = 1, .bit_width = 1, .name = "V"};
-  auto c = F{.guest_access = RW, .bit_offset = 0, .bit_width = 1, .name = "C"};
-  scan->expose(SR{.byte_width = 1,
-                  .guest_access = RW,
-                  .target = cid,
-                  .order = BE,
-                  .name = "NZVC",
-                  .fields = {n, z, v, c},
-                  .loc = Address(0)});
+  _regbank->set_initiator(id());
+  _csrs->set_initiator(id());
   const auto cpuid = id();
   // Expose call depth, which is useful for implementing step modes.
   // host_access defaults to ReadWrite, which is used by the trace buffer for step_back.
@@ -216,8 +176,8 @@ void PepISA3CPU::clock_tick(PulseSchedule::PulseIndex idx, u64 tick) {
   // data-dependence for the branch target.
   const auto pc_delta = _pc - init_pc;
   if ((pc_delta & 0b11) == pc_delta) {
-    _regbank->write_increment<u16, bits::host_is_le>(static_cast<u8>(isa::Pep10::Register::PC) * 2, _pc,
-                                                     op_data(), bits::Order::BigEndian);
+    _trace.emit_incr_register(op_data(), _regbank->ref(isa::Pep10::Register::PC), static_cast<i16>(pc_delta));
+    _regbank->write_pc_untraced(_pc);
   } else write_register_uncached(isa::Pep10::Register::PC, _pc);
   // TODO: handle breakpoints, debug info, etc
   record.commit();
@@ -252,13 +212,9 @@ void PepISA3CPU::decrement_call_depth() {
   _trace.emit_incr_register(op_data(), _ref_call_depth, -1);
 }
 
-// The CSR bank is one byte holding all four flags, N at bit 3 through C at bit 0, matching the packing at the ISA
-// layer. One access also means one trace record byte rather than 4
-u8 PepISA3CPU::read_packed_csr() { return static_cast<u8>(_csrs->read<u8, false>(0, op_data()).second & CSR_MASK); }
+u8 PepISA3CPU::read_packed_csr() const { return _csrs->read_packed(); }
 
-void PepISA3CPU::write_packed_csr(u8 value) {
-  _csrs->write<u8, false>(0, static_cast<u8>(value & CSR_MASK), op_data());
-}
+void PepISA3CPU::write_packed_csr(u8 value) { _csrs->write_packed(value); }
 
 void PepISA3CPU::handle(Op opcode) {
   using R = isa::Pep10::Register;

--- a/core/core/sim/cores/cpu/pep_isa.hpp
+++ b/core/core/sim/cores/cpu/pep_isa.hpp
@@ -41,8 +41,10 @@ public:
   PepISA3CPU(const PepISA3CPU &) = delete;
   PepISA3CPU &operator=(const PepISA3CPU &) = delete;
 
-  const Target *target() const;
-  Target *target();
+  // Explicitly inlined because clang was doing  apoor job of inlining these calls, and it's called millions of times
+  // per second.
+  inline const Target *target() const { return _target; }
+  inline Target *target() { return _target; }
 
   // Device interface
   void initialize(System *) override;

--- a/core/core/sim/cores/cpu/pep_isa.hpp
+++ b/core/core/sim/cores/cpu/pep_isa.hpp
@@ -8,9 +8,9 @@
 #include "core/sim/api/trace.hpp"
 #include "core/sim/debugger/register_scanner.hpp"
 #include "core/sim/debugger/trace_recorder.hpp"
-#include "core/sim/memory/ram/dense.hpp"
+#include "core/sim/cores/cpu/pep_csrbank.hpp"
+#include "core/sim/cores/cpu/pep_regbank.hpp"
 
-class Dense;
 
 /*
  * The following classes of instructions are still not tested. Those tests require a more complete system model to
@@ -77,16 +77,15 @@ public:
   template <typename RegisterType> u16 read_register_uncached(RegisterType reg);
   template <typename RegisterType> void write_register_uncached(RegisterType reg, u16 value);
   // The flags occupy the low nibble of the CSR bank's single byte, N at bit 3 through C at bit 0.
-  static constexpr u8 CSR_MASK = 0x0F;
   // Which bit of that nibble a given flag is.
   template <typename CSRType> static constexpr u8 csr_bit(CSRType csr);
   template <typename CSRType> bool read_csr(CSRType csr);
   template <typename CSRType> void write_csr(CSRType csr, bool value);
-  u8 read_packed_csr();
+  u8 read_packed_csr() const;
   void write_packed_csr(u8 value);
 
-  Dense *registers() const { return _regbank; }
-  Dense *csrs() const { return _csrs; }
+  PepRegisterBank *registers() const { return _regbank; }
+  PepCSRBank *csrs() const { return _csrs; }
 
   // No longer static const because it embeds this instance's id.
   Operation op_data() const { return _op_data; }
@@ -107,7 +106,8 @@ private:
   u16 _pc = 0;
   Configuration _config;
   trace::Recorder _trace;
-  Dense *_regbank = nullptr, *_csrs = nullptr;
+  PepRegisterBank *_regbank = nullptr;
+  PepCSRBank *_csrs = nullptr;
   Target *_target = nullptr;
   isa::OpcodePlane _opcodes;
   // Override this value once our id is known.
@@ -123,7 +123,8 @@ template <typename RegisterType> inline void PepISA3CPU::write_register(Register
 }
 
 template <typename RegisterType> inline void PepISA3CPU::write_register_uncached(RegisterType reg, u16 value) {
-  _regbank->write<u16, bits::host_is_le>(static_cast<u8>(reg) * 2, value, op_data());
+  // Pep9 and Pep10 declare identical Register enums, so the bank's is interchangeable with either.
+  _regbank->write(static_cast<PepRegisterBank::Register>(reg), value);
 }
 
 template <typename RegisterType> inline u16 PepISA3CPU::read_register(RegisterType reg) {
@@ -132,7 +133,7 @@ template <typename RegisterType> inline u16 PepISA3CPU::read_register(RegisterTy
 }
 
 template <typename RegisterType> inline u16 PepISA3CPU::read_register_uncached(RegisterType reg) {
-  return _regbank->read<u16, bits::host_is_le>(static_cast<u8>(reg) * 2, op_data()).second;
+  return _regbank->read(static_cast<PepRegisterBank::Register>(reg));
 }
 
 // All four flags live in one byte, so a single flag is a bit of it rather than a byte of its own. The enum runs

--- a/core/core/sim/cores/cpu/pep_isa.hpp
+++ b/core/core/sim/cores/cpu/pep_isa.hpp
@@ -65,6 +65,7 @@ public:
   void set_recorder(const trace::Recorder &recorder) override;
   bool can_generate_traces() const override;
   bool traced() const override;
+  void on_traced_changed(bool enabled) override;
   void trace(bool enabled) override;
 
   void increment_call_depth();
@@ -114,6 +115,9 @@ private:
   PepRegisterBank *_regbank = nullptr;
   PepCSRBank *_csrs = nullptr;
   Target *_target = nullptr;
+  // Mirror of the buffer's traced bit, pushed by TraceBuffer::trace. Read several times per instruction, and the
+  // reason the trace hooks below cost a branch rather than a call when tracing is off.
+  bool _may_trace = true;
   isa::OpcodePlane _opcodes;
   // Override this value once our id is known.
   Operation _op_data = Operation(Operation::Type::Standard, Operation::Kind::data, Device::ID{0});

--- a/core/core/sim/cores/cpu/pep_isa.hpp
+++ b/core/core/sim/cores/cpu/pep_isa.hpp
@@ -73,6 +73,11 @@ public:
   // Both redirect PC accesses to _pc.
   template <typename RegisterType> u16 read_register(RegisterType reg);
   template <typename RegisterType> void write_register(RegisterType reg, u16 value);
+  // Compile-time forms. PC is shadowed and every other register is not, so a runtime `reg` costs a branch on every
+  // access purely to ask a question the caller usually already knows the answer to. Where the register is fixed by
+  // the instruction's encoding, these fold to a member access with no branch at all.
+  template <PepRegisterBank::Register R> u16 read_register();
+  template <PepRegisterBank::Register R> void write_register(u16 value);
   // Same as above, but does not redirect PC access.
   template <typename RegisterType> u16 read_register_uncached(RegisterType reg);
   template <typename RegisterType> void write_register_uncached(RegisterType reg, u16 value);
@@ -130,6 +135,18 @@ template <typename RegisterType> inline void PepISA3CPU::write_register_uncached
 template <typename RegisterType> inline u16 PepISA3CPU::read_register(RegisterType reg) {
   if (reg == RegisterType::PC) return _pc;
   else return read_register_uncached(reg);
+}
+
+template <PepRegisterBank::Register R> inline u16 PepISA3CPU::read_register() {
+  // The shadow exists because PC is written many times per instruction and committed once, so it cannot come from
+  // the bank mid-instruction. Nothing else is shadowed, and this is where that stops costing a branch.
+  if constexpr (R == PepRegisterBank::Register::PC) return _pc;
+  else return _regbank->read<R>();
+}
+
+template <PepRegisterBank::Register R> inline void PepISA3CPU::write_register(u16 value) {
+  if constexpr (R == PepRegisterBank::Register::PC) _pc = value;
+  else _regbank->write<R>(value);
 }
 
 template <typename RegisterType> inline u16 PepISA3CPU::read_register_uncached(RegisterType reg) {

--- a/core/core/sim/cores/cpu/pep_isa.hpp
+++ b/core/core/sim/cores/cpu/pep_isa.hpp
@@ -8,6 +8,7 @@
 #include "core/sim/api/trace.hpp"
 #include "core/sim/debugger/register_scanner.hpp"
 #include "core/sim/debugger/trace_recorder.hpp"
+#include "core/sim/memory/ram/dense.hpp"
 
 class Dense;
 
@@ -118,7 +119,7 @@ template <typename RegisterType> inline void PepISA3CPU::write_register(Register
 }
 
 template <typename RegisterType> inline void PepISA3CPU::write_register_uncached(RegisterType reg, u16 value) {
-  ((Target *)_regbank)->write<u16, bits::host_is_le>(static_cast<u8>(reg) * 2, value, op_data());
+  _regbank->write<u16, bits::host_is_le>(static_cast<u8>(reg) * 2, value, op_data());
 }
 
 template <typename RegisterType> inline u16 PepISA3CPU::read_register(RegisterType reg) {
@@ -127,7 +128,7 @@ template <typename RegisterType> inline u16 PepISA3CPU::read_register(RegisterTy
 }
 
 template <typename RegisterType> inline u16 PepISA3CPU::read_register_uncached(RegisterType reg) {
-  return ((Target *)_regbank)->read<u16, bits::host_is_le>(static_cast<u8>(reg) * 2, op_data()).second;
+  return _regbank->read<u16, bits::host_is_le>(static_cast<u8>(reg) * 2, op_data()).second;
 }
 
 // All four flags live in one byte, so a single flag is a bit of it rather than a byte of its own. The enum runs

--- a/core/core/sim/cores/cpu/pep_isa.hpp
+++ b/core/core/sim/cores/cpu/pep_isa.hpp
@@ -87,7 +87,7 @@ public:
   Dense *csrs() const { return _csrs; }
 
   // No longer static const because it embeds this instance's id.
-  Operation op_data() const { return Operation(Operation::Type::Standard, Operation::Kind::data, id()); }
+  Operation op_data() const { return _op_data; }
 
   // While an instruction is in flight, this contains the active PC.
   // At the end of an instruction, it will be written back with the updated value.
@@ -108,6 +108,8 @@ private:
   Dense *_regbank = nullptr, *_csrs = nullptr;
   Target *_target = nullptr;
   isa::OpcodePlane _opcodes;
+  // Override this value once our id is known.
+  Operation _op_data = Operation(Operation::Type::Standard, Operation::Kind::data, Device::ID{0});
 
   void handle(isa::SharedOp opcode);
   const ClockSource *_clk = nullptr;

--- a/core/core/sim/cores/cpu/pep_isa_instructions.cpp
+++ b/core/core/sim/cores/cpu/pep_isa_instructions.cpp
@@ -2,6 +2,9 @@
 #include "core/sim/cores/cpu/pep_csrbank.hpp"
 #include "core/sim/cores/cpu/pep_isa.hpp"
 
+// The two ISAs declare identical Register enums, so one alias serves both.
+using R = isa::Pep10::Register;
+
 u16 decode_op_addr(PepISA3CPU *self, isa::SharedAddrMode addr) {
   // Fetch current PC
   u16 pc = self->read_pc();
@@ -10,7 +13,7 @@ u16 decode_op_addr(PepISA3CPU *self, isa::SharedAddrMode addr) {
   auto target = self->target();
   // Read value at mem[PC] into OS register.
   u16 opr = target->read<u16, bits::host_is_le>(pc, self->op_data()).second;
-  self->write_register(isa::Pep10::Register::OS, opr);
+  self->write_register<R::OS>(opr);
 
   switch (addr) {
   case isa::SharedAddrMode::I: return pc;
@@ -18,16 +21,16 @@ u16 decode_op_addr(PepISA3CPU *self, isa::SharedAddrMode addr) {
   case isa::SharedAddrMode::D: return opr;
 
   case isa::SharedAddrMode::SF:
-    opr = self->read_register(isa::Pep10::Register::SP) + opr;
+    opr = self->read_register<R::SP>() + opr;
     return self->target()->read<u16, bits::host_is_le>(opr, self->op_data()).second;
 
-  case isa::SharedAddrMode::S: return self->read_register(isa::Pep10::Register::SP) + opr;
-  case isa::SharedAddrMode::X: return self->read_register(isa::Pep10::Register::X) + opr;
+  case isa::SharedAddrMode::S: return self->read_register<R::SP>() + opr;
+  case isa::SharedAddrMode::X: return self->read_register<R::X>() + opr;
   case isa::SharedAddrMode::SX:
-    return self->read_register(isa::Pep10::Register::X) + self->read_register(isa::Pep10::Register::SP) + opr;
+    return self->read_register<R::X>() + self->read_register<R::SP>() + opr;
   case isa::SharedAddrMode::SFX:
-    opr = self->read_register(isa::Pep10::Register::SP) + opr;
-    return self->read_register(isa::Pep10::Register::X) + self->target()->read<u16, bits::host_is_le>(opr, self->op_data()).second;
+    opr = self->read_register<R::SP>() + opr;
+    return self->read_register<R::X>() + self->target()->read<u16, bits::host_is_le>(opr, self->op_data()).second;
   }
   throw std::logic_error("Invalid addressing mode for decode_op_addr");
 }
@@ -36,10 +39,10 @@ void unimpl_handler(PepISA3CPU *) { throw std::logic_error("Unimplemented instru
 
 void handle_ret(PepISA3CPU *self) {
   self->decrement_call_depth();
-  u16 sp = self->read_register(isa::Pep10::Register::SP);
+  u16 sp = self->read_register<R::SP>();
   auto addr = self->target()->read<u16, bits::host_is_le>(sp, self->op_data()).second;
   self->write_pc(addr);
-  self->write_register(isa::Pep10::Register::SP, sp + 2);
+  self->write_register<R::SP>(sp + 2);
   // TODO: notify debugger of ret @ PC
 }
 
@@ -54,7 +57,7 @@ void handle_sret(PepISA3CPU *self) {
   // Then we can do a single write back to _regs and only generate 1 trace
   // packet.
   auto regs = self->registers();
-  u16 sp = self->read_register(isa::Pep10::Register::SP);
+  u16 sp = self->read_register<R::SP>();
   u16 tmp = size_inclusive(regs->span());
   regs->read(0, {ctx, tmp}, self->op_data());
 
@@ -81,7 +84,7 @@ void handle_sret(PepISA3CPU *self) {
   // That write covered PC, restoring it from the stack. Hand it to the working copy, or clock_tick's single store
   // would put the pre-instruction value straight back over it. Read it back through the bank rather than picking it
   // out of ctx so this stays independent of the context block's layout and byte order.
-  self->write_pc(self->read_register(isa::Pep10::Register::PC));
+  self->write_pc(self->read_register<R::PC>());
 
   tmp = sp + 12;
   // Using "host"'s variables, so byte swap if necessary.
@@ -98,22 +101,22 @@ void handle_sret(PepISA3CPU *self) {
 
 void handle_movflga(PepISA3CPU *self) {
   auto nzvc = self->read_packed_csr();
-  self->write_register(isa::Pep10::Register::A, nzvc);
+  self->write_register<R::A>(nzvc);
 }
 
 void handle_movaflg(PepISA3CPU *self) {
-  auto nzvc = self->read_register(isa::Pep10::Register::A);
+  auto nzvc = self->read_register<R::A>();
   self->write_packed_csr(nzvc);
 }
 
 void handle_movspa(PepISA3CPU *self) {
-  auto sp = self->read_register(isa::Pep10::Register::SP);
-  self->write_register(isa::Pep10::Register::A, sp);
+  auto sp = self->read_register<R::SP>();
+  self->write_register<R::A>(sp);
 }
 
 void handle_movasp(PepISA3CPU *self) {
-  auto a = self->read_register(isa::Pep10::Register::A);
-  self->write_register(isa::Pep10::Register::SP, a);
+  auto a = self->read_register<R::A>();
+  self->write_register<R::SP>(a);
 }
 
 void handle_nop(PepISA3CPU *) {}
@@ -225,9 +228,9 @@ void handle_unconditional_branch(PepISA3CPU *self, Op op, u16 op_addr) {
 void handle_call(PepISA3CPU *self, Op op, u16 op_addr) {
   const u16 op_spec = self->target()->read<u16, bits::host_is_le>(op_addr, self->op_data()).second;
   const u16 pc = self->read_pc();
-  u16 sp = self->read_register(isa::Pep10::Register::SP);
+  u16 sp = self->read_register<R::SP>();
   self->target()->write<u16, bits::host_is_le>(sp -= 2, pc, self->op_data());
-  self->write_register(isa::Pep10::Register::SP, sp);
+  self->write_register<R::SP>(sp);
   self->write_pc(op_spec);
   self->increment_call_depth();
   // TODO: if (_dbg) _dbg->notifyCall(pc - 3, sp);
@@ -235,15 +238,15 @@ void handle_call(PepISA3CPU *self, Op op, u16 op_addr) {
 
 void handle_addsp(PepISA3CPU *self, Op op, u16 op_addr) {
   const u16 op_spec = self->target()->read<u16, bits::host_is_le>(op_addr, self->op_data()).second;
-  const auto sp = self->read_register(isa::Pep10::Register::SP) + op_spec;
-  self->write_register(isa::Pep10::Register::SP, sp);
+  const auto sp = self->read_register<R::SP>() + op_spec;
+  self->write_register<R::SP>(sp);
   // TODO: if (_dbg) _dbg->notifyAddSP(pc - 3, sp);
 }
 
 void handle_subsp(PepISA3CPU *self, Op op, u16 op_addr) {
   const u16 op_spec = self->target()->read<u16, bits::host_is_le>(op_addr, self->op_data()).second;
-  const auto sp = self->read_register(isa::Pep10::Register::SP) - op_spec;
-  self->write_register(isa::Pep10::Register::SP, sp);
+  const auto sp = self->read_register<R::SP>() - op_spec;
+  self->write_register<R::SP>(sp);
   // TODO: if (_dbg) _dbg->notifySubSP(pc - 3, sp);
 }
 

--- a/core/core/sim/cores/cpu/pep_isa_instructions.cpp
+++ b/core/core/sim/cores/cpu/pep_isa_instructions.cpp
@@ -1,23 +1,6 @@
 #include "pep_isa_instructions.hpp"
+#include "core/sim/cores/cpu/pep_csrbank.hpp"
 #include "core/sim/cores/cpu/pep_isa.hpp"
-#include "core/sim/memory/ram/dense.hpp"
-
-u8 pack_csr(bool n, bool z, bool v, bool c) {
-  u8 nzvc = 0;
-  if (n) nzvc |= 1 << 3;
-  if (z) nzvc |= 1 << 2;
-  if (v) nzvc |= 1 << 1;
-  if (c) nzvc |= 1 << 0;
-  return nzvc;
-}
-
-std::tuple<bool, bool, bool, bool> unpack_csrs(u8 nzvc) {
-  bool n = nzvc & (1 << 3);
-  bool z = nzvc & (1 << 2);
-  bool v = nzvc & (1 << 1);
-  bool c = nzvc & (1 << 0);
-  return {n, z, v, c};
-}
 
 u16 decode_op_addr(PepISA3CPU *self, isa::SharedAddrMode addr) {
   // Fetch current PC
@@ -92,8 +75,9 @@ void handle_sret(PepISA3CPU *self) {
   // Load SP into ctx
   memory->read(sp + 7, {ctx + 2 * static_cast<u8>(isa::Pep10::Register::SP), 2}, self->op_data());
 
-  // Bulk write-back regs, saving a number of bits on trace metadata.
-  regs->write(0, {ctx, registersBytes}, self->op_data());
+  // Bulk write-back regs, saving a number of bits on trace metadata. Sized from the bank rather than from
+  // RegisterCount, which counts one more than there are registers.
+  regs->write(0, {ctx, tmp}, self->op_data());
   // That write covered PC, restoring it from the stack. Hand it to the working copy, or clock_tick's single store
   // would put the pre-instruction value straight back over it. Read it back through the bank rather than picking it
   // out of ctx so this stays independent of the context block's layout and byte order.
@@ -142,7 +126,7 @@ void handle_negr(PepISA3CPU *self, isa::Pep10::Register reg) {
   bool v = tmp == 0x8000;
   bool c = src == 0x0000;
   self->write_register(reg, tmp);
-  self->write_packed_csr(pack_csr(n, z, v, c));
+  self->write_packed_csr(PepCSRBank::pack(n, z, v, c));
 }
 
 void handle_aslr(PepISA3CPU *self, isa::Pep10::Register reg) {
@@ -160,7 +144,7 @@ void handle_aslr(PepISA3CPU *self, isa::Pep10::Register reg) {
   // Carry out if register starts with high order 1.
   bool c = src & 0x8000;
   self->write_register(reg, tmp);
-  self->write_packed_csr(pack_csr(n, z, v, c));
+  self->write_packed_csr(PepCSRBank::pack(n, z, v, c));
 }
 
 void handle_asrr(PepISA3CPU *self, isa::Pep10::Register reg) {
@@ -176,22 +160,22 @@ void handle_asrr(PepISA3CPU *self, isa::Pep10::Register reg) {
   bool c = src & 0x1;
   bool v = 0;
   self->write_register(reg, tmp);
-  self->write_packed_csr(pack_csr(n, z, v, c));
+  self->write_packed_csr(PepCSRBank::pack(n, z, v, c));
 }
 
 void handle_notr(PepISA3CPU *self, isa::Pep10::Register reg) {
   auto src = self->read_register(reg);
-  auto [n, z, v, c] = unpack_csrs(self->read_packed_csr());
+  auto [n, z, v, c] = PepCSRBank::unpack(self->read_packed_csr());
   u16 tmp = ~src;
   n = tmp & 0x8000;
   z = tmp == 0x0000;
   self->write_register(reg, tmp);
-  self->write_packed_csr(pack_csr(n, z, v, c));
+  self->write_packed_csr(PepCSRBank::pack(n, z, v, c));
 }
 
 void handle_rolr(PepISA3CPU *self, isa::Pep10::Register reg) {
   auto src = self->read_register(reg);
-  auto [n, z, v, c] = unpack_csrs(self->read_packed_csr());
+  auto [n, z, v, c] = PepCSRBank::unpack(self->read_packed_csr());
   // Shift the carry in to low order bit.
   u16 tmp = static_cast<u16>(src << 1 | (c ? 1 : 0));
   n = tmp & 0x8000;
@@ -199,12 +183,12 @@ void handle_rolr(PepISA3CPU *self, isa::Pep10::Register reg) {
   // Carry out if register starts with high order 1.
   c = src & 0x8000;
   self->write_register(reg, tmp);
-  self->write_packed_csr(pack_csr(n, z, v, c));
+  self->write_packed_csr(PepCSRBank::pack(n, z, v, c));
 }
 
 void handle_rorr(PepISA3CPU *self, isa::Pep10::Register reg) {
   auto src = self->read_register(reg);
-  auto [n, z, v, c] = unpack_csrs(self->read_packed_csr());
+  auto [n, z, v, c] = PepCSRBank::unpack(self->read_packed_csr());
   // Shift the carry in to high order bit.
   u16 tmp = src >> 1 | (c ? 1 << 15 : 0);
   n = tmp & 0x8000;
@@ -212,11 +196,11 @@ void handle_rorr(PepISA3CPU *self, isa::Pep10::Register reg) {
   // Carry out if register starts with low order 1.
   c = src & 0x1;
   self->write_register(reg, tmp);
-  self->write_packed_csr(pack_csr(n, z, v, c));
+  self->write_packed_csr(PepCSRBank::pack(n, z, v, c));
 }
 
 void handle_branch(PepISA3CPU *self, Op op, BranchCondition cond, u16 op_addr) {
-  const auto [n, z, v, c] = unpack_csrs(self->read_packed_csr());
+  const auto [n, z, v, c] = PepCSRBank::unpack(self->read_packed_csr());
   const u16 op_spec = self->target()->read<u16, bits::host_is_le>(op_addr, self->op_data()).second;
   bool taken;
   switch (cond) {
@@ -280,7 +264,7 @@ void handle_addr(PepISA3CPU *self, Op op, u16 op_addr) {
   // Carry out iff result is unsigned less than register or operand.
   bool c = tmp < src || tmp < op_spec;
   self->write_register(reg, tmp);
-  self->write_packed_csr(pack_csr(n, z, v, c));
+  self->write_packed_csr(PepCSRBank::pack(n, z, v, c));
 }
 
 void handle_subr(PepISA3CPU *self, Op op, u16 op_addr) {
@@ -300,14 +284,14 @@ void handle_subr(PepISA3CPU *self, Op op, u16 op_addr) {
   // Carry out iff result is unsigned less than register or operand.
   bool c = tmp < src || tmp < static_cast<u16>(1 + ~operand);
   self->write_register(reg, tmp);
-  self->write_packed_csr(pack_csr(n, z, v, c));
+  self->write_packed_csr(PepCSRBank::pack(n, z, v, c));
 }
 
 void handle_bitopr(PepISA3CPU *self, Op op, Bitop bitop, u16 op_addr) {
   const isa::Pep10::Register reg = static_cast<isa::Pep10::Register>(op.target);
   const u16 op_spec = self->target()->read<u16, bits::host_is_le>(op_addr, self->op_data()).second;
   const u16 src = self->read_register(reg);
-  auto [n, z, v, c] = unpack_csrs(self->read_packed_csr());
+  auto [n, z, v, c] = PepCSRBank::unpack(self->read_packed_csr());
   u16 tmp;
   switch (bitop) {
   case Bitop::AND: tmp = src & op_spec; break;
@@ -319,7 +303,7 @@ void handle_bitopr(PepISA3CPU *self, Op op, Bitop bitop, u16 op_addr) {
   // Is zero if all bits are 0's.
   z = tmp == 0x0000;
   self->write_register(reg, tmp);
-  self->write_packed_csr(pack_csr(n, z, v, c));
+  self->write_packed_csr(PepCSRBank::pack(n, z, v, c));
 }
 
 void handle_cpwr(PepISA3CPU *self, Op op, u16 op_addr) {
@@ -341,7 +325,7 @@ void handle_cpwr(PepISA3CPU *self, Op op, u16 op_addr) {
   bool c = tmp < src || tmp < neg;
   // Invert N bit if there was signed overflow.
   n ^= v;
-  self->write_packed_csr(pack_csr(n, z, v, c));
+  self->write_packed_csr(PepCSRBank::pack(n, z, v, c));
 }
 
 void handle_cpbr(PepISA3CPU *self, Op op, u16 op_addr) {
@@ -356,32 +340,32 @@ void handle_cpbr(PepISA3CPU *self, Op op, u16 op_addr) {
   // Is zero if all bits are 0's.
   bool z = tmp == 0x00;
   // RTL specifies that VC get 0.
-  self->write_packed_csr(pack_csr(n, z, 0, 0));
+  self->write_packed_csr(PepCSRBank::pack(n, z, 0, 0));
 }
 
 void handle_ldwr(PepISA3CPU *self, Op op, u16 op_addr) {
   const isa::Pep10::Register reg = static_cast<isa::Pep10::Register>(op.target);
   const u16 op_spec = self->target()->read<u16, bits::host_is_le>(op_addr, self->op_data()).second;
-  auto [n, z, v, c] = unpack_csrs(self->read_packed_csr());
+  auto [n, z, v, c] = PepCSRBank::unpack(self->read_packed_csr());
   // Is negative if high order bit is 1.
   n = op_spec & 0x8000;
   z = op_spec == 0x0000;
 
   self->write_register(reg, op_spec);
-  self->write_packed_csr(pack_csr(n, z, v, c));
+  self->write_packed_csr(PepCSRBank::pack(n, z, v, c));
 }
 
 void handle_ldbr(PepISA3CPU *self, Op op, u16 op_addr) {
   const isa::Pep10::Register reg = static_cast<isa::Pep10::Register>(op.target);
   // op_addr is address for 2-byte operands, so we need an offset of 1.
   const u8 op_spec = self->target()->read<u8>(op_addr + 1, self->op_data()).second;
-  auto [n, z, v, c] = unpack_csrs(self->read_packed_csr());
+  auto [n, z, v, c] = PepCSRBank::unpack(self->read_packed_csr());
   // LDBr always clears n.
   n = 0;
   z = op_spec == 0x0000;
 
   self->write_register(reg, op_spec);
-  self->write_packed_csr(pack_csr(n, z, v, c));
+  self->write_packed_csr(PepCSRBank::pack(n, z, v, c));
 }
 
 void handle_stwr(PepISA3CPU *self, Op op, u16 op_addr) {

--- a/core/core/sim/cores/cpu/pep_isa_instructions.cpp
+++ b/core/core/sim/cores/cpu/pep_isa_instructions.cpp
@@ -233,6 +233,11 @@ void handle_branch(PepISA3CPU *self, Op op, BranchCondition cond, u16 op_addr) {
   if (taken) self->write_pc(op_spec);
 }
 
+void handle_unconditional_branch(PepISA3CPU *self, Op op, u16 op_addr) {
+  const u16 op_spec = self->target()->read<u16, bits::host_is_le>(op_addr, self->op_data()).second;
+  self->write_pc(op_spec);
+}
+
 void handle_call(PepISA3CPU *self, Op op, u16 op_addr) {
   const u16 op_spec = self->target()->read<u16, bits::host_is_le>(op_addr, self->op_data()).second;
   const u16 pc = self->read_pc();

--- a/core/core/sim/cores/cpu/pep_isa_instructions.hpp
+++ b/core/core/sim/cores/cpu/pep_isa_instructions.hpp
@@ -7,8 +7,6 @@ class PepISA3CPU;
 
 using Op = isa::SharedOp;
 
-u8 pack_csr(bool n, bool z, bool v, bool c);
-std::tuple<bool, bool, bool, bool> unpack_csrs(u8 nzvc);
 
 // Read word at Mem[PC] and store to OS, incrementing PC by 2.
 // Return the /address/ of the operand value, which is usable for both load and store instructions.

--- a/core/core/sim/cores/cpu/pep_isa_instructions.hpp
+++ b/core/core/sim/cores/cpu/pep_isa_instructions.hpp
@@ -36,6 +36,8 @@ void handle_rorr(PepISA3CPU *self, isa::Pep10::Register reg);
 enum class BranchCondition { UNCONDITIONAL, LE, LT, EQ, NE, GE, GT, V, C };
 
 void handle_branch(PepISA3CPU *self, Op op, BranchCondition cond, u16 op_addr);
+// Specialization of handle_branch() which executes more efficiently.
+void handle_unconditional_branch(PepISA3CPU *self, Op op, u16 op_addr);
 void handle_call(PepISA3CPU *self, Op op, u16 op_addr);
 
 void handle_addsp(PepISA3CPU *self, Op op, u16 op_addr);

--- a/core/core/sim/cores/cpu/pep_regbank.cpp
+++ b/core/core/sim/cores/cpu/pep_regbank.cpp
@@ -57,41 +57,37 @@ void PepRegisterBank::set_initiator(Device::ID cpu) {
   _op = Operation(Operation::Type::Standard, Operation::Kind::data, cpu);
 }
 
-template <std::integral I> void PepRegisterBank::store(Register reg, I &slot, I value, Operation op) {
-  // The xor is one instruction here, where both values are already in hand -- which is why the recorder takes them
-  // combined rather than fetching the prior value itself.
-  if (_traced) _trace.emit_write_register(op, _refs[static_cast<u8>(reg)], static_cast<I>(slot ^ value));
-  slot = value;
-}
+void PepRegisterBank::write_a(u16 value) { write<Register::A>(value); }
+void PepRegisterBank::write_x(u16 value) { write<Register::X>(value); }
+void PepRegisterBank::write_sp(u16 value) { write<Register::SP>(value); }
+void PepRegisterBank::write_pc(u16 value) { write<Register::PC>(value); }
+void PepRegisterBank::write_os(u16 value) { write<Register::OS>(value); }
+// Truncating rather than refusing: IS is a byte, and every caller that writes it is handing over an opcode.
+void PepRegisterBank::write_is(u8 value) { write<Register::IS>(value); }
 
-void PepRegisterBank::write_a(u16 value) { store(Register::A, _a, value, _op); }
-void PepRegisterBank::write_x(u16 value) { store(Register::X, _x, value, _op); }
-void PepRegisterBank::write_sp(u16 value) { store(Register::SP, _sp, value, _op); }
-void PepRegisterBank::write_pc(u16 value) { store(Register::PC, _pc, value, _op); }
-void PepRegisterBank::write_os(u16 value) { store(Register::OS, _os, value, _op); }
-void PepRegisterBank::write_is(u8 value) { store(Register::IS, _is, value, _op); }
-
+// The runtime forms, for the few callers that genuinely do not know the register until they have decoded something.
+// Both forward to the compile-time form rather than repeating the mapping, so a register cannot be wired up correctly
+// in one of these and wrongly in the other.
 u16 PepRegisterBank::read(Register reg) const {
   switch (reg) {
-  case Register::A: return _a;
-  case Register::X: return _x;
-  case Register::SP: return _sp;
-  case Register::PC: return _pc;
-  case Register::IS: return _is;
-  case Register::OS: return _os;
+  case Register::A: return read<Register::A>();
+  case Register::X: return read<Register::X>();
+  case Register::SP: return read<Register::SP>();
+  case Register::PC: return read<Register::PC>();
+  case Register::IS: return read<Register::IS>();
+  case Register::OS: return read<Register::OS>();
   default: return 0;
   }
 }
 
 void PepRegisterBank::write(Register reg, u16 value) {
   switch (reg) {
-  case Register::A: write_a(value); break;
-  case Register::X: write_x(value); break;
-  case Register::SP: write_sp(value); break;
-  case Register::PC: write_pc(value); break;
-  // Truncating rather than refusing: IS is a byte, and every caller that writes it is handing over an opcode.
-  case Register::IS: write_is(static_cast<u8>(value)); break;
-  case Register::OS: write_os(value); break;
+  case Register::A: write<Register::A>(value); break;
+  case Register::X: write<Register::X>(value); break;
+  case Register::SP: write<Register::SP>(value); break;
+  case Register::PC: write<Register::PC>(value); break;
+  case Register::IS: write<Register::IS>(value); break;
+  case Register::OS: write<Register::OS>(value); break;
   default: break;
   }
 }

--- a/core/core/sim/cores/cpu/pep_regbank.cpp
+++ b/core/core/sim/cores/cpu/pep_regbank.cpp
@@ -65,33 +65,6 @@ void PepRegisterBank::write_os(u16 value) { write<Register::OS>(value); }
 // Truncating rather than refusing: IS is a byte, and every caller that writes it is handing over an opcode.
 void PepRegisterBank::write_is(u8 value) { write<Register::IS>(value); }
 
-// The runtime forms, for the few callers that genuinely do not know the register until they have decoded something.
-// Both forward to the compile-time form rather than repeating the mapping, so a register cannot be wired up correctly
-// in one of these and wrongly in the other.
-u16 PepRegisterBank::read(Register reg) const {
-  switch (reg) {
-  case Register::A: return read<Register::A>();
-  case Register::X: return read<Register::X>();
-  case Register::SP: return read<Register::SP>();
-  case Register::PC: return read<Register::PC>();
-  case Register::IS: return read<Register::IS>();
-  case Register::OS: return read<Register::OS>();
-  default: return 0;
-  }
-}
-
-void PepRegisterBank::write(Register reg, u16 value) {
-  switch (reg) {
-  case Register::A: write<Register::A>(value); break;
-  case Register::X: write<Register::X>(value); break;
-  case Register::SP: write<Register::SP>(value); break;
-  case Register::PC: write<Register::PC>(value); break;
-  case Register::IS: write<Register::IS>(value); break;
-  case Register::OS: write<Register::OS>(value); break;
-  default: break;
-  }
-}
-
 RegisterScan::RegisterRef PepRegisterBank::ref(Register reg) const {
   const auto index = static_cast<u8>(reg);
   return index < REGISTER_COUNT ? _refs[index] : RegisterScan::RegisterRef{};

--- a/core/core/sim/cores/cpu/pep_regbank.cpp
+++ b/core/core/sim/cores/cpu/pep_regbank.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "core/sim/cores/cpu/pep_regbank.hpp"
+#include "core/sim/memory/errors.hpp"
+#include "core/sim/system.hpp"
+
+namespace {
+// Register N occupies bytes [N*2, N*2+1], most significant first. That is the layout the Dense this replaces held,
+// so an address-based caller sees exactly what it saw before.
+constexpr u8 slot_of(Address at) { return static_cast<u8>(at / 2); }
+constexpr bool is_high_byte(Address at) { return (at % 2) == 0; }
+
+} // namespace
+
+PepRegisterBank::PepRegisterBank(Configuration config) : Device(), _config(config) {}
+
+void PepRegisterBank::initialize(System *sys) {
+  using SR = RegisterScan::Register;
+  auto *scan = sys->register_scan();
+  // Pointer-backed and host order: the scan reads the member directly, with no target lookup and no byte swap.
+  const auto expose = [&](Register reg, const char *name, auto *slot) {
+    SR r{};
+    r.byte_width = sizeof(*slot);
+    r.order = bits::hostOrder();
+    r.target = id();
+    r.name = name;
+    r.loc = slot;
+    _refs[static_cast<u8>(reg)] = scan->expose(r);
+  };
+  expose(Register::A, "A", &_a);
+  expose(Register::X, "X", &_x);
+  expose(Register::SP, "SP", &_sp);
+  expose(Register::PC, "PC", &_pc);
+  expose(Register::IS, "IS", &_is);
+  expose(Register::OS, "OS", &_os);
+}
+
+void PepRegisterBank::reset() {
+  _a = _x = _sp = _pc = _os = 0;
+  _is = 0;
+}
+
+void PepRegisterBank::set_initiator(Device::ID cpu) {
+  _op = Operation(Operation::Type::Standard, Operation::Kind::data, cpu);
+}
+
+template <std::integral I> void PepRegisterBank::store(Register reg, I &slot, I value, Operation op) {
+  // The xor is one instruction here, where both values are already in hand -- which is why the recorder takes them
+  // combined rather than fetching the prior value itself.
+  if (_traced) _trace.emit_write_register(op, _refs[static_cast<u8>(reg)], static_cast<I>(slot ^ value));
+  slot = value;
+}
+
+void PepRegisterBank::write_a(u16 value) { store(Register::A, _a, value, _op); }
+void PepRegisterBank::write_x(u16 value) { store(Register::X, _x, value, _op); }
+void PepRegisterBank::write_sp(u16 value) { store(Register::SP, _sp, value, _op); }
+void PepRegisterBank::write_pc(u16 value) { store(Register::PC, _pc, value, _op); }
+void PepRegisterBank::write_os(u16 value) { store(Register::OS, _os, value, _op); }
+void PepRegisterBank::write_is(u8 value) { store(Register::IS, _is, value, _op); }
+
+u16 PepRegisterBank::read(Register reg) const {
+  switch (reg) {
+  case Register::A: return _a;
+  case Register::X: return _x;
+  case Register::SP: return _sp;
+  case Register::PC: return _pc;
+  case Register::IS: return _is;
+  case Register::OS: return _os;
+  default: return 0;
+  }
+}
+
+void PepRegisterBank::write(Register reg, u16 value) {
+  switch (reg) {
+  case Register::A: write_a(value); break;
+  case Register::X: write_x(value); break;
+  case Register::SP: write_sp(value); break;
+  case Register::PC: write_pc(value); break;
+  // Truncating rather than refusing: IS is a byte, and every caller that writes it is handing over an opcode.
+  case Register::IS: write_is(static_cast<u8>(value)); break;
+  case Register::OS: write_os(value); break;
+  default: break;
+  }
+}
+
+RegisterScan::RegisterRef PepRegisterBank::ref(Register reg) const {
+  const auto index = static_cast<u8>(reg);
+  return index < REGISTER_COUNT ? _refs[index] : RegisterScan::RegisterRef{};
+}
+
+const Device::Configuration &PepRegisterBank::config() const { return _config; }
+const PepRegisterBank::Configuration &PepRegisterBank::casted_config() const { return _config; }
+const Device::ID PepRegisterBank::id() const { return _config.id; }
+
+Device::Type PepRegisterBank::type() const {
+  using namespace bits;
+  using T = Device::Type;
+  return T::MemoryTarget | T::Traceable;
+}
+
+std::unique_ptr<DeviceSerializer> PepRegisterBank::serializer() const {
+  // Should never be called: the CPU builds this with skip_serialize = true.
+  throw std::logic_error("PepRegisterBank is synthetic and has no serialized form");
+}
+
+void PepRegisterBank::set_recorder(const trace::Recorder &recorder) { _trace = recorder; }
+bool PepRegisterBank::can_generate_traces() const { return true; }
+void PepRegisterBank::trace(bool enabled) { _trace.set_traced(enabled); }
+bool PepRegisterBank::traced() const { return _traced; }
+void PepRegisterBank::on_traced_changed(bool enabled) { _traced = enabled; }
+
+AddressSpan PepRegisterBank::span() const { return AddressSpan(0, REGISTER_COUNT * 2 - 1); }
+
+Target::Result PepRegisterBank::read(Address address, bits::span<u8> dest, Operation op) const {
+  using E = Error;
+  const auto bounds = span();
+  const auto max_addr = (address + std::max<Address>(0, dest.size() - 1));
+  if (address < bounds.lower() || max_addr > bounds.upper()) throw E(E::Type::OOBAccess, address);
+  // Byte at a time, because a caller may start or end mid-register and the halves come from one host-order member.
+  for (std::size_t i = 0; i < dest.size(); ++i) {
+    const Address at = address + static_cast<Address>(i);
+    const u16 value = read(static_cast<Register>(slot_of(at)));
+    dest[i] = is_high_byte(at) ? static_cast<u8>(value >> 8) : static_cast<u8>(value & 0xFF);
+  }
+  return {};
+}
+
+Target::Result PepRegisterBank::write(Address address, bits::span<const u8> src, Operation op) {
+  using E = Error;
+  const auto bounds = span();
+  const auto max_addr = (address + std::max<Address>(0, src.size() - 1));
+  if (address < bounds.lower() || max_addr > bounds.upper()) throw E(E::Type::OOBAccess, address);
+  // Read-modify-write per register with one trace emitted per register. A write covering half a reigster needs to emit
+  // a full SETREGX, with the unused half being 0s. handle_sret exists to reduce the number of traces emitted for bulk
+  // register writeback.
+  std::size_t i = 0;
+  while (i < src.size()) {
+    const auto slot = slot_of(address + static_cast<Address>(i));
+    const auto reg = static_cast<Register>(slot);
+    u16 value = read(reg);
+    // Consume every byte of this register present in src before recording anything.
+    while (i < src.size() && slot_of(address + static_cast<Address>(i)) == slot) {
+      const Address at = address + static_cast<Address>(i);
+      value = is_high_byte(at) ? static_cast<u16>((value & 0x00FF) | (u16(src[i]) << 8))
+                               : static_cast<u16>((value & 0xFF00) | src[i]);
+      ++i;
+    }
+    write_slot(reg, value, op);
+  }
+  return {};
+}
+
+void PepRegisterBank::write_slot(Register reg, u16 value, Operation op) {
+  switch (reg) {
+  case Register::A: store(reg, _a, value, op); break;
+  case Register::X: store(reg, _x, value, op); break;
+  case Register::SP: store(reg, _sp, value, op); break;
+  case Register::PC: store(reg, _pc, value, op); break;
+  case Register::OS: store(reg, _os, value, op); break;
+  case Register::IS: store(reg, _is, static_cast<u8>(value & 0xFF), op); break;
+  default: break;
+  }
+}
+
+void PepRegisterBank::clear(u8 fill) {
+  // TODO: emit a "clear" trace to TB.
+  const auto wide = static_cast<u16>((u16(fill) << 8) | fill);
+  _a = _x = _sp = _pc = _os = wide;
+  _is = fill;
+}
+
+void PepRegisterBank::dump(bits::span<u8> dest) const {
+  if (dest.size() <= 0) throw std::logic_error("dump requires non-0 size");
+  for (std::size_t i = 0; i < dest.size(); ++i) {
+    const auto slot = slot_of(static_cast<Address>(i));
+    const u16 value = slot < REGISTER_COUNT ? read(static_cast<Register>(slot)) : 0;
+    dest[i] = is_high_byte(static_cast<Address>(i)) ? static_cast<u8>(value >> 8) : static_cast<u8>(value & 0xFF);
+  }
+}

--- a/core/core/sim/cores/cpu/pep_regbank.hpp
+++ b/core/core/sim/cores/cpu/pep_regbank.hpp
@@ -42,13 +42,37 @@ public:
   PepRegisterBank &operator=(const PepRegisterBank &) = delete;
 
   // --- Typed access.
-  u16 read_a() const { return _a; }
-  u16 read_x() const { return _x; }
-  u16 read_sp() const { return _sp; }
-  u16 read_pc() const { return _pc; }
-  u16 read_os() const { return _os; }
+  //
+  // Expose an inline form which the compile should be able to reason about when the register is variable (but known at
+  // compile time). All other versions forward to this one, because profiling data suggests the compiler is as smart as
+  // I expect.
+  template <Register R> auto read() const {
+    if constexpr (R == Register::A) return _a;
+    else if constexpr (R == Register::X) return _x;
+    else if constexpr (R == Register::SP) return _sp;
+    else if constexpr (R == Register::PC) return _pc;
+    else if constexpr (R == Register::IS) return _is;
+    else if constexpr (R == Register::OS) return _os;
+    else static_assert(false, "no storage backs that register");
+  }
+  template <Register R> void write(u16 value) {
+    if constexpr (R == Register::IS) store(R, _is, static_cast<u8>(value), _op);
+    else if constexpr (R == Register::A) store(R, _a, value, _op);
+    else if constexpr (R == Register::X) store(R, _x, value, _op);
+    else if constexpr (R == Register::SP) store(R, _sp, value, _op);
+    else if constexpr (R == Register::PC) store(R, _pc, value, _op);
+    else if constexpr (R == Register::OS) store(R, _os, value, _op);
+    else static_assert(false, "no storage backs that register");
+  }
+
+  // Named forms, for readability where the name is what the caller is thinking in.
+  u16 read_a() const { return read<Register::A>(); }
+  u16 read_x() const { return read<Register::X>(); }
+  u16 read_sp() const { return read<Register::SP>(); }
+  u16 read_pc() const { return read<Register::PC>(); }
+  u16 read_os() const { return read<Register::OS>(); }
   // One byte, and stored as a single u8 to avoid masking a u16 to one byte on each operation.
-  u8 read_is() const { return _is; }
+  u8 read_is() const { return read<Register::IS>(); }
 
   void write_a(u16 value);
   void write_x(u16 value);
@@ -101,7 +125,12 @@ public:
 private:
   // Common tail of every typed write: record the xor if traced, then store. Templated so the recorded packet is the
   // register's own width rather than a fixed word.
-  template <std::integral I> void store(Register reg, I &slot, I value, Operation op);
+  template <std::integral I> void store(Register reg, I &slot, I value, Operation op) {
+    // The xor is one instruction here, where both values are already in hand -- which is why the recorder takes them
+    // combined rather than fetching the prior value itself.
+    if (_traced) _trace.emit_write_register(op, _refs[static_cast<u8>(reg)], static_cast<I>(slot ^ value));
+    slot = value;
+  }
   // Enum dispatch for the Target path, which has a value and a slot index but no name.
   void write_slot(Register reg, u16 value, Operation op);
 

--- a/core/core/sim/cores/cpu/pep_regbank.hpp
+++ b/core/core/sim/cores/cpu/pep_regbank.hpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+#include <array>
+#include "core/arch/pep/isa/pep10.hpp"
+#include "core/sim/api/device.hpp"
+#include "core/sim/api/memory.hpp"
+#include "core/sim/api/trace.hpp"
+#include "core/sim/debugger/register_scanner.hpp"
+#include "core/sim/debugger/trace_recorder.hpp"
+
+// The Pep register file, held as C++ membner variables rather than offsets into an array.
+// It replaces the previous Dense* Target. With some optimization, the compiler is better able to elide useless calls to
+// memcpy. Registers are stored in host order for the direct RegisterBank API, but exposed in LE order via Target. This
+// maintains backwards-compatibility with usage of the Dense* register bank.
+// From the Target API, register N occupies bytes [N*2, N*2+1]
+//
+// Pep8, Pep9, amd Pep10 declare identical Register enums, so one bank serves all ISAs.
+class PepRegisterBank final : public Device, public Target, public Traceable {
+public:
+  using Register = isa::Pep10::Register;
+  static constexpr auto REGISTER_COUNT = static_cast<u8>(Register::INVALID);
+  // Fully synthetic: the CPU constructs it, nothing parses one, and it is never written out.
+  struct Configuration : public Device::Configuration {};
+
+  explicit PepRegisterBank(Configuration config);
+  ~PepRegisterBank() = default;
+  PepRegisterBank(const PepRegisterBank &) = delete;
+  PepRegisterBank &operator=(const PepRegisterBank &) = delete;
+
+  // --- Typed access.
+  u16 read_a() const { return _a; }
+  u16 read_x() const { return _x; }
+  u16 read_sp() const { return _sp; }
+  u16 read_pc() const { return _pc; }
+  u16 read_os() const { return _os; }
+  // One byte, and stored as a single u8 to avoid masking a u16 to one byte on each operation.
+  u8 read_is() const { return _is; }
+
+  void write_a(u16 value);
+  void write_x(u16 value);
+  void write_sp(u16 value);
+  void write_pc(u16 value);
+  void write_os(u16 value);
+  void write_is(u8 value);
+
+  // Store PC without recording. The CPU defers PC writeback to the end of an instruction and records the change
+  // itself as a STEPREG, which is smaller than a SETREGX when the delta is the same every time -- so this must not
+  // emit one as well. The caller owns the record; this owns the value.
+  void write_pc_untraced(u16 value) { _pc = value; }
+
+  // --- Enum dispatch, for callers holding a Register rather than a name. Switches to the above. ---
+  u16 read(Register reg) const;
+  void write(Register reg, u16 value);
+  // The scan reference for a register, so a CPU can name it when recording something this class does not emit.
+  RegisterScan::RegisterRef ref(Register reg) const;
+
+  // Device interface
+  void initialize(System *) override;
+  void reset() override;
+  const Device::Configuration &config() const override;
+  const Configuration &casted_config() const;
+  const Device::ID id() const override;
+  Device::Type type() const override;
+  // Throws. See the definition.
+  std::unique_ptr<DeviceSerializer> serializer() const override;
+
+  // Traceable interface
+  void set_recorder(const trace::Recorder &recorder) override;
+  bool can_generate_traces() const override;
+  void trace(bool enabled) override;
+  bool traced() const override;
+  void on_traced_changed(bool enabled) override;
+
+  // Target interface. The slow, generic path: big-endian, bounds checked, byte addressable. Keeps
+  // backwards-compatibility with previus tests / usages.
+  using Target::read;
+  using Target::write;
+  AddressSpan span() const override;
+  Result read(Address address, bits::span<u8> dest, Operation op) const override;
+  Result write(Address address, bits::span<const u8> src, Operation op) override;
+  void clear(u8 fill) override;
+  void dump(bits::span<u8> dest) const override;
+
+  // The Operation the typed writers record under. Set once, by the CPU that owns this bank.
+  void set_initiator(Device::ID cpu);
+
+private:
+  // Common tail of every typed write: record the xor if traced, then store. Templated so the recorded packet is the
+  // register's own width rather than a fixed word.
+  template <std::integral I> void store(Register reg, I &slot, I value, Operation op);
+  // Enum dispatch for the Target path, which has a value and a slot index but no name.
+  void write_slot(Register reg, u16 value, Operation op);
+
+  Configuration _config;
+  // Host order, always. Nothing here is ever byte swapped in place; the Target path converts on the way out.
+  u16 _a = 0, _x = 0, _sp = 0, _pc = 0, _os = 0;
+  u8 _is = 0;
+  // Filled in by initialize(). SETREGX names its target by scan id, so a write cannot be recorded without these.
+  std::array<RegisterScan::RegisterRef, REGISTER_COUNT> _refs{};
+  trace::Recorder _trace;
+  // Mirror of the buffer's traced bit, pushed via on_traced_changed(). Read on every write.
+  bool _traced = false;
+  Operation _op = Operation(Operation::Type::Standard, Operation::Kind::data, Device::ID{0});
+};

--- a/core/core/sim/cores/cpu/pep_regbank.hpp
+++ b/core/core/sim/cores/cpu/pep_regbank.hpp
@@ -41,11 +41,8 @@ public:
   PepRegisterBank(const PepRegisterBank &) = delete;
   PepRegisterBank &operator=(const PepRegisterBank &) = delete;
 
-  // --- Typed access.
-  //
-  // Expose an inline form which the compile should be able to reason about when the register is variable (but known at
-  // compile time). All other versions forward to this one, because profiling data suggests the compiler is as smart as
-  // I expect.
+  // Inline, compile-time form which the compiler reduces to a register read or write, usable when you know the target
+  // register at compile time.
   template <Register R> auto read() const {
     if constexpr (R == Register::A) return _a;
     else if constexpr (R == Register::X) return _x;
@@ -65,7 +62,8 @@ public:
     else static_assert(false, "no storage backs that register");
   }
 
-  // Named forms, for readability where the name is what the caller is thinking in.
+  // Variants used at design-time when you know which register you want to use. Syntactic sugar over read<R> and
+  // write<R>
   u16 read_a() const { return read<Register::A>(); }
   u16 read_x() const { return read<Register::X>(); }
   u16 read_sp() const { return read<Register::SP>(); }
@@ -81,14 +79,33 @@ public:
   void write_os(u16 value);
   void write_is(u8 value);
 
-  // Store PC without recording. The CPU defers PC writeback to the end of an instruction and records the change
-  // itself as a STEPREG, which is smaller than a SETREGX when the delta is the same every time -- so this must not
-  // emit one as well. The caller owns the record; this owns the value.
+  // Store PC without recording a trace. Used to implement the specialized PC increment in conjuction with the CPU's
+  // clock_tick handler.
   void write_pc_untraced(u16 value) { _pc = value; }
 
-  // --- Enum dispatch, for callers holding a Register rather than a name. Switches to the above. ---
-  u16 read(Register reg) const;
-  void write(Register reg, u16 value);
+  // Inlining reduce cost of dynamic read to a jumptable rather than JT + call.
+  u16 read(Register reg) const {
+    switch (reg) {
+    case Register::A: return read<Register::A>();
+    case Register::X: return read<Register::X>();
+    case Register::SP: return read<Register::SP>();
+    case Register::PC: return read<Register::PC>();
+    case Register::IS: return read<Register::IS>();
+    case Register::OS: return read<Register::OS>();
+    default: return 0;
+    }
+  }
+  void write(Register reg, u16 value) {
+    switch (reg) {
+    case Register::A: write<Register::A>(value); break;
+    case Register::X: write<Register::X>(value); break;
+    case Register::SP: write<Register::SP>(value); break;
+    case Register::PC: write<Register::PC>(value); break;
+    case Register::IS: write<Register::IS>(value); break;
+    case Register::OS: write<Register::OS>(value); break;
+    default: break;
+    }
+  }
   // The scan reference for a register, so a CPU can name it when recording something this class does not emit.
   RegisterScan::RegisterRef ref(Register reg) const;
 

--- a/core/core/sim/debugger/trace_recorder.cpp
+++ b/core/core/sim/debugger/trace_recorder.cpp
@@ -12,20 +12,20 @@ bool Recorder::traced() const { return _tb != nullptr && _tb->traced(_emitter); 
 
 // --- Initiator side ---
 
-Recorder::Instruction::Instruction(const Recorder &rec) {
-  if (!rec.traced()) return;
+void Recorder::Instruction::open(const Recorder &rec) {
+  // The caller has already decided this is traced; an unbound recorder still has no buffer to open against.
+  if (rec._tb == nullptr) return;
   _tb = rec._tb;
   _initiator = rec._emitter;
   _tb->begin(_initiator);
 }
 
-Recorder::Instruction::~Instruction() {
-  // Non-null here means commit() never ran, so we are unwinding out of a half-executed instruction.
-  if (_tb != nullptr) _tb->abort(_initiator);
+void Recorder::Instruction::abort() {
+  // Reached from the destructor, so commit() never ran and we are unwinding out of a half-executed instruction.
+  _tb->abort(_initiator);
 }
 
-void Recorder::Instruction::tick(i16 delta) {
-  if (_tb == nullptr) return;
+void Recorder::Instruction::tick_slow(i16 delta) {
   // Resolve rather than using the Device::ID overloads, which assert on a closed recording and dereference null once
   // NDEBUG removes the assert.
   auto rec = _tb->find_recording(_initiator);
@@ -39,8 +39,7 @@ void Recorder::Instruction::tick(i16 delta) {
   _tb->emit_body(*rec, {isyn.data(), isyn.size()});
 }
 
-void Recorder::Instruction::commit() {
-  if (_tb == nullptr) return;
+void Recorder::Instruction::commit_slow() {
   // Clear before committing: if commit() throws, the destructor must not then abort a recording that commit()
   // already closed.
   auto *tb = std::exchange(_tb, nullptr);

--- a/core/core/sim/debugger/trace_recorder.cpp
+++ b/core/core/sim/debugger/trace_recorder.cpp
@@ -172,6 +172,31 @@ void Recorder::emit_incr_register(const Operation &op, RegisterScan::RegisterRef
   else emit(std::array<u8, 2>{(u8)(value & 0xFF), (u8)((value >> 8) & 0xFF)});
 }
 
+void Recorder::emit_register_xor(const Operation &op, RegisterScan::RegisterRef ref, u64 combined, u8 size) {
+  if (combined == 0) return;  // The write changed nothing, so there is nothing to undo.
+  else if (!traced()) return; // Don't record for untraced.
+  else if (op.type == Operation::Type::BufferInternal)
+    return; // Access related to TB or UI. Filter or we'll loop infinitely.
+  // Register 0 is never handed out by RegisterScan::expose, so this is a device that never exposed the register it is
+  // trying to write. Drop it here rather than letting the replay hard-stop on RegisterInvalid.
+  else if (ref.reg.value == 0) return;
+  const auto rec = _tb->find_recording(op.initiator);
+  // begin() never called for that initiator.
+  if (rec == nullptr) return;
+
+  // Payload goes in the data chain and the instruction reaches it through DP, exactly as SETMEMX does.
+  // Generic register writes don't have a discernable pattern, so emitting immediate data would supress stencil
+  // promotion.
+  const auto slot = _tb->append_data_uninitialized(*rec, size);
+  // Immediates and payloads are little-endian throughout this ISA.
+  bits::memcpy_endian(slot.bytes, bits::Order::LittleEndian, combined);
+  emit_dp_update(slot, *rec, size, 0);
+
+  const auto set =
+      tvm::EncodedOp::SetReg<true, 3>{.access = op.as_u16(), .reg = ref.reg.value, .field = ref.field.value}.encode();
+  _tb->emit_body(*rec, {set.data(), set.size()});
+}
+
 void Recorder::emit_mm(const Operation &op, Address address, u8 pushed, bool read_write) {
   static constexpr u16 len = 1; // MMIO data payload is one byte.
   if (!traced()) return;        // Don't record for untraced.

--- a/core/core/sim/debugger/trace_recorder.hpp
+++ b/core/core/sim/debugger/trace_recorder.hpp
@@ -41,7 +41,8 @@ public:
   // traced bit, so that there is one representation of it. See TraceBuffer::set_address_in_payload.
   Recorder(tvm::TraceBuffer *tb, Device::ID emitter) : _tb(tb), _emitter(emitter) {}
 
-  // Whether this device's writes are being recorded.
+  // Whether this device's writes are being recorded. A device on a hot path should cache this value via
+  // Traceable::on_traced_changed rather than ask per access.
   bool traced() const;
   // Switch recording of this device on or off.
   void set_traced(bool enabled);

--- a/core/core/sim/debugger/trace_recorder.hpp
+++ b/core/core/sim/debugger/trace_recorder.hpp
@@ -112,6 +112,14 @@ public:
   // payload at all.
   void emit_incr_register(const Operation &op, RegisterScan::RegisterRef ref, i16 value);
 
+  // Record an overwrite of a scan-exposed register as SETREGX, whose payload is an already-combined `now ^ prior`.
+  //
+  // The width comes from I, and must match the register's declared byte_width. Unlike the STEPREG form, the payload
+  // will be DP-relative rather than immediate to increase opportunities for stencil promotion.
+  template <std::integral I> void emit_write_register(const Operation &op, RegisterScan::RegisterRef ref, I combined) {
+    emit_register_xor(op, ref, static_cast<u64>(static_cast<std::make_unsigned_t<I>>(combined)), sizeof(I));
+  }
+
   // A helper class which which helps open & close a recording for a single instruction.
   class Instruction {
   public:
@@ -145,6 +153,9 @@ public:
 private:
   // 0 if read, 1 if write.
   void emit_mm(const Operation &op, Address address, u8 pushed, bool read_write);
+  // Width-erased body of emit_write_register. Out of line because it needs the TraceBuffer, which this header only
+  // forward declares.
+  void emit_register_xor(const Operation &op, RegisterScan::RegisterRef ref, u64 combined, u8 size);
   void emit_dp_update(const tvm::DataSlot &slot, tvm::Recording &rec, u16 size, u16 prologue);
   // Null means this device was never bound to a buffer.
   tvm::TraceBuffer *_tb = nullptr;

--- a/core/core/sim/debugger/trace_recorder.hpp
+++ b/core/core/sim/debugger/trace_recorder.hpp
@@ -121,14 +121,21 @@ public:
   }
 
   // A helper class which which helps open & close a recording for a single instruction.
+  // Multiple methods are partially inlined. Allowing every TU to see tha guard condition has lead to substantially
+  // faster code.
   class Instruction {
   public:
-    // Opens a recording when `rec` is bound and traced, and is inert otherwise. An untraced CPU pays one bitset
-    // test per instruction and nothing more.
-    explicit Instruction(const Recorder &rec);
+    // Opens a recording when `traced` says to, and is inert otherwise. The caller passes its own cached copy of the
+    // bit rather than reaching into the TraceBuffer to avoid an expensive call for each instruction. If you don't have
+    // a cached copy, you'll need to work with your recorder instead.
+    explicit Instruction(const Recorder &rec, bool traced) {
+      if (traced) open(rec);
+    }
     // If commit() was never called, abort() the recording rather than commit(). Destructors run while an exception
     // unwinds, and commit() can throw, which would call std::terminate.
-    ~Instruction();
+    ~Instruction() {
+      if (_tb != nullptr) abort();
+    }
     Instruction(const Instruction &) = delete;
     Instruction &operator=(const Instruction &) = delete;
     Instruction(Instruction &&) = delete;
@@ -137,15 +144,26 @@ public:
     // Record an ISYN with a relative tick count, which is the number of ticks since the PREVIOUS GLOBAL TICK FOR THAT
     // CLOCK. This value will be provided to you by the caller of our tick() equivalent. The value is carried as two
     // bytes and sign-extended on decode, so it spans the same range as i16.
-    void tick(i16 delta);
+    void tick(i16 delta) {
+      if (_tb != nullptr) tick_slow(delta);
+    }
 
     // Finish the record. A no-op when nothing was opened.
-    void commit();
+    void commit() {
+      if (_tb != nullptr) commit_slow();
+    }
 
     // True when a recording was actually opened.
     explicit operator bool() const { return _tb != nullptr; }
 
   private:
+    // Out of line because each needs the TraceBuffer, which this header only forward declares. Reached only when a
+    // recording is actually open.
+    void open(const Recorder &rec);
+    void abort();
+    void tick_slow(i16 delta);
+    void commit_slow();
+
     tvm::TraceBuffer *_tb = nullptr;
     Device::ID _initiator{};
   };

--- a/core/core/sim/debugger/trace_recorder.hpp
+++ b/core/core/sim/debugger/trace_recorder.hpp
@@ -120,9 +120,9 @@ public:
     emit_register_xor(op, ref, static_cast<u64>(static_cast<std::make_unsigned_t<I>>(combined)), sizeof(I));
   }
 
-  // A helper class which which helps open & close a recording for a single instruction.
-  // Multiple methods are partially inlined. Allowing every TU to see tha guard condition has lead to substantially
-  // faster code.
+  // A helper class which helps open & close a recording for a single instruction.
+  // Multiple methods are partially inlined. Allowing every TU to see the guard condition causes the compiler to
+  // generate better code.
   class Instruction {
   public:
     // Opens a recording when `traced` says to, and is inert otherwise. The caller passes its own cached copy of the

--- a/core/core/sim/debugger/tvm_tracebuffer.cpp
+++ b/core/core/sim/debugger/tvm_tracebuffer.cpp
@@ -1,9 +1,10 @@
 #include "tvm_tracebuffer.hpp"
 #include <algorithm>
 #include <cassert>
-#include <iterator>
 #include <cstring>
+#include <iterator>
 #include "core/ds/hash/fnv.hpp"
+#include "core/sim/api/trace.hpp"
 #include "core/sim/debugger/tvm_encoding.hpp"
 
 namespace tvm {
@@ -51,11 +52,22 @@ TraceBuffer::TraceBuffer(std::shared_ptr<pepp::bts::BufferManager> mgr, size_t r
   clear();
 }
 
+
+void TraceBuffer::trace(Device::ID device, bool enabled) {
+  _traced[device.value] = enabled;
+  // Try to push the cached change to the device.
+  if (auto traceable = find_traceable(device); traceable) traceable->on_traced_changed(enabled);
+}
+
 TraceBuffer::~TraceBuffer() noexcept {
   for (auto &node : _ring) {
     if (node.locations) _mgr->free_buffer(node.locations->id());
   }
 }
+
+void TraceBuffer::set_traceable_finder(TraceableFinder finder) { _finder = std::move(finder); }
+
+Traceable *TraceBuffer::find_traceable(Device::ID initiator) const { return _finder ? _finder(initiator) : nullptr; }
 
 // --- Recording lifecycle ---
 

--- a/core/core/sim/debugger/tvm_tracebuffer.hpp
+++ b/core/core/sim/debugger/tvm_tracebuffer.hpp
@@ -12,6 +12,7 @@
 #include "core/sim/debugger/tvm_machine.hpp"
 #include "core/sim/debugger/tvm_opcodes.hpp"
 
+class Traceable;
 
 namespace tvm {
 
@@ -140,6 +141,12 @@ public:
   TraceBuffer(std::shared_ptr<pepp::bts::BufferManager> mgr, size_t ring_size = 4);
   ~TraceBuffer() noexcept;
 
+  // Helpers from the system to convert Device::IDs to instances of classes that are Traceable.
+  // Return nullptr if the device ID does not exist or is not traceable.
+  using TraceableFinder = std::function<Traceable *(Device::ID)>;
+  void set_traceable_finder(TraceableFinder finder);
+  Traceable *find_traceable(Device::ID initiator) const;
+
   // --- Recording ---
   // True between begin() and commit() for this initiator. Since UI accesses may trigger traces, we need to be able to
   bool is_recording(Device::ID initiator) const;
@@ -212,7 +219,8 @@ public:
   DpAnchor dp_anchor(Recording &rec) const;
   void set_dp_anchor(Recording &rec, pepp::bts::Buffer::Location at, u16 size, u16 stride);
 
-  void trace(Device::ID device, bool enabled = true) { _traced[device.value] = enabled; }
+  // Sets the bit and notifies the device of the update via Traceable::on_trace_changed.
+  void trace(Device::ID device, bool enabled = true);
   bool traced(Device::ID device) const { return _traced[device.value]; }
 
   // When false, we prefer packet formats which encode offsets in the instruction,
@@ -516,6 +524,9 @@ private:
     WatermarkCallback callback;
     bool fired = false;
   };
+  // Helper method to return a pointer to a Traceable given a Device::ID and notify it of tracing state changes.
+  TraceableFinder _finder = [](Device::ID) -> Traceable * { return nullptr; };
+
   std::vector<Watermark> _watermarks;
   // Both indexed by Device::ID, whose underlying type is u8. 32 bytes each, and a lookup is a word load plus a bit
   // test and cheap enough to sit on the per-write path.

--- a/core/core/sim/memory/bus/simplebus.hpp
+++ b/core/core/sim/memory/bus/simplebus.hpp
@@ -114,7 +114,7 @@ private:
 
 // Bug: only raise_error policy works. Both read & write need to be updated to ingore faulting addresses in the case of
 // yield_default.
-class SimpleBus final : public Device, public Target, public Initiator, public Traceable {
+class SimpleBus final : public Target, public Device, public Initiator, public Traceable {
 public:
   static const inline std::string compatible = "bus,simple";
   struct Configuration : public Device::Configuration {

--- a/core/core/sim/memory/ram/dense.cpp
+++ b/core/core/sim/memory/ram/dense.cpp
@@ -72,6 +72,7 @@ void Dense::initialize(System *sys) {
 void Dense::reset() {
   clear(_config.fill);
   _counters = {};
+  _may_trace = true;
 }
 
 const Device::ID Dense::id() const { return _config.id; }
@@ -104,6 +105,8 @@ void Dense::trace(bool enabled) { _trace.set_traced(enabled); }
 
 bool Dense::traced() const { return _trace.traced(); }
 
+void Dense::on_traced_changed(bool enabled) { _may_trace = enabled; }
+
 AddressSpan Dense::span() const { return _config.span; }
 
 Target::Result Dense::read(Address address, bits::span<u8> dest, Operation op) const {
@@ -127,7 +130,7 @@ Target::Result Dense::write(Address address, bits::span<const u8> src, Operation
   if (address < span.lower() || max_addr > span.upper()) throw E(E::Type::OOBAccess, address);
   const auto offset = address - span.lower();
   auto dest = bits::span<u8>{_data.data(), std::size_t(_data.size())}.subspan(offset);
-  _trace.emit_write(op, address, dest.first(src.size()), src);
+  if (_may_trace) _trace.emit_write(op, address, dest.first(src.size()), src);
   bits::memcpy(dest, src);
   if (is_performance_countable(op)) _counters.wr_bytes += src.size();
   return {};
@@ -141,7 +144,7 @@ Target::Result Dense::write_increment(Address address, bits::span<const u8> src,
   if (address < span.lower() || max_addr > span.upper()) throw E(E::Type::OOBAccess, address);
   const auto offset = address - span.lower();
   auto dest = bits::span<u8>{_data.data(), std::size_t(_data.size())}.subspan(offset);
-  _trace.emit_write_increment(op, address, dest.first(src.size()), src, order);
+  if (_may_trace) _trace.emit_write_increment(op, address, dest.first(src.size()), src, order);
   bits::memcpy(dest, src);
   if (is_performance_countable(op)) _counters.wr_bytes += src.size();
   return {};

--- a/core/core/sim/memory/ram/dense.cpp
+++ b/core/core/sim/memory/ram/dense.cpp
@@ -1,4 +1,5 @@
 #include "dense.hpp"
+#include <cstring>
 #include <nlohmann/json.hpp>
 #include "core/sim/memory/errors.hpp"
 #include "core/sim/system.hpp"
@@ -116,8 +117,16 @@ Target::Result Dense::read(Address address, bits::span<u8> dest, Operation op) c
   const auto max_addr = (address + std::max<Address>(0, dest.size() - 1));
   if (address < span.lower() || max_addr > span.upper()) throw E(E::Type::OOBAccess, address);
   const auto offset = address - span.lower();
-  const auto src = bits::span<const u8>{_data.data(), std::size_t(_data.size())}.subspan(offset);
-  bits::memcpy(dest, src);
+  const u8 *src = _data.data() + offset;
+  // Switched on the width so the copy length is a constant the compiler can turn into a register operation for common
+  // register sizes rather than a trip through the actual C code of memcpy.
+  switch (dest.size()) {
+  case 1: dest[0] = src[0]; break;
+  case 2: std::memcpy(dest.data(), src, 2); break;
+  case 4: std::memcpy(dest.data(), src, 4); break;
+  case 8: std::memcpy(dest.data(), src, 8); break;
+  default: std::memcpy(dest.data(), src, dest.size()); break;
+  }
   if (is_performance_countable(op)) _counters.rd_bytes += dest.size();
   return {};
 }
@@ -129,9 +138,17 @@ Target::Result Dense::write(Address address, bits::span<const u8> src, Operation
   const auto max_addr = (address + std::max<Address>(0, src.size() - 1));
   if (address < span.lower() || max_addr > span.upper()) throw E(E::Type::OOBAccess, address);
   const auto offset = address - span.lower();
-  auto dest = bits::span<u8>{_data.data(), std::size_t(_data.size())}.subspan(offset);
-  if (_may_trace) _trace.emit_write(op, address, dest.first(src.size()), src);
-  bits::memcpy(dest, src);
+  u8 *dest = _data.data() + offset;
+  if (_may_trace) _trace.emit_write(op, address, bits::span<const u8>{dest, src.size()}, src);
+  // Switched on the width so the copy length is a constant the compiler can turn into a register operation for common
+  // register sizes rather than a trip through the actual C code of memcpy.
+  switch (src.size()) {
+  case 1: dest[0] = src[0]; break;
+  case 2: std::memcpy(dest, src.data(), 2); break;
+  case 4: std::memcpy(dest, src.data(), 4); break;
+  case 8: std::memcpy(dest, src.data(), 8); break;
+  default: std::memcpy(dest, src.data(), src.size()); break;
+  }
   if (is_performance_countable(op)) _counters.wr_bytes += src.size();
   return {};
 }

--- a/core/core/sim/memory/ram/dense.hpp
+++ b/core/core/sim/memory/ram/dense.hpp
@@ -21,7 +21,7 @@
 #include "core/sim/api/trace.hpp"
 #include "core/sim/debugger/trace_recorder.hpp"
 
-class Dense final : public Device, public Target, public Traceable {
+class Dense final : public Target, public Device, public Traceable {
 public:
   static const inline std::string compatible = "ram,dense";
   struct Configuration : public Device::Configuration {

--- a/core/core/sim/memory/ram/dense.hpp
+++ b/core/core/sim/memory/ram/dense.hpp
@@ -60,9 +60,6 @@ public:
   AddressSpan span() const override;
   Result read(Address address, bits::span<u8> dest, Operation op) const override;
   Result write(Address address, bits::span<const u8> src, Operation op) override;
-  // Re-declared an re-implemented to allow devirtualization when held through a concrete pointer.
-  template <std::integral I, bool byteswap = false> std::pair<Result, I> read(Address address, Operation op) const;
-  template <std::integral I, bool byteswap = false> Result write(Address address, I src, Operation op);
 
   // Overloads which emit traces using an increment/offset encoding.
   // When Dense is used to hold registers, this can be a more efficient encoding than a full write.
@@ -95,17 +92,6 @@ private:
  * Inline implementations
  */
 
-template <std::integral I, bool byteswap>
-std::pair<Target::Result, I> Dense::read(Address address, Operation op) const {
-  I dest;
-  auto r = read(address, bits::span<u8>(reinterpret_cast<u8 *>(&dest), sizeof(I)), op);
-  if constexpr (byteswap) dest = bits::byteswap(dest);
-  return {r, dest};
-}
-template <std::integral I, bool byteswap> Target::Result Dense::write(Address address, I src, Operation op) {
-  if constexpr (byteswap) src = bits::byteswap(src);
-  return write(address, bits::span<const u8>(reinterpret_cast<const u8 *>(&src), sizeof(I)), op);
-}
 template <std::integral I, bool byteswap>
 inline Target::Result Dense::write_increment(Address address, I src, Operation op, bits::Order order) {
   if constexpr (byteswap) src = bits::byteswap(src);

--- a/core/core/sim/memory/ram/dense.hpp
+++ b/core/core/sim/memory/ram/dense.hpp
@@ -54,6 +54,7 @@ public:
   bool can_generate_traces() const override;
   void trace(bool enabled) override;
   bool traced() const override;
+  void on_traced_changed(bool enabled) override;
 
   // Target interface
   AddressSpan span() const override;
@@ -83,6 +84,12 @@ private:
   Configuration _config;
   std::vector<u8> _data;
   trace::Recorder _trace;
+  // If false, then we definitely aren't traced and we can skip the overhead of emit via _trace.
+  // If true, we either are traced or we don't know. Either way, we need to try to emit via _trace.
+  // Default value should be true. Only set to false if you've received a notification from the TB that you aren't
+  // traced. Ideally this would be an optional and nullopt would express the "unknown" rather than using true, but that
+  // gae up a good chunk of performance.
+  bool _may_trace = true;
 };
 /*
  * Inline implementations

--- a/core/core/sim/memory/ram/dense.hpp
+++ b/core/core/sim/memory/ram/dense.hpp
@@ -59,6 +59,10 @@ public:
   AddressSpan span() const override;
   Result read(Address address, bits::span<u8> dest, Operation op) const override;
   Result write(Address address, bits::span<const u8> src, Operation op) override;
+  // Re-declared an re-implemented to allow devirtualization when held through a concrete pointer.
+  template <std::integral I, bool byteswap = false> std::pair<Result, I> read(Address address, Operation op) const;
+  template <std::integral I, bool byteswap = false> Result write(Address address, I src, Operation op);
+
   // Overloads which emit traces using an increment/offset encoding.
   // When Dense is used to hold registers, this can be a more efficient encoding than a full write.
   // order is the byte order of the destination, which is required to compute the signed difference between src and the
@@ -80,7 +84,21 @@ private:
   std::vector<u8> _data;
   trace::Recorder _trace;
 };
+/*
+ * Inline implementations
+ */
 
+template <std::integral I, bool byteswap>
+std::pair<Target::Result, I> Dense::read(Address address, Operation op) const {
+  I dest;
+  auto r = read(address, bits::span<u8>(reinterpret_cast<u8 *>(&dest), sizeof(I)), op);
+  if constexpr (byteswap) dest = bits::byteswap(dest);
+  return {r, dest};
+}
+template <std::integral I, bool byteswap> Target::Result Dense::write(Address address, I src, Operation op) {
+  if constexpr (byteswap) src = bits::byteswap(src);
+  return write(address, bits::span<const u8>(reinterpret_cast<const u8 *>(&src), sizeof(I)), op);
+}
 template <std::integral I, bool byteswap>
 inline Target::Result Dense::write_increment(Address address, I src, Operation op, bits::Order order) {
   if constexpr (byteswap) src = bits::byteswap(src);

--- a/core/core/sim/memory/ram/sparse.hpp
+++ b/core/core/sim/memory/ram/sparse.hpp
@@ -21,7 +21,7 @@
 #include "core/sim/api/trace.hpp"
 #include "core/sim/debugger/trace_recorder.hpp"
 
-class Sparse final : public Device, public Target, public Traceable {
+class Sparse final : public Target, public Device, public Traceable {
 public:
   static const inline std::string compatible = "ram,sparse";
   struct Configuration : public Device::Configuration {

--- a/core/core/sim/system.cpp
+++ b/core/core/sim/system.cpp
@@ -68,6 +68,13 @@ Device::ID System::next_ID() { return _next_ID++; }
 Device::IDGenerator System::gen_next_ID() { return _gen_next_ID; }
 
 void System::bind_recorders(tvm::TraceBuffer &tb) {
+  // Give the TraceBuffer a helper to convert ids to Traceables. This allows the TraceBuffer to "push" trace
+  // enable/disable information to the devices themselves.
+  auto finder = [this](Device::ID id) -> Traceable * {
+    if (auto dev = find_by_id(id); !dev) return nullptr;
+    else return dev->capability<Traceable>();
+  };
+  tb.set_traceable_finder(finder);
   // Each Traceable must get its own device ID to allow per-ID enables to work.
   for (auto dev : *_root) {
     auto *traceable = dev->capability<Traceable>();

--- a/core/core/sim/system.cpp
+++ b/core/core/sim/system.cpp
@@ -81,6 +81,8 @@ void System::bind_recorders(tvm::TraceBuffer &tb) {
     if (traceable == nullptr) continue;
 
     traceable->set_recorder(trace::Recorder{&tb, dev->id()});
+    // Push the current traced state to the device's local cache.
+    traceable->on_traced_changed(tb.traced(dev->id()));
     // Try to select register banks and CSRs by filtering based on their size.
     // For small targets, prefer to pass addresses/offsets via the trace's code rather than the trace's data stream. A
     // system that knows better can call set_address_in_payload() after initialize().

--- a/test/core/sim/core/pep/instr/dyadic_br.cpp
+++ b/test/core/sim/core/pep/instr/dyadic_br.cpp
@@ -44,7 +44,7 @@ void inner(PepISA3CPU::ISA isa, Mnemonic op, should_branch taken) {
     cpu->write_packed_csr(nzvc);
 
     REQUIRE_NOTHROW(cpu->clock_tick(PulseSchedule::PulseIndex{0}, 0));
-    auto [n, z, v, c] = unpack_csrs(cpu->read_packed_csr());
+    auto [n, z, v, c] = PepCSRBank::unpack(cpu->read_packed_csr());
 
     CHECK(reg(cpu, Register::A) == 0);
     CHECK(reg(cpu, Register::X) == 0);

--- a/test/core/sim/hwdbg/register_scan.cpp
+++ b/test/core/sim/hwdbg/register_scan.cpp
@@ -74,7 +74,7 @@ template <typename Register, typename CSR, typename Mnemonic> void inner_call(Pe
   cpu->registers()->clear(0);
   cpu->csrs()->clear(0);
   cpu->write_register(Register::SP, init_sp);
-  cpu->write_packed_csr(pack_csr(true, false, true, false)); // NZVC = 1010
+  cpu->write_packed_csr(PepCSRBank::pack(true, false, true, false)); // NZVC = 1010
 
   REQUIRE_NOTHROW(cpu->clock_tick(PulseSchedule::PulseIndex{0}, 0));
 

--- a/test/core/sim/hwdbg/trace_recorder.cpp
+++ b/test/core/sim/hwdbg/trace_recorder.cpp
@@ -908,3 +908,91 @@ TEST_CASE("System::initialize: at most one trace buffer, wherever it sits",
     CHECK_THROWS_AS(sys->initialize(), std::logic_error);
   }
 }
+
+TEST_CASE("trace::Recorder: emit_write_register()", "[scope:core][scope:core.dbg][kind:unit][arch:pep10]") {
+  auto [sys, mem] = make_system();
+  tvm::TraceBuffer tb(sys->buffer_manager());
+  constexpr Device::ID CPU{1};
+
+  // A register living in a plain member and held in host order, which is how a specialized bank keeps them.
+  u16 reg_a = 0;
+  RegisterScan::Register decl{};
+  decl.byte_width = sizeof(reg_a);
+  decl.target = mem->id();
+  decl.order = bits::hostOrder();
+  decl.name = "A";
+  decl.loc = &reg_a;
+  const auto ref = sys->register_scan()->expose(decl);
+
+  // A one-byte register too, to ensure that all register sizes are respected.
+  u8 reg_is = 0;
+  RegisterScan::Register narrow{};
+  narrow.byte_width = sizeof(reg_is);
+  narrow.target = mem->id();
+  narrow.order = bits::hostOrder();
+  narrow.name = "IS";
+  narrow.loc = &reg_is;
+  const auto narrow_ref = sys->register_scan()->expose(narrow);
+
+  trace::Recorder rec(&tb, mem->id());
+  tb.trace(mem->id());
+  const Operation emit_op(Operation::Type::Standard, Operation::Kind::data, CPU);
+
+  SECTION("a recorded overwrite replays forward, then undoes itself") {
+    // The caller has both values in hand and hands over the xor, which is what SETREGX carries.
+    const u16 before = 0x1234, after = 0xBEEF;
+    reg_a = before;
+    tb.begin(CPU);
+    rec.emit_write_register(emit_op, ref, u16(before ^ after));
+    reg_a = after;
+    const auto loc = tb.commit(CPU);
+
+    auto blaster = sys->make_trace_interpreter();
+    reg_a = before; // rewind so the forward replay has something to do
+    blaster->run(loc);
+    CHECK(blaster->stop_cause() == tvm::StopCause::None);
+    CHECK(reg_a == after);
+
+    // Xor is its own inverse, which is the whole reason this form is used rather than SETREG.
+    blaster->backend().set_direction(tvm::Direction::Backward);
+    blaster->run(loc);
+    CHECK(reg_a == before);
+  }
+
+  SECTION("a one-byte register records a one-byte payload") {
+    // The register declares byte_width 1, so a wider packet wouldd hard-stop on RegisterSizeMismatch
+    reg_is = 0x0F;
+    tb.begin(CPU);
+    rec.emit_write_register(emit_op, narrow_ref, u8(0x0F ^ 0xA5));
+    const auto loc = tb.commit(CPU);
+
+    auto blaster = sys->make_trace_interpreter();
+    blaster->run(loc);
+    CHECK(blaster->stop_cause() == tvm::StopCause::None);
+    CHECK(reg_is == 0xA5);
+  }
+
+  SECTION("no-op writes are supressed") {
+    // Measured on the data chain rather than the code because we will always pay some code size for creating a
+    // instruction (the terminating HALT).
+    const auto before = tb.footprint();
+    tb.begin(CPU);
+    rec.emit_write_register(emit_op, ref, u16(0));
+    tb.commit(CPU);
+    CHECK(tb.footprint().data == before.data);
+  }
+
+  SECTION("two writes to the same register share a stencil") {
+    // The reason for putting the payload in the data chain is to allow different values to be written to the same
+    // register.
+    tb.begin(CPU);
+    rec.emit_write_register(emit_op, ref, u16(0x0101));
+    tb.commit(CPU);
+    CHECK(tb.stencil_count() == 0); // seen once, not yet promoted
+
+    tb.begin(CPU);
+    rec.emit_write_register(emit_op, ref, u16(0xBEEF)); // deliberately a different value
+    tb.commit(CPU);
+    CHECK(tb.stencil_count() == 1);
+  }
+}


### PR DESCRIPTION
I'm using the same measure instruction throughput (`mit`) subcommand on Pepp-term, which executes 100 million instructions. The program is a simple `self: br self`, which is sufficient to test for the overhead of the simulator. Testing indicates a performance ceiling rather than expected performance on student programs. The system-under-tests is a CPU attached to an array of main memory, which bypasses the cost of decoding addresses. Debugging features like breakpoints, tracing are disabled in both the before and after cases.

Here are the results at each optimization step:
| Change | SHA | MIPS | Improvement over Previous | Total Improvement |
| --- | --- | --- | --- | --- |
| Baseline | 27a5cd5b86c666ae2b9aa38a53ab4b93dc3e28bd | 31 | 0.0% | |
| De-virtualize regbank access | cf7380e50ad81d92ceabdd0983a3df875d810ed1 | 34.6 | 11.6% | 11.6% |
| Cache Operation type | 91fd215cf8cdbef98697d833605e98d952429d45 | 36.2 | 4.6% | 16.8% |
| Inline target accessors | af2dbfc9c86e0006a15d1ef93e2ee718c2305bf1 | 37.2 | 2.8% | 20.0% |
| Cache trace-enable state in dense devices | 9a9dba55283a7ab98c31402376fd39dcafa8f34e | 39.8 | 7.0% | 28.4% |
| Specialize for unconditional branches | 55f207433c41e84d6085e27b6e6e68c2c9d9b346 | 46.3 | 16.3% | 49.4% |
| Specialize register bank & CSRS | f90e2f1f47af17b1e19ede249d1ddd67a0cdc643 | 56.8 | 22.7% | 83.2% |
| Accelerate register access with known-at-compile-time registers | eca6f16e99dd81b72a6d0cde6ff8403f01f570f3 | 60.0 | 5.6% | 93.5% |
| Avoid std::span overhead for integral types | e718f4e7900a879911c70f1d8fef7570a9719bf7 | 71.6 | 19.3% | 131.0% |
| Inline a handful of important tracing methods | 05457d69ae2390b40d3c7969a317f2c9154c1941 | 81.9 | 14.4% | 164.2% |
| Cache trace-enable state in CPU | a5fdc3f3c065e678205b34f519788919fb246978 | 93.5 | 14.2% | 201.6% |
| Swap base class ordering for Memory Targets | 364c8d9ed645d5196da24adad4327644f8277fd2 | 100.9 | 7.9% | 225.5% |
| Inline register access switches | 9b21d05e074376ac534ee5b384a5bd47faedc9b5 | 109.9 | 8.9% | 254.5% |
| Unify opcode dispatch switch | 734abb11011ac948db73b96be15bec900f2a2d5a | 122.2 | 11.2% | 294.2% |


After modifying the instruction throughput tests, I ran the program through Apple's instruments. Attached to this PR is a [trace file](https://github.com/user-attachments/files/31249847/demo.trace.zip) with before / after states and a handful of screenshots of the timelines.


# Pre optimization:
<img width="963" height="973" alt="Screenshot 2026-08-19 at 22 11 09" src="https://github.com/user-attachments/assets/4b0ed1a9-7961-437d-91c8-a81e12bfd323" />
<img width="2926" height="318" alt="Screenshot 2026-08-19 at 22 10 08" src="https://github.com/user-attachments/assets/1e1ff46d-ddd6-42e4-bff1-74c52f5a4157" />

# Post optimization:
<img width="899" height="268" alt="Screenshot 2026-08-19 at 22 08 44" src="https://github.com/user-attachments/assets/8da4eba6-a2a9-4e01-8531-111cf478d9f0" />
<img width="2944" height="235" alt="Screenshot 2026-08-19 at 22 09 18" src="https://github.com/user-attachments/assets/45e146a1-b1d0-46ea-ba56-1dc8f326c5f1" />

