### PR TITLE
Improve local compile times

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,12 +167,18 @@ jobs:
         env:
           DEVELOPER_NAME: ${{ secrets.MAC_DEVELOPER_TEAM_ID }}
           CCACHE_LOGFILE: ccache.log
+          # ccache needs adjustments for precompiled headers to work.
+          # See: https://ccache.dev/manual/latest.html#_precompiled_headers
+          CCACHE_SLOPPINESS: pch_defines,time_macros
 
 
       - name: Run build
         run: cmake --build build -j6 ${{ contains(inputs.name, 'MSVC') && format('--config {0}', inputs.variant) ||'' }}
         env:
           CCACHE_LOGFILE: ccache.log
+          # ccache needs adjustments for precompiled headers to work.
+          # See: https://ccache.dev/manual/latest.html#_precompiled_headers
+          CCACHE_SLOPPINESS: pch_defines,time_macros
 
       - name: Upload compile_commands.json on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,8 @@ jobs:
           - { name: "Ubuntu 24.04; EMSDK 4.1.07", cache_name: 'ubuntu-emsdk', runs-on: "ubuntu-latest", image: "ghcr.io/matthew-mcraven/pepp/wasm:v0.18.1", cmake_generator: "Ninja", compiler_launcher: "ccache", cmake_toolchain: '$Qt6_DIR/qt.toolchain.cmake', cmake_xargs: '-D QT_HOST_PATH=/qt/6.11.0/gcc_64', release_variant: 'MinSizeRel', debug_variant: 'MinSizeRel' }
           # See: https://bugreports.qt.io/browse/QTBUG-118086
           - { name: "MacOS-15 ARM64", cache_name: 'macos-clang-arm', runs-on: "macos-15" , compiler_launcher: "ccache", compiler_c: 'clang', compiler_cpp: 'clang++', cmake_generator: "Ninja", artifact_key: "artifact-macos-arm", cmake_xargs: '-D CMAKE_OSX_ARCHITECTURES=arm64' }
-          - { name: "MacOS-15 x86-64", cache_name: 'macos-clang-x86', runs-on: "macos-15" , compiler_launcher: "ccache", compiler_c: 'clang', compiler_cpp: 'clang++', cmake_generator: "Ninja", artifact_key: "artifact-macos-x86", cmake_xargs: '-D CMAKE_OSX_ARCHITECTURES=x86_64' }
+          # Also disabled precompiled headers as a canary case. MacOS tends to be the fastest.
+          - { name: "MacOS-15 x86-64", cache_name: 'macos-clang-x86', runs-on: "macos-15" , compiler_launcher: "ccache", compiler_c: 'clang', compiler_cpp: 'clang++', cmake_generator: "Ninja", artifact_key: "artifact-macos-x86", cmake_xargs: '-D CMAKE_OSX_ARCHITECTURES=x86_64 -D PEPP_PRECOMPILE_HEADERS=OFF' }
           - { name: "Windows Latest; MSVC", cache_name: 'windows-msvc', runs-on: "windows-latest" , compiler_launcher: "ccache", artifact_key: "artifact-windows", cmake_generator: "Ninja", debug_variant: 'Release', release_variant: 'Release', cmake_xargs: '-D CMAKE_C_COMPILER=cl -D CMAKE_CXX_COMPILER=cl'}
 
     permissions:

--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -43,7 +43,30 @@ if(PEPP_BUILD_GUI)
   # On Windows, we ship with MSVC redistributable. Mismatch on static CRT
   # linkage causes compile errors on Windows.
   set(WITH_STATIC_CRT CACHE INTERNAL FALSE FORCE)
+  # Build only the antlr4 runtime flavor we actually link. Default builds both,
+  # which wastes compile time.
+  if(BUILD_SHARED_LIBS)
+    set(ANTLR_BUILD_SHARED
+        ON
+        CACHE BOOL "" FORCE)
+    set(ANTLR_BUILD_STATIC
+        OFF
+        CACHE BOOL "" FORCE)
+    set(PEPP_ANTLR4_TARGET antlr4_shared)
+  else()
+    set(ANTLR_BUILD_SHARED
+        OFF
+        CACHE BOOL "" FORCE)
+    set(ANTLR_BUILD_STATIC
+        ON
+        CACHE BOOL "" FORCE)
+    set(PEPP_ANTLR4_TARGET antlr4_static)
+  endif()
   add_subdirectory(antlr4)
