### PR TITLE
Add fast BP check to CPU simulator

### DIFF
--- a/bin/term/commands/throughput.cpp
+++ b/bin/term/commands/throughput.cpp
@@ -137,7 +137,9 @@ std::chrono::high_resolution_clock::time_point ThroughputTask::do_core() {
   cpu->on_traced_changed(false);
   cpu->csrs()->on_traced_changed(false);
   cpu->registers()->on_traced_changed(false);
+  cpu->has_bps = has_bps;
   const auto start = std::chrono::high_resolution_clock::now();
   for (int it = 0; it < maxInstr; it++) cpu->clock_tick(PulseSchedule::PulseIndex{(u64)it}, it);
+  fmt::println("Filter hits: {}", cpu->filter_hits());
   return start;
 }

--- a/bin/term/commands/throughput.hpp
+++ b/bin/term/commands/throughput.hpp
@@ -32,6 +32,7 @@ public:
   std::chrono::high_resolution_clock::time_point do_sim3();
   std::chrono::high_resolution_clock::time_point do_core();
   u64 maxInstr = 100'000'000;
+  bool has_bps = false;
 
 private:
   WhichVersion _version;
@@ -41,6 +42,7 @@ void registerThroughput(auto &app, task_factory_t &task, detail::SharedFlags &fl
   static auto instrThruSC = app.add_subcommand("mit", "Measure instruction throughput");
   static ThroughputTask::WhichVersion version = ThroughputTask::WhichVersion::Sim3;
   static u64 maxInstr = 100'000'000;
+  static bool has_bps = false;
   auto versionOpt =
       instrThruSC->add_option("-v,--version", version, "Which version to run")
           ->transform(CLI::CheckedTransformer(std::map<std::string, ThroughputTask::WhichVersion>{
@@ -48,12 +50,16 @@ void registerThroughput(auto &app, task_factory_t &task, detail::SharedFlags &fl
 
   static auto maxInstrOpt =
       instrThruSC->add_option("-n,--max-instr", maxInstr, "Maximum number of instructions to run");
+  static auto hasBpsOpt =
+      instrThruSC->add_flag("--bps,!--no-bps", has_bps, "Add spurious breakpoints which will not be hit")
+          ->default_val(false);
   instrThruSC->group("");
   instrThruSC->callback([&]() {
     flags.kind = detail::SharedFlags::Kind::TERM;
     task = [](QObject *parent) {
       auto ret = new ThroughputTask(version, parent);
       ret->maxInstr = maxInstr;
+      ret->has_bps = has_bps;
       return ret;
     };
   });

--- a/core/core/ds/bloom.hpp
+++ b/core/core/ds/bloom.hpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+#include <array>
+#include <bit>
+#include <span>
+#include <type_traits>
+#include "core/ds/hash/splitmix64.hpp"
+#include "core/integers.h"
+#include "core/macros.hpp"
+
+namespace pepp {
+
+// While multiplicative hashes tend to yield poor results, using 2^64/phi as a multiplicand is suprisingly effective for
+// mapping for a large range to a smaller range. In particular, it will distribute consecutive keys very effective. A
+// major issue is that the low-order bits are less likely to change, which is why our bloom filter discards them with
+// a shift.
+// https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
+// Knuth, TAOCP vol. 3 sec. 6.4.
+struct FibonacciHash {
+  static constexpr u64 hash(u64 x) noexcept { return x * 0x9e3779b97f4a7c15ull; }
+};
+
+// At the cost of a shift + XOR, we can transfer some entropy of the high bits to the low bits.
+struct FibonacciMixHash {
+  static constexpr u64 hash(u64 x) noexcept {
+    x *= 0x9e3779b97f4a7c15ull;
+    return x ^ (x >> 32);
+  }
+};
+
+// Horrid hash algorithm which returns itself. Useful as a control against which we compare.
+struct IdentityHash {
+  static constexpr u64 hash(u64 x) noexcept { return x; }
+};
+
+// Highest quality hash we currently provide wtih ~3x the number of cycles/hash as FibonacciHash.
+struct SplitMix64Hash {
+  static constexpr u64 hash(u64 x) noexcept { return splitmix64(x); }
+};
+
+// A fixed-size split block Bloom filter which rejects all true negatives at the expense of some false positives.
+// It's based heavily on Apache Parquet's specification.
+// Other useful resources when designing this filter were:
+// Apple, "Split block Bloom filters" (arXiv:2101.01719),  https://arxiv.org/pdf/2101.01719
+// Lang et al, "Performance-Optimal Filtering", https://dl.acm.org/doi/abs/10.14778/3303753.3303757
+//
+// Parquet uses 256-bit blocks composed of 32-bit words while we use 64-bit blocks with 64/k-bit words.
+// For our most important targets (x84-64, arm64) a block fits nicely in a register, and operations should be
+// shifts ands masks oer that register.
+//
+// Each key sets K bits within its selected block, and each bit set is in a different word within that block.
+//
+//   BYTES   filter footprint. Any non-zero multiple of 8.
+//   K       Number of bits set within a block by a key. Must be 1, 2, 4, or 8.
+//   SHIFT   Drop this many low-order bits of the key before hashing.
+//   Hash    any type with `static constexpr u64 hash(u64) noexcept`. A weak hash raises the
+//           false-positive rate but cannot cause a false negative.
+template <typename Key, std::size_t BYTES, unsigned K = 2, unsigned SHIFT = 0, class Hash = FibonacciMixHash>
+class SplitBlockBloom {
+public:
+  using key_type = Key;
+  static constexpr std::size_t NBLOCKS = BYTES / 8;
+  static constexpr u32 WORDS_PER_BLOCK = K;
+  // Multiply-shift keeps the top WORD_BITS of each 32x32->64 bit product.
+  static constexpr unsigned WORD_BITS = 64 / K;
+  // Verbatim from the Parquet specification; we use the first K.
+  static constexpr std::array<u32, 8> SALT = {0x47b6137bu, 0x44974d91u, 0x8824ad5bu, 0xa2b7289du,
+                                              0x705495c7u, 0x2df1424bu, 0x9efc4947u, 0x5c6bfb31u};
+
+  static_assert(std::is_unsigned_v<Key>, "Key must be an unsigned integer type");
+  static_assert(BYTES >= 8 && BYTES % 8 == 0, "BYTES must be a non-zero multiple of sizeof(u64)");
+  static_assert(K >= 1 && K <= 8 && std::has_single_bit(K), "K must be a power of two in [1, 8]");
+  static_assert(NBLOCKS <= (u64(1) << 32), "block selection requires NBLOCKS <= 2^32");
+
+  constexpr SplitBlockBloom() = default;
+  explicit constexpr SplitBlockBloom(std::span<const Key> keys) { rebuild(keys); }
+  // Keep copy+move ctor+assign, but just be warned that they can be quite slow.
+
+  // Removal means rebuilding from scratch
+  constexpr void rebuild(std::span<const Key> keys) noexcept {
+    clear();
+    for (auto key : keys) insert(key);
+  }
+  constexpr void clear() noexcept { _blocks.fill(0); }
+  constexpr void insert(Key key) noexcept {
+    const u64 h = Hash::hash(static_cast<u64>(key) >> SHIFT);
+    _blocks[block_index(h)] |= mask(static_cast<u32>(h));
+  }
+
+  // False means definitely absent, true requires checking authoritative source.
+  [[nodiscard]] PEPP_ALWAYS_INLINE constexpr bool maybe_contains(Key key) const noexcept {
+    const u64 h = Hash::hash(static_cast<u64>(key) >> SHIFT);
+    const u64 masked = mask(static_cast<u32>(h));
+    return (_blocks[block_index(h)] & masked) == masked;
+  }
+
+  // Count the number of set bits in the filter. False-positive rate correlates to fullness, meaning I need to measure
+  // that rate to tune filter instantiations.
+  [[nodiscard]] constexpr std::size_t popcount() const noexcept {
+    std::size_t count = 0;
+    for (auto word : _blocks) count += static_cast<std::size_t>(std::popcount(word));
+    return count;
+  }
+
+private:
+  // One bit per word, so a key sets exactly K bits. Two of its own bits can never collide.
+  static constexpr u64 mask(u32 x) noexcept {
+    // Select the top bits of the product.
+    static constexpr unsigned PROD_SHIFT = 32 - static_cast<unsigned>(std::countr_zero(WORD_BITS));
+    u64 result = 0;
+    for (unsigned i = 0; i < K; ++i) {
+      u32 y = x * SALT[i];
+      result |= 1ULL << (i * WORD_BITS + (y >> PROD_SHIFT));
+    }
+    return result;
+  }
+  // Convert u64 to [0, NBLOCKS) while avoiding integer division and power-of-two constraints.
+  static constexpr std::size_t block_index(u64 h) noexcept {
+    // We can avoid a 128-bit multiply first truncating our u64 to only have 32 significant bits. NBLOCKs is <=2^32,
+    // so we really have two u32s expressed as u64s. Multiply them together and extract the high order bits (which is
+    // Lemire's trick).
+    return static_cast<std::size_t>(((h >> 32) * NBLOCKS) >> 32);
+  }
+  std::array<u64, NBLOCKS> _blocks = {};
+};
+} // namespace pepp

--- a/core/core/macros.hpp
+++ b/core/core/macros.hpp
@@ -15,3 +15,11 @@
 #else
 #error "PEPP_UNREACHABLE: no supported unreachable intrinsic (need C++23 std::unreachable, MSVC, GCC, or Clang)."
 #endif
+
+#if defined(__GNUC__)
+#define PEPP_ALWAYS_INLINE inline __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define PEPP_ALWAYS_INLINE __forceinline
+#else
+#define PEPP_ALWAYS_INLINE inline
+#endif

--- a/core/core/sim/cores/cpu/pep_isa.cpp
+++ b/core/core/sim/cores/cpu/pep_isa.cpp
@@ -181,6 +181,10 @@ void PepISA3CPU::clock_tick(PulseSchedule::PulseIndex idx, u64 tick) {
     _regbank->write_pc_untraced(_pc);
   } else write_register_uncached(isa::Pep10::Register::PC, _pc);
   // TODO: handle breakpoints, debug info, etc
+  if (has_bps && _bp_filter.maybe_contains(_pc)) {
+    // Placeholder action to ensure that the bp check is not optimized out.
+    _filter_hits += 1;
+  }
   record.commit();
   _count.instructions += 1;
 }

--- a/core/core/sim/cores/cpu/pep_isa.hpp
+++ b/core/core/sim/cores/cpu/pep_isa.hpp
@@ -2,15 +2,15 @@
 
 #include "core/arch/pep/isa/pep10.hpp"
 #include "core/arch/pep/isa/pep_shared_ops.hpp"
+#include "core/ds/bloom.hpp"
 #include "core/sim/api/clock.hpp"
 #include "core/sim/api/device.hpp"
 #include "core/sim/api/memory.hpp"
 #include "core/sim/api/trace.hpp"
-#include "core/sim/debugger/register_scanner.hpp"
-#include "core/sim/debugger/trace_recorder.hpp"
 #include "core/sim/cores/cpu/pep_csrbank.hpp"
 #include "core/sim/cores/cpu/pep_regbank.hpp"
-
+#include "core/sim/debugger/register_scanner.hpp"
+#include "core/sim/debugger/trace_recorder.hpp"
 
 /*
  * The following classes of instructions are still not tested. Those tests require a more complete system model to
@@ -101,6 +101,12 @@ public:
   u16 read_pc() const { return _pc; }
   void write_pc(u16 value) { _pc = value; }
 
+  // TODO: when we update the bp filter, run a popcount as well.
+  // If no breakpoints were set, cache that information in a class-local variable like this one.
+  // This cached value is rarely updated and should be easy for the branch predictor to learn.
+  bool has_bps = true;
+  auto filter_hits() const { return _filter_hits; }
+
 private:
   struct PerfCounters {
     i16 call_depth = 0;
@@ -119,6 +125,9 @@ private:
   // reason the trace hooks below cost a branch rather than a call when tracing is off.
   bool _may_trace = true;
   isa::OpcodePlane _opcodes;
+  // Bloom filter used to rule out
+  pepp::SplitBlockBloom<u16, 256> _bp_filter;
+  u32 _filter_hits = 0;
   // Override this value once our id is known.
   Operation _op_data = Operation(Operation::Type::Standard, Operation::Kind::data, Device::ID{0});
 

--- a/lib/sim3/common_macros.hpp
+++ b/lib/sim3/common_macros.hpp
@@ -32,6 +32,7 @@
  * <https://opensource.org/license/bsd-3-clause>
  */
 #pragma once
+#include "core/macros.hpp"
 
 #ifdef __GNUG__
 #ifndef LIKELY
@@ -46,27 +47,21 @@
 #ifndef PEPP_HOT_PATH
 #define PEPP_HOT_PATH() __attribute__((hot))
 #endif
-#define PEPP_ALWAYS_INLINE __attribute__((always_inline))
 #define PEPP_NOINLINE __attribute__((noinline))
-#define PEPP_UNREACHABLE() __builtin_unreachable()
 #define RISCV_EXPORT __attribute__((visibility("default")))
 #elif defined(_MSC_VER)
 #define LIKELY(x) (x)
 #define UNLIKELY(x) (x)
 #define PEPP_COLD_PATH() /* */
 #define PEPP_HOT_PATH()  /* */
-#define PEPP_ALWAYS_INLINE __forceinline
 #define PEPP_NOINLINE __declspec(noinline)
-#define PEPP_UNREACHABLE() __assume(0)
 #define RISCV_EXPORT __declspec(dllexport)
 #else
 #define LIKELY(x) (x)
 #define UNLIKELY(x) (x)
 #define PEPP_COLD_PATH()   /* */
 #define PEPP_HOT_PATH()    /* */
-#define PEPP_ALWAYS_INLINE /* */
 #define PEPP_NOINLINE      /* */
-#define PEPP_UNREACHABLE() /* */
 #define RISCV_EXPORT       /* */
 #endif
 

--- a/lib/sim3/cores/riscv/cpu_inline.hpp
+++ b/lib/sim3/cores/riscv/cpu_inline.hpp
@@ -66,19 +66,25 @@ template <AddressType address_t> inline void CPU<address_t>::increment_pc(int de
 
 // Use a trick to access the Machine directly on g++/clang, Linux-only for now
 #if (defined(__GNUG__) || defined(__clang__)) && defined(__linux__)
-template <AddressType address_t> PEPP_ALWAYS_INLINE inline
-Machine<address_t>& CPU<address_t>::machine() noexcept { return *reinterpret_cast<Machine<address_t>*> (this); }
-template <AddressType address_t> PEPP_ALWAYS_INLINE inline
-const Machine<address_t>& CPU<address_t>::machine() const noexcept { return *reinterpret_cast<const Machine<address_t>*> (this); }
+template <AddressType address_t> PEPP_ALWAYS_INLINE Machine<address_t> &CPU<address_t>::machine() noexcept {
+  return *reinterpret_cast<Machine<address_t> *>(this);
+}
+template <AddressType address_t> PEPP_ALWAYS_INLINE const Machine<address_t> &CPU<address_t>::machine() const noexcept {
+  return *reinterpret_cast<const Machine<address_t> *>(this);
+}
 #else
-template <AddressType address_t> PEPP_ALWAYS_INLINE inline
-Machine<address_t>& CPU<address_t>::machine() noexcept { return this->m_machine; }
-template <AddressType address_t> PEPP_ALWAYS_INLINE inline
-const Machine<address_t>& CPU<address_t>::machine() const noexcept { return this->m_machine; }
+template <AddressType address_t> PEPP_ALWAYS_INLINE Machine<address_t> &CPU<address_t>::machine() noexcept {
+  return this->m_machine;
+}
+template <AddressType address_t> PEPP_ALWAYS_INLINE const Machine<address_t> &CPU<address_t>::machine() const noexcept {
+  return this->m_machine;
+}
 #endif
 
-template <AddressType address_t> PEPP_ALWAYS_INLINE inline
-Memory<address_t>& CPU<address_t>::memory() noexcept { return machine().memory; }
-template <AddressType address_t> PEPP_ALWAYS_INLINE inline
-const Memory<address_t>& CPU<address_t>::memory() const noexcept { return machine().memory; }
+template <AddressType address_t> PEPP_ALWAYS_INLINE Memory<address_t> &CPU<address_t>::memory() noexcept {
+  return machine().memory;
+}
+template <AddressType address_t> PEPP_ALWAYS_INLINE const Memory<address_t> &CPU<address_t>::memory() const noexcept {
+  return machine().memory;
+}
 } // namespace riscv

--- a/test/core/ds/bloom.cpp
+++ b/test/core/ds/bloom.cpp
@@ -15,7 +15,6 @@
  */
 #include "core/ds/bloom.hpp"
 #include <catch.hpp>
-#include <limits>
 #include <span>
 #include <vector>
 

--- a/test/core/ds/bloom.cpp
+++ b/test/core/ds/bloom.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "core/ds/bloom.hpp"
+#include <catch.hpp>
+#include <limits>
+#include <span>
+#include <vector>
+
+using namespace pepp;
+
+namespace {
+
+// Generate a number of keys for testing using PRNG for reproducibility.
+std::vector<u32> make_keys(std::size_t count, u64 seed = 0x1234'5678'9abc'def0ull) {
+  std::vector<u32> keys;
+  keys.reserve(count);
+  u64 state = seed;
+  for (std::size_t i = 0; i < count; ++i) {
+    state = splitmix64(state);
+    keys.push_back(static_cast<u32>(state));
+  }
+  return keys;
+}
+
+template <class Filter> void check_no_false_negatives(std::span<const typename Filter::key_type> keys) {
+  Filter filter;
+  filter.rebuild(keys);
+  for (auto key : keys) CHECK(filter.maybe_contains(key));
+}
+
+} // namespace
+
+TEST_CASE("SplitBlockBloom", "[scope:core][kind:unit][arch:*]") {
+  using Key = u32;
+  const auto members = make_keys(24);
+  const auto keys = std::span<const Key>(members);
+
+  SECTION("An empty filter rejects everything") {
+    SplitBlockBloom<Key, 256> filter;
+    CHECK(filter.popcount() == 0);
+    for (auto key : make_keys(4096, 0xfeed'face'dead'beefull)) CHECK_FALSE(filter.maybe_contains(key));
+  }
+
+  SECTION("No false negatives, across sizes and hash algorithms") {
+    check_no_false_negatives<SplitBlockBloom<Key, 64, 1>>(keys);
+    check_no_false_negatives<SplitBlockBloom<Key, 64, 2>>(keys);
+    check_no_false_negatives<SplitBlockBloom<Key, 256, 2>>(keys);
+    check_no_false_negatives<SplitBlockBloom<Key, 1024, 2>>(keys);
+    // Increase K.
+    check_no_false_negatives<SplitBlockBloom<Key, 256, 4>>(keys);
+    check_no_false_negatives<SplitBlockBloom<Key, 256, 8>>(keys);
+    // Dropping the low bits won't affect correctness, just false-positive rate.
+    check_no_false_negatives<SplitBlockBloom<Key, 256, 2, 2>>(keys);
+    check_no_false_negatives<SplitBlockBloom<Key, 256, 2, 6>>(keys);
+    // Footprints that are not a power of two.
+    check_no_false_negatives<SplitBlockBloom<Key, 24, 2>>(keys);
+    check_no_false_negatives<SplitBlockBloom<Key, 1000, 4, 2>>(keys);
+    // Test all hash policies
+    check_no_false_negatives<SplitBlockBloom<Key, 256, 2, 0, SplitMix64Hash>>(keys);
+    check_no_false_negatives<SplitBlockBloom<Key, 256, 2, 0, FibonacciHash>>(keys);
+    check_no_false_negatives<SplitBlockBloom<Key, 256, 2, 0, IdentityHash>>(keys);
+  }
+
+  SECTION("Overfilling degrades the false-positive rate but not correctness") {
+    // Ineffective filter, but ever key will return true.
+    const auto many = make_keys(4096);
+    check_no_false_negatives<SplitBlockBloom<Key, 64, 2>>(many);
+  }
+
+  SECTION("clear() returns the filter to empty") {
+    SplitBlockBloom<Key, 256> filter(keys);
+    CHECK(filter.popcount() > 0);
+    filter.clear();
+    CHECK(filter.popcount() == 0);
+    CHECK_FALSE(filter.maybe_contains(members.front()));
+  }
+
+  SECTION("rebuild() functions as a clear") {
+    SplitBlockBloom<Key, 1024, 2> filter(keys);
+    CHECK(filter.popcount() > 0);
+    filter.rebuild(std::span<const Key>{});
+    CHECK(filter.popcount() == 0);
+  }
+
+  SECTION("SHIFT quantizes keys") {
+    constexpr unsigned kShift = 4;
+    SplitBlockBloom<Key, 256, 2, kShift> filter;
+    const Key key = 0x0001'2340;
+    filter.insert(key);
+    for (Key offset = 0; offset < (1u << kShift); ++offset) CHECK(filter.maybe_contains(key + offset));
+  }
+
+  SECTION("Footprints are as expected") {
+    CHECK(sizeof(SplitBlockBloom<Key, 64>) == 64);
+    CHECK(sizeof(SplitBlockBloom<Key, 256>) == 256);
+    CHECK(sizeof(SplitBlockBloom<Key, 1024, 2>) == 1024);
+    CHECK(sizeof(SplitBlockBloom<Key, 24, 2>) == 24);
+    CHECK(SplitBlockBloom<Key, 256>::NBLOCKS == 32);
+  }
+
+  SECTION("Usable at compile time") {
+    constexpr bool found = [] {
+      SplitBlockBloom<Key, 64, 2> filter;
+      filter.insert(0x1234'5678);
+      return filter.maybe_contains(0x1234'5678);
+    }();
+    STATIC_REQUIRE(found);
+  }
+}

--- a/test/core/ds/bloom_bench.cpp
+++ b/test/core/ds/bloom_bench.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 J. Stanley Warford, Matthew McRaven
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// Measure false-positive rates for SplitBlockBloomFilter.
+#include <array>
+#include <catch.hpp>
+#include <set>
+#include <span>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+#include "core/ds/bloom.hpp"
+#include "fmt/format.h"
+
+using namespace pepp;
+
+namespace {
+// Try keys from 0..kSpace in the test function,
+constexpr u32 kSpace = 1u << 16;
+// Averaged over this many independently generated member sets.
+constexpr unsigned kTrials = 8;
+constexpr u64 kSeed = 0x5eed'1234'abcd'0001ull;
+constexpr std::array<u32, 3> kCounts = {4, 16, 64};
+
+// Sample count values from from [0, kSpace), in runs of adjacent keys.
+// Large run values cluster keys, while small values distribute them.
+template <typename Key> std::vector<Key> make_members(u32 count, unsigned run, u64 seed) {
+  std::set<Key> keys;
+  u64 state = seed;
+  while (keys.size() < count) {
+    state = splitmix64(state);
+    const u32 base = static_cast<u32>(state % kSpace);
+    for (unsigned i = 0; i < run && keys.size() < count; ++i) keys.insert(static_cast<Key>((base + i) % kSpace));
+  }
+  return {keys.begin(), keys.end()};
+}
+
+// A result from a single trial.
+struct Cell {
+  double fp = 0.0;
+  double bits = 0.0;
+};
+
+// Search the entire declared key space.
+template <class Filter> Cell measure(u32 count, unsigned run) {
+  using Key = typename Filter::key_type;
+  Cell total;
+  for (unsigned trial = 0; trial < kTrials; ++trial) {
+    const auto members = make_members<Key>(count, run, kSeed + trial);
+    const std::unordered_set<Key> truth(members.begin(), members.end());
+    const Filter filter(members);
+    u64 positives = 0, negatives = 0;
+    for (u32 q = 0; q < kSpace; ++q) {
+      const Key key = static_cast<Key>(q);
+      if (truth.contains(key)) continue;
+      negatives += 1, positives += filter.maybe_contains(key);
+    }
+    total.fp += negatives ? 100.0 * static_cast<double>(positives) / static_cast<double>(negatives) : 0.0;
+    total.bits += static_cast<double>(filter.popcount());
+  }
+  total.fp /= kTrials;
+  total.bits /= kTrials;
+  return total;
+}
+
+// Two row header. Key counts on top, the K values underneath each count.
+void print_header(std::string_view title, std::span<const u32> counts, std::span<const unsigned> ks) {
+  fmt::print("\n{}\n", title);
+  fmt::print("  {:<12}", "");
+  for (u32 n : counts) fmt::print("{:^{}}", fmt::format("n={}", n), 8 * ks.size());
+  fmt::print("\n  {:<12}", "size");
+  for (std::size_t i = 0; i < counts.size(); ++i)
+    for (unsigned k : ks) fmt::print("{:>8}", fmt::format("K={}", k));
+  fmt::print("\n");
+}
+
+template <typename Key, class Hash, std::size_t BYTES, unsigned... K>
+void print_size_row(std::span<const u32> counts, std::integer_sequence<unsigned, K...>) {
+  static constexpr u32 run_size = 1;
+  std::vector<Cell> cells;
+  for (u32 n : counts) (cells.push_back(measure<SplitBlockBloom<Key, BYTES, K, 0, Hash>>(n, run_size)), ...);
+  fmt::print("  {:<7}{:<5}", fmt::format("{}B", BYTES), "fp%");
+  for (const auto &cell : cells) fmt::print("{:>8.2f}", cell.fp);
+  fmt::print("\n  {:<7}{:<5}", "", "bits");
+  for (const auto &cell : cells) fmt::print("{:>8.0f}", cell.bits);
+  fmt::print("\n");
+}
+
+template <typename Key, class Hash, std::size_t... BYTES>
+void size_table(std::string_view hash_name, std::index_sequence<BYTES...>) {
+  constexpr std::array<unsigned, 4> ks = {1, 2, 4, 8};
+  print_header(fmt::format("Error Rate for key count and k vs size  shift=0, hash={}", hash_name), kCounts, ks);
+  (print_size_row<Key, Hash, BYTES>(kCounts, std::integer_sequence<unsigned, 1, 2, 4, 8>{}), ...);
+}
+} // namespace
+
+TEST_CASE("SplitBlockBloom false-positive rates", "[scope:core][kind:perf][arch:*]") {
+  using Key = u32;
+  constexpr auto sizes = std::index_sequence<16, 32, 64, 128, 192, 256, 512, 1024>{};
+
+  size_table<Key, FibonacciHash>("FibonacciHash", sizes);
+  size_table<Key, IdentityHash>("IdentityHash", sizes);
+  size_table<Key, SplitMix64Hash>("SplitMix64Hash", sizes);
+}


### PR DESCRIPTION
Rather than use an exact filter, I use a cheap split block bloom filter, which will only touch a single cache line.
When removing BPs, you need to rebuild the entire set from scratch.

On a miss, you are guaranteed that the PC value does not have a BP.
On a hit, you need to make an exact test against the debugger.
This pattern exists in the `sim3` version of the simulator, and this PR just brings the feature forward.

I went with a bloom filter over a bitmap so that I can use the same datatructure between Pep/N and RISC-V.