+  # Consumers link ${PEPP_ANTLR4_TARGET} rather than naming a flavor.
+  set(PEPP_ANTLR4_TARGET
+      ${PEPP_ANTLR4_TARGET}
+      PARENT_SCOPE)
 
   add_subdirectory(scintilla)
 
@@ -103,7 +126,7 @@ if(PEPP_BUILD_GUI)
       endif()
     endforeach()
     pepp_precompile_headers(
-      antlr4_shared PRIVATE
+      ${PEPP_ANTLR4_TARGET} PRIVATE
       "${CMAKE_CURRENT_LIST_DIR}/antlr4/runtime/src/antlr4-common.h"
       "${CMAKE_CURRENT_LIST_DIR}/antlr4/runtime/src/Exceptions.h")
   endif()

--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -92,9 +92,16 @@ if(PEPP_BUILD_GUI)
       PARENT_SCOPE)
 
   if(PEPP_PRECOMPILE_HEADERS)
+
     pepp_precompile_headers(scintilla_qt PRIVATE <QtCore>)
     pepp_precompile_headers(lexilla PRIVATE <QtCore>)
     pepp_precompile_headers(kddockwidgets PRIVATE <QtCore>)
+    # The unit-test targets only inherited catch.hpp via catch's INTERFACE PCH.
+    foreach(_t IN ITEMS lexilla_unit scintilla_unit_qt)
+      if(TARGET ${_t})
+        pepp_precompile_headers(${_t} PRIVATE <QtCore>)
+      endif()
+    endforeach()
     pepp_precompile_headers(
       antlr4_shared PRIVATE
       "${CMAKE_CURRENT_LIST_DIR}/antlr4/runtime/src/antlr4-common.h"

--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -90,6 +90,16 @@ if(PEPP_BUILD_GUI)
   set(monaspace_SOURCE_DIR
       "${CMAKE_CURRENT_BINARY_DIR}/monaspace"
       PARENT_SCOPE)
+
+  if(PEPP_PRECOMPILE_HEADERS)
+    pepp_precompile_headers(scintilla_qt PRIVATE <QtCore>)
+    pepp_precompile_headers(lexilla PRIVATE <QtCore>)
+    pepp_precompile_headers(kddockwidgets PRIVATE <QtCore>)
+    pepp_precompile_headers(
+      antlr4_shared PRIVATE
+      "${CMAKE_CURRENT_LIST_DIR}/antlr4/runtime/src/antlr4-common.h"
+      "${CMAKE_CURRENT_LIST_DIR}/antlr4/runtime/src/Exceptions.h")
+  endif()
 endif()
 
 # CXXGraph has some annoying packaging "stuff" for being a header-only library

--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -22,8 +22,9 @@ if(EMSCRIPTEN OR NOT PEPP_BUILD_GUI)
       OFF
       CACHE BOOL "" FORCE)
 else(PEPP_BUILD_GUI)
+  # Avoid building mockturtle until we start simulating circuits.
   set(MOCKTURTLE_BUILD_TESTS
-      ON
+      OFF
       CACHE BOOL "" FORCE)
 endif()
 add_subdirectory(mockturtle)

--- a/3rd-party/antlr4/runtime/src/Lexer.cpp
+++ b/3rd-party/antlr4/runtime/src/Lexer.cpp
@@ -94,7 +94,7 @@ std::unique_ptr<Token> Lexer::nextToken() {
       }
     } while (type == MORE);
     if (token == nullptr) {
-      emit();
+      emitToken();
     }
     return std::move(token);
   }
@@ -152,20 +152,19 @@ CharStream* Lexer::getInputStream() {
   return _input;
 }
 
-void Lexer::emit(std::unique_ptr<Token> newToken) {
-  token = std::move(newToken);
-}
+void Lexer::emitToken(std::unique_ptr<Token> newToken) { token = std::move(newToken); }
 
-Token* Lexer::emit() {
-  emit(_factory->create({ this, _input }, type, _text, channel,
-    tokenStartCharIndex, getCharIndex() - 1, tokenStartLine, tokenStartCharPositionInLine));
+Token *Lexer::emitToken() {
+  emitToken(_factory->create({this, _input}, type, _text, channel, tokenStartCharIndex, getCharIndex() - 1,
+                             tokenStartLine, tokenStartCharPositionInLine));
   return token.get();
 }
 
 Token* Lexer::emitEOF() {
   size_t cpos = getCharPositionInLine();
   size_t line = getLine();
-  emit(_factory->create({ this, _input }, EOF, "", Token::DEFAULT_CHANNEL, _input->index(), _input->index() - 1, line, cpos));
+  emitToken(_factory->create({this, _input}, EOF, "", Token::DEFAULT_CHANNEL, _input->index(), _input->index() - 1,
+                             line, cpos));
   return token.get();
 }
 

--- a/3rd-party/antlr4/runtime/src/Lexer.h
+++ b/3rd-party/antlr4/runtime/src/Lexer.h
@@ -113,14 +113,14 @@ namespace antlr4 {
     /// for efficiency reasons. Subclasses can override this method, nextToken,
     /// and getToken (to push tokens into a list and pull from that list
     /// rather than a single variable as this implementation does).
-    virtual void emit(std::unique_ptr<Token> newToken);
+    virtual void emitToken(std::unique_ptr<Token> newToken);
 
     /// The standard method called to automatically emit a token at the
     /// outermost lexical rule.  The token object should point into the
     /// char buffer start..stop.  If there is a text override in 'text',
     /// use that to set the token's text.  Override this method to emit
     /// custom Token objects or provide a new factory.
-    virtual Token* emit();
+    virtual Token *emitToken();
 
     virtual Token* emitEOF();
 

--- a/3rd-party/catch/CMakeLists.txt
+++ b/3rd-party/catch/CMakeLists.txt
@@ -7,12 +7,14 @@ project(catch VERSION 3.5.1)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 # Link against this target to be able to use catch features.
 add_library(catch ${CMAKE_CURRENT_LIST_DIR}/catch.cpp)
 set_target_properties(catch PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(catch PUBLIC CATCH_AMALGAMATED_CUSTOM_MAIN)
 target_include_directories(catch PUBLIC .)
+
+pepp_precompile_headers(catch PUBLIC "${CMAKE_CURRENT_LIST_DIR}/catch.hpp")
 
 # Link against this target to get catch plus a default main.
 add_library(catch-main INTERFACE catch_main.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,27 +13,35 @@ option(BUILD_SHARED_LIBS
        "Build using shared libraries. May be ignored on some platforms" ON)
 option(PEPP_BUILD_PYTHON "Build only Python bindings" OFF)
 option(PEPP_BUILD_GUI "Build GUI applications" ON)
-# Allow normalized paths (e.g., "toolchain/pas" ) without nesting that directory
-# folder inside a nested "src" hierarchy. May cause linking issues if you do not
-# pay attention.
-include_directories(${CMAKE_CURRENT_LIST_DIR}/lib)
-
 option(SANITIZE "Enable sanitizers" OFF)
 option(CODECOV "Enable code coverage" OFF)
 option(TIME_TRACE "Enable clang time trace" OFF)
-if(SANITIZE AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  add_compile_options(-fsanitize=undefined -fsanitize=address)
-  add_link_options(-fsanitize=undefined -fsanitize=address)
-endif()
-if(TIME_TRACE AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  add_compile_options(-ftime-trace)
-endif()
 
 # DO NOT AUTO-FORMAT. CI looks for a line with this format to extract the
 # version.
 # cmake-format: off
 project(Pepp VERSION 0.16.0 LANGUAGES C CXX)
 # cmake-format: on
+
+# Allow normalized paths (e.g., "toolchain/pas" ) without nesting that directory
+# folder inside a nested "src" hierarchy. May cause linking issues if you do not
+# pay attention.
+include_directories(${CMAKE_CURRENT_LIST_DIR}/lib)
+
+if(SANITIZE AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  add_compile_options(-fsanitize=undefined -fsanitize=address)
+  add_link_options(-fsanitize=undefined -fsanitize=address)
+endif()
+if(TIME_TRACE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  message(STATUS "Enabling clang time trace")
+  add_compile_options(-ftime-trace)
+endif()
+# Clang stamps the PCH with its sources' times and rejects the PCH when they
+# differ. If using PCH with a compiler cache, this would effectively invalidate
+# the cache. See: https://ccache.dev/manual/latest.html#_precompiled_headers
+if(PEPP_PRECOMPILE_HEADERS AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Xclang -fno-pch-timestamp)
+endif()
 
 include(config/cmake/inject_defs.cmake)
 # Not respected by all generators, but incredibly useful when debugging builds.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,11 +37,16 @@ if(TIME_TRACE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   message(STATUS "Enabling clang time trace")
   add_compile_options(-ftime-trace)
 endif()
-# Clang stamps the PCH with its sources' times and rejects the PCH when they
-# differ. If using PCH with a compiler cache, this would effectively invalidate
-# the cache. See: https://ccache.dev/manual/latest.html#_precompiled_headers
-if(PEPP_PRECOMPILE_HEADERS AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Xclang -fno-pch-timestamp)
+
+if(PEPP_PRECOMPILE_HEADERS)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Clang stamps the PCH with its sources' times and rejects the PCH when they
+    # differ. If using PCH with a compiler cache, this would effectively invalidate
+    # the cache. See: https://ccache.dev/manual/latest.html#_precompiled_headers
+    add_compile_options(-Xclang -fno-pch-timestamp)
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    add_compile_options(/Yl-)
+  endif()
 endif()
 
 include(config/cmake/inject_defs.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,12 @@ if(PEPP_PRECOMPILE_HEADERS)
     # the cache. See: https://ccache.dev/manual/latest.html#_precompiled_headers
     add_compile_options(-Xclang -fno-pch-timestamp)
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    # /Yl is on by default with precompiled headers.
+    # CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS exports a marker type and the linker
+    # produces a warning (LNK4022 / LNK4002). /Yl- omits the marker, and is a
+    # no-op wherever /Yc is not used. Do not combine with /Z7, else it produces
+    # LNK1211/LNK4206 instead.
+    # https://learn.microsoft.com/en-us/cpp/build/reference/yl-inject-pch-reference-for-debug-library
     add_compile_options(/Yl-)
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ option(BUILD_SHARED_LIBS
        "Build using shared libraries. May be ignored on some platforms" ON)
 option(PEPP_BUILD_PYTHON "Build only Python bindings" OFF)
 option(PEPP_BUILD_GUI "Build GUI applications" ON)
+option(PEPP_PRECOMPILE_HEADERS "Enable precompiled headers" ON)
 option(SANITIZE "Enable sanitizers" OFF)
 option(CODECOV "Enable code coverage" OFF)
 option(TIME_TRACE "Enable clang time trace" OFF)
@@ -44,6 +45,7 @@ if(PEPP_PRECOMPILE_HEADERS AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 include(config/cmake/inject_defs.cmake)
+include(config/cmake/pch.cmake)
 # Not respected by all generators, but incredibly useful when debugging builds.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 23)

--- a/bin/circuit/CMakeLists.txt
+++ b/bin/circuit/CMakeLists.txt
@@ -15,7 +15,6 @@ qt_add_qml_module(
   ui/ComponentEditor.qml
   ui/BluePrintListView.qml
   SOURCES
-
   ui/blueprintlibrarymodel.hpp
   ui/blueprintlibrarymodel.cpp
   ui/componentpropertymodel.hpp
@@ -64,3 +63,7 @@ target_link_libraries(
           pepp-core)
 
 set_target_properties(CircuitDesign PROPERTIES FOLDER "qtc_runnable")
+
+if(PEPP_PRECOMPILE_HEADERS)
+  target_precompile_headers(CircuitDesign PRIVATE <QtCore>)
+endif()

--- a/bin/ide/CMakeLists.txt
+++ b/bin/ide/CMakeLists.txt
@@ -83,7 +83,7 @@ if(WIN32)
     COMMAND_EXPAND_LISTS)
   # Must specify antlr, because we can't easily install 3rd-party deps.
   install(
-    TARGETS pepp pepp-lib test-lib-all
+    TARGETS pepp pepp-lib
     COMPONENT Pepp
     RUNTIME DESTINATION bin
     BUNDLE DESTINATION .)
@@ -91,7 +91,7 @@ elseif(APPLE)
   # Install our pepp application antlr4 isn't copied by any target since it is a
   # 3rd-party dependency. we must copy it here in a platform-dependent way.
   install(
-    TARGETS pepp pepp-lib test-lib-all
+    TARGETS pepp pepp-lib
     COMPONENT Pepp
     LIBRARY DESTINATION pepp.app/Contents/Frameworks
     BUNDLE DESTINATION .)
@@ -106,7 +106,7 @@ elseif(APPLE)
   set_target_properties(pepp PROPERTIES OUTPUT_NAME "Pepp")
 elseif(EMSCRIPTEN)
   install(
-    TARGETS pepp pepp-lib test-lib-all
+    TARGETS pepp pepp-lib
     COMPONENT Pepp
     RUNTIME DESTINATION bin
     BUNDLE DESTINATION .)
@@ -119,7 +119,7 @@ elseif(EMSCRIPTEN)
 else()
   # Otherwise use default install logic on Linux for now.
   install(
-    TARGETS pepp pepp-lib test-lib-all
+    TARGETS pepp pepp-lib
     COMPONENT Pepp
     RUNTIME DESTINATION bin
     BUNDLE DESTINATION .)

--- a/bin/ide/CMakeLists.txt
+++ b/bin/ide/CMakeLists.txt
@@ -69,7 +69,7 @@ set_target_properties(
              WIN32_EXECUTABLE TRUE
              FOLDER "qtc_runnable")
 # DLL/dylibs/SO we want to copy without copying over their headers too
-set(pepp_vendored_libs antlr4_shared fmt spdlog catch)
+set(pepp_vendored_libs ${PEPP_ANTLR4_TARGET} fmt spdlog catch)
 if(WIN32)
   # Non-DLL platforms have empty generator expression, so use more generator
   # magic to only copy DLLs if they exist.

--- a/bin/simexp/CMakeLists.txt
+++ b/bin/simexp/CMakeLists.txt
@@ -10,8 +10,14 @@ qt_add_executable(
   event_scheduler.cpp
   sim_top.cpp
   sim_device.cpp
-  sim_eventhandle.hpp sim_eventhandle.cpp
-  sim_clocktree.hpp sim_clocktree.cpp)
+  sim_eventhandle.hpp
+  sim_eventhandle.cpp
+  sim_clocktree.hpp
+  sim_clocktree.cpp)
 
 target_link_libraries(simexp PRIVATE pepp-core)
 set_target_properties(simexp PROPERTIES FOLDER "qtc_runnable")
+
+if(PEPP_PRECOMPILE_HEADERS)
+  target_precompile_headers(simexp PRIVATE <QtCore>)
+endif()

--- a/bin/term/CMakeLists.txt
+++ b/bin/term/CMakeLists.txt
@@ -74,6 +74,21 @@ file(REMOVE \"\${_dir}/${alias}\")
 file(CREATE_LINK \"${path_prefix}pepp-term\" \"\${_dir}/${alias}\" SYMBOLIC)
 ")
   install(SCRIPT "${_script}" COMPONENT Pepp)
+  # Also place the alias next to pepp-term in the build tree, so it is usable
+  # without installing. Windows symlinks need elevation/developer mode, so
+  # build-tree aliases are POSIX-only.
+  if(NOT
+     (WIN32
+      OR EMSCRIPTEN
+      OR IOS))
+    add_custom_command(
+      TARGET pepp-term
+      POST_BUILD
+      COMMAND
+        ${CMAKE_COMMAND} ARGS -E create_symlink $<TARGET_FILE_NAME:pepp-term>
+        "$<TARGET_FILE_DIR:pepp-term>/${alias}"
+      VERBATIM)
+  endif()
 endfunction()
 add_term_alias(readelf)
 add_term_alias(addr2line)

--- a/bin/term/CMakeLists.txt
+++ b/bin/term/CMakeLists.txt
@@ -5,6 +5,10 @@ target_link_libraries(pepp-term PRIVATE cli Qt6::Core catch test-lib-all
                                         pepp-lib catch)
 set_target_properties(pepp-term PROPERTIES FOLDER "qtc_runnable")
 
+if(PEPP_PRECOMPILE_HEADERS)
+  target_precompile_headers(pepp-term PRIVATE <QtCore>)
+endif()
+
 if(WIN32)
   install(
     TARGETS pepp-term

--- a/config/cmake/create_targets.cmake
+++ b/config/cmake/create_targets.cmake
@@ -10,6 +10,11 @@ qt6_add_library(test-lib-all-int INTERFACE)
 qt6_add_library(test-lib-all OBJECT)
 target_link_libraries(test-lib-all PUBLIC test-lib-all-int)
 set_target_properties(test-lib-all PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# Don't need catch.hpp, because it arrives via an INTERFACE precompiled header
+if(PEPP_PRECOMPILE_HEADERS)
+  pepp_precompile_headers(test-lib-all PRIVATE <QtCore>)
+endif()
 # test-all bundles all the tests into a single executable to provide a runnable
 # target in the IDE other than pepp-term selftest.
 qt6_add_executable(test-all ${PROJECT_SOURCE_DIR}/config/cmake/main.cpp)

--- a/config/cmake/create_targets.cmake
+++ b/config/cmake/create_targets.cmake
@@ -13,7 +13,12 @@ set_target_properties(test-lib-all PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Don't need catch.hpp, because it arrives via an INTERFACE precompiled header
 if(PEPP_PRECOMPILE_HEADERS)
-  pepp_precompile_headers(test-lib-all PRIVATE <QtCore>)
+  # Most expensive headers as profiled so far. Paths resolve relative to this
+  # dir, so use abs paths.
+  pepp_precompile_headers(
+    test-lib-all PRIVATE <QtCore>
+    "${PROJECT_SOURCE_DIR}/lib/sim/debug/debugger.hpp"
+    "${PROJECT_SOURCE_DIR}/core/core/math/geom/interval.hpp")
 endif()
 # test-all bundles all the tests into a single executable to provide a runnable
 # target in the IDE other than pepp-term selftest.

--- a/config/cmake/create_targets.cmake
+++ b/config/cmake/create_targets.cmake
@@ -4,17 +4,17 @@ include_guard()
 # dependent on all the tests' libaries. Our test browser must depend on this
 # target.
 qt6_add_library(test-lib-all-int INTERFACE)
-# test-all bundles all the tests into a single executable to prove that there
-# are no linker errors. do not add to ctest, otherwise every test runs twice.
-qt6_add_executable(test-all ${PROJECT_SOURCE_DIR}/config/cmake/main.cpp)
-# Make test-lib-all a library of all of our sources to reduce the number of
+# Make test-lib-all a library of all of our objects to reduce the number of
 # object members we "bubble up" to other targets. Otherwise we can hit LNK1189
-# on Windows
-qt6_add_library(test-lib-all)
+# on Windows.
+qt6_add_library(test-lib-all OBJECT)
 target_link_libraries(test-lib-all PUBLIC test-lib-all-int)
 set_target_properties(test-lib-all PROPERTIES POSITION_INDEPENDENT_CODE ON)
-set_target_properties(test-all PROPERTIES FOLDER "qtc_runnable")
+# test-all bundles all the tests into a single executable to provide a runnable
+# target in the IDE other than pepp-term selftest.
+qt6_add_executable(test-all ${PROJECT_SOURCE_DIR}/config/cmake/main.cpp)
 target_link_libraries(test-all PUBLIC test-lib-all catch)
+set_target_properties(test-all PROPERTIES FOLDER "qtc_runnable")
 # Failure to copy DLLs on Windows causes tests to fail at runtime.
 if(WIN32)
   add_custom_command(
@@ -31,7 +31,7 @@ define_property(GLOBAL PROPERTY ALL_LIBRARIES)
 set_property(GLOBAL PROPERTY ALL_LIBRARIES "")
 
 function(catch_test_count count_name)
-  get_target_property(FILES test-lib-all INTERFACE_SOURCES)
+  get_target_property(FILES test-lib-all SOURCES)
   list(LENGTH FILES count)
   # message("Test count: ${count} with files ${FILES}")
   set(${count_name}

--- a/config/cmake/pch.cmake
+++ b/config/cmake/pch.cmake
@@ -1,0 +1,29 @@
+include_guard()
+
+# Wrapper around target_precompile_headers that restricts the PCH to C++.
+#
+# `project()` enables C as well as CXX, so CMake emits a C variant of the
+# precompiled header (cmake_pch.h) next to the C++ one. Given that our code in
+# PCHs are exclusively C++, we get compile errors.
+#
+# Restricting each entry to $<COMPILE_LANGUAGE:CXX> makes CMake skip the C
+# variant altogether. Angle-bracket names need $<ANGLE-R> for their closing
+# bracket, otherwise it terminates the generator expression early.
+#
+# Usage: pepp_precompile_headers(<target> <PRIVATE|PUBLIC|INTERFACE>
+# <headers...>)
+function(pepp_precompile_headers target visibility)
+  if(NOT PEPP_PRECOMPILE_HEADERS)
+    return()
+  endif()
+  set(guarded "")
+  foreach(hdr IN LISTS ARGN)
+    if(hdr MATCHES "^<(.+)>$")
+      list(APPEND guarded
+           "$<$<COMPILE_LANGUAGE:CXX>:<${CMAKE_MATCH_1}$<ANGLE-R>>")
+    else()
+      list(APPEND guarded "$<$<COMPILE_LANGUAGE:CXX>:${hdr}>")
+    endif()
+  endforeach()
+  target_precompile_headers(${target} ${visibility} ${guarded})
+endfunction()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -17,9 +17,8 @@ target_link_libraries(
          cnl)
 target_include_directories(pepp-core PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
-# Only precompile standard library headers for now. In the future, this could be
-# extended to include common "internal" headers.
 if(PEPP_PRECOMPILE_HEADERS)
+  # Precompile elements of the standard library.
   pepp_precompile_headers(
     pepp-core
     PRIVATE
@@ -31,4 +30,7 @@ if(PEPP_PRECOMPILE_HEADERS)
     <algorithm>
     <stdexcept>
     <array>)
+  # Precompile most expensive headers from this library.
+  pepp_precompile_headers(
+    pepp-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/core/math/geom/interval.hpp")
 endif()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -16,3 +16,19 @@ target_link_libraries(
          zpp_bits
          cnl)
 target_include_directories(pepp-core PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+
+# Only precompile standard library headers for now. In the future, this could be
+# extended to include common "internal" headers.
+if(PEPP_PRECOMPILE_HEADERS)
+  pepp_precompile_headers(
+    pepp-core
+    PRIVATE
+    <string>
+    <memory>
+    <vector>
+    <map>
+    <optional>
+    <algorithm>
+    <stdexcept>
+    <array>)
+endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -58,7 +58,7 @@ target_link_libraries(
          Qt6::Quick
          Qt6::Sql
          $<$<TARGET_EXISTS:Qt6::Concurrent>:Qt6::Concurrent>
-         antlr4_shared
+         ${PEPP_ANTLR4_TARGET}
          elfio
          lru-cache
          scintilla_qt
@@ -72,7 +72,8 @@ target_link_libraries(
          pepp-changelog)
 # Will fail to find hpp files without this, see
 # https://bugreports.qt.io/browse/QTBUG-101146.
-get_target_property(ANTLR4_INCLUDE_DIR antlr4_shared INCLUDE_DIRECTORIES)
+get_target_property(ANTLR4_INCLUDE_DIR ${PEPP_ANTLR4_TARGET}
+                    INCLUDE_DIRECTORIES)
 target_include_directories(pepp-lib PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
                                            ${ANTLR4_INCLUDE_DIR})
 target_include_directories(

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -45,6 +45,12 @@ qt_add_qml_module(
   OUTPUT_DIRECTORY
   "${CMAKE_BINARY_DIR}/edu/pepp")
 target_compile_definitions(pepp-lib PRIVATE "PEPP_LIBRARY")
+
+# Parsing Qt headers is the dominant cost of building this library, profiled via
+# ClangBuildAnalyzer.
+if(PEPP_PRECOMPILE_HEADERS)
+  pepp_precompile_headers(pepp-lib PRIVATE <QtCore> <QtQmlIntegration>)
+endif()
 target_link_libraries(
   pepp-lib
   PUBLIC Qt6::Core

--- a/lib/toolchain/pas/ast/pepp/attr_instruction.hpp
+++ b/lib/toolchain/pas/ast/pepp/attr_instruction.hpp
@@ -20,13 +20,13 @@
 #include "core/arch/pep/isa/pep10.hpp"
 #include "core/arch/pep/isa/pep9.hpp"
 
+namespace pas::ast::pepp {
 namespace detail {
 template <typename ISA> constexpr uint8_t attr() { return 19; }
 template <> constexpr uint8_t attr<isa::Pep10>() { return 191; };
 template <> constexpr uint8_t attr<isa::Pep9>() { return 190; };
 } // namespace detail
 
-namespace pas::ast::pepp {
 template <typename ISA> struct Instruction {
   static const inline QString attributeName = "pepp:instr";
   static const inline uint8_t attribute = detail::attr<ISA>();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 file(GLOB_RECURSE tests CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/*.cpp")
 
 get_filename_component(CURRENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
-target_sources(test-lib-all INTERFACE ${tests})
+target_sources(test-lib-all PRIVATE ${tests})
 maybe_append_all_libraries(pepp-lib)
 
 if(MOCKTURTLE_BUILD_TESTS)


### PR DESCRIPTION
Avoid building tests and targets which we don't actually need, saving a chunk of build time.

Another way to improve compile times is using [precompiled headers](https://cmake.org/cmake/help/latest/command/target_precompile_headers.html).
When chosen carefully, they can improve compile times at the cost of slightly large intermediate output.
On Windows 11, for example, this branch increase the size of a debug build from 7GB to 8.8GB.

I used [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer) to select the headers with the worst parse times and added them to a set of precompiled headers per-project.
The slowest headers tended to be <QtCore> as well as a number of C++ STL headers.
I generally avoided adding our own headers to the precompiled header list for fear that I will "freeze" the wrong headers and make compile times worse.
No one here will make edits to the system's standard libraries.

Through an iterative process, I was able to reduce build times on MacBook Pro, M4 Max using a RAM drive for build of a clean build from 3600 cpu-seconds to 1100 cpu-seconds. Factoring in concurrency, that's reducing a 172 second Debug build to 59 seconds.

My compiler caches aren't warmed in CI, so I'm uncertain how much time savings we will see there.
I have intentionally left one target (MacOS x86) with PCH disabled to assert that using precompiled headers won't cause any correctness bugs.

I've guarded the use of precompiled headers with a option `PEPP_PRECOMPILE_HEADERS` in cmake.
If I discover that CI doesn't jive with PCH, I'll just disable this flag on all CI builds.
The real goal is to make local development faster, which this commit achieves.