### PR TITLE
Track changes made to memory `Target`s

### DIFF
--- a/bin/term/commands/throughput.cpp
+++ b/bin/term/commands/throughput.cpp
@@ -22,6 +22,7 @@
 #include "core/sim/cores/cpu/pep_isa.hpp"
 #include "core/sim/memory/bus/simplebus.hpp"
 #include "core/sim/memory/ram/dense.hpp"
+#include "core/sim/memory/ram/sparse.hpp"
 #include "core/sim/system.hpp"
 #include "sim3/cores/pep/traced_pep10_isa3.hpp"
 #include "sim3/subsystems/ram/dense.hpp"
@@ -49,26 +50,43 @@ auto make_sim3() {
   return std::pair{storage, cpu};
 };
 
-auto make_core() {
+auto make_core(bool use_sparse) {
   static constexpr auto isa = PepISA3CPU::ISA::Pep10;
   using namespace bits;
+
+  System::Configuration root_cfg{{.basename = "/", .compatible = System::compatible}};
+  auto system = std::make_unique<System>(root_cfg);
+
   PepISA3CPU::Configuration cpu_cfg{Device::Configuration{
                                         .basename = "cpu",
                                         .compatible = PepISA3CPU::compatible,
                                     },
                                     isa, "/memory"};
-  System::Configuration root_cfg{{.basename = "/", .compatible = System::compatible}};
-  Dense::Configuration mem_cfg{
-      Device::Configuration{
-          .basename = "memory",
-          .compatible = Dense::compatible,
-      },
-      0x00,
-      AddressSpan(0x0000, 0xffff),
-  };
-  auto system = std::make_unique<System>(root_cfg);
-  auto *mem = system->make_device<Dense>(mem_cfg);
   auto *cpu = system->make_device<PepISA3CPU>(cpu_cfg, system.get());
+
+  Target *mem = nullptr;
+  if (!use_sparse) {
+    Dense::Configuration mem_cfg{
+        Device::Configuration{
+            .basename = "memory",
+            .compatible = Dense::compatible,
+        },
+        0x00,
+        AddressSpan(0x0000, 0xffff),
+    };
+    mem = system->make_device<Dense>(mem_cfg);
+  } else {
+    Sparse::Configuration mem_cfg{
+        Device::Configuration{
+            .basename = "memory",
+            .compatible = Sparse::compatible,
+        },
+        0x00,
+        AddressSpan(0x0000, 0xffff),
+    };
+    mem = system->make_device<Sparse>(mem_cfg);
+  }
+
   system->initialize();
   return std::make_tuple(std::move(system), mem, cpu);
 }
@@ -152,11 +170,11 @@ std::chrono::high_resolution_clock::time_point ThroughputTask::do_sim3(std::span
 std::chrono::high_resolution_clock::time_point ThroughputTask::do_core(std::span<const u8> program) {
   static constexpr auto rw = Operation{Operation::Type::Standard, Operation::Kind::data};
   fmt::println("Simulator: core");
-  auto [system, mem, cpu] = make_core();
+  auto [system, mem, cpu] = make_core(this->use_sparse);
   cpu->write_register(isa::Pep10::Register::PC, 0x0000);
   mem->write(0x0000, program, rw);
   // We are untraced, provide explicit hints to avoid recording.
-  mem->on_traced_changed(false);
+  dynamic_cast<Traceable *>(mem)->on_traced_changed(false);
   cpu->on_traced_changed(false);
   cpu->csrs()->on_traced_changed(false);
   cpu->registers()->on_traced_changed(false);

--- a/bin/term/commands/throughput.cpp
+++ b/bin/term/commands/throughput.cpp
@@ -78,10 +78,37 @@ ThroughputTask::ThroughputTask(WhichVersion ver, QObject *parent) : Task(parent)
 void ThroughputTask::run() {
   using namespace Qt::StringLiterals;
 
+  // Infinite looping branch to 0.
+  static constexpr std::array<u8, 3> SelfBranch{static_cast<u8>(isa::Pep10::Mnemonic::BR), 0x00, 0x00};
+  // Program that calculates fib(n/3) in A, truncated to 16 bits of
+  // clang-format off
+  static constexpr std::array<u8, 12> RMW{
+      // Loop preamble
+      static_cast<u8>(isa::Pep10::Mnemonic::LDWA),     0x00, 0x01, // Pre-populate A with 1
+      // Loop body, which uses stores temporary data in LDWA's operand.
+      static_cast<u8>(isa::Pep10::Mnemonic::ADDA) + 1, 0x00, 0x01, // Add A to previous iteration's copy
+      static_cast<u8>(isa::Pep10::Mnemonic::STWA) + 1, 0x00, 0x01, // Store copy of A to 0x0001
+      static_cast<u8>(isa::Pep10::Mnemonic::BR),       0x00, 0x03  // Loop back to the start
+  };
+  // clang-format on
+  std::span<const u8> program = SelfBranch;
+  std::string program_name = "??";
+  switch (this->program) {
+  case TestProgram::SelfBranch:
+    program = SelfBranch;
+    program_name = "self-branch";
+    break;
+  case TestProgram::RMW:
+    program = RMW;
+    program_name = "read-modify-write loop";
+    break;
+  }
+  fmt::println("Selected program: {}", program_name);
+
   std::chrono::high_resolution_clock::time_point start;
   switch (_version) {
-  case WhichVersion::Sim3: start = do_sim3(); break;
-  case WhichVersion::Core: start = do_core(); break;
+  case WhichVersion::Sim3: start = do_sim3(program); break;
+  case WhichVersion::Core: start = do_core(program); break;
   }
   const auto end = std::chrono::high_resolution_clock::now();
   const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
@@ -94,12 +121,12 @@ void ThroughputTask::run() {
   emit finished(0);
 }
 
-std::chrono::high_resolution_clock::time_point ThroughputTask::do_sim3() {
+std::chrono::high_resolution_clock::time_point ThroughputTask::do_sim3(std::span<const u8> program) {
   static constexpr sim::api2::memory::Operation rw = {
       .type = sim::api2::memory::Operation::Type::Standard,
       .kind = sim::api2::memory::Operation::Kind::data,
   };
-  fmt::println("Selected: sim3");
+  fmt::println("Simulator: sim3");
   auto env = nullptr;
   // Add some spurious breakpoints which will not be hit
   // auto debugger = std::make_shared<pepp::debug::Debugger>(env);
@@ -116,22 +143,18 @@ std::chrono::high_resolution_clock::time_point ThroughputTask::do_sim3() {
   // cpu->setDebugger(&*debugger);
   cpu->regs()->clear(0);
   cpu->csrs()->clear(0);
-  // Infinite looping branch to 0.
-  const auto program = std::array<quint8, 3>{static_cast<quint8>(isa::Pep10::Mnemonic::BR), 0x00, 0x00};
-  mem->write(0, {program.data(), program.size()}, rw);
+  mem->write(0, program, rw);
   const auto start = std::chrono::high_resolution_clock::now();
   for (int it = 0; it < maxInstr; it++) cpu->clock(it);
   return start;
 }
 
-std::chrono::high_resolution_clock::time_point ThroughputTask::do_core() {
+std::chrono::high_resolution_clock::time_point ThroughputTask::do_core(std::span<const u8> program) {
   static constexpr auto rw = Operation{Operation::Type::Standard, Operation::Kind::data};
-  fmt::println("Selected: core");
+  fmt::println("Simulator: core");
   auto [system, mem, cpu] = make_core();
   cpu->write_register(isa::Pep10::Register::PC, 0x0000);
-  // Infinite looping branch to 0.
-  const auto program = std::array<u8, 3>{static_cast<u8>(isa::Pep10::Mnemonic::BR), 0x00, 0x00};
-  mem->write(0x0000, {program.data(), program.size()}, rw);
+  mem->write(0x0000, program, rw);
   // We are untraced, provide explicit hints to avoid recording.
   mem->on_traced_changed(false);
   cpu->on_traced_changed(false);

--- a/bin/term/commands/throughput.hpp
+++ b/bin/term/commands/throughput.hpp
@@ -37,6 +37,7 @@ public:
   std::chrono::high_resolution_clock::time_point do_core(std::span<const u8> prog);
   u64 maxInstr = 100'000'000;
   bool has_bps = false;
+  bool use_sparse = false;
   TestProgram program = TestProgram::SelfBranch;
 
 private:
@@ -48,7 +49,7 @@ void registerThroughput(auto &app, task_factory_t &task, detail::SharedFlags &fl
   static ThroughputTask::WhichVersion version = ThroughputTask::WhichVersion::Core;
   static ThroughputTask::TestProgram program = ThroughputTask::TestProgram::SelfBranch;
   static u64 maxInstr = 100'000'000;
-  static bool has_bps = false;
+  static bool has_bps = false, use_sparse = false;
   auto versionOpt =
       instrThruSC->add_option("-v,--version", version, "Which version to run")
           ->transform(CLI::CheckedTransformer(std::map<std::string, ThroughputTask::WhichVersion>{
@@ -62,6 +63,9 @@ void registerThroughput(auto &app, task_factory_t &task, detail::SharedFlags &fl
   static auto hasBpsOpt =
       instrThruSC->add_flag("--bps,!--no-bps", has_bps, "Add spurious breakpoints which will not be hit")
           ->default_val(false);
+  static auto useSparseOpt =
+      instrThruSC->add_flag("--sparse,!--no-sparse", use_sparse, "Use Sparse storage for RAM rather then Dense")
+          ->default_val(false);
   instrThruSC->group("");
   instrThruSC->callback([&]() {
     flags.kind = detail::SharedFlags::Kind::TERM;
@@ -70,6 +74,7 @@ void registerThroughput(auto &app, task_factory_t &task, detail::SharedFlags &fl
       ret->maxInstr = maxInstr;
       ret->has_bps = has_bps;
       ret->program = program;
+      ret->use_sparse = use_sparse;
       return ret;
     };
   });

--- a/bin/term/commands/throughput.hpp
+++ b/bin/term/commands/throughput.hpp
@@ -25,14 +25,19 @@ class ThroughputTask : public Task {
   Q_OBJECT
 public:
   enum class WhichVersion { Sim3, Core };
+  enum class TestProgram {
+    SelfBranch, // self: BR self
+    RMW,        // Accumulate a meaningless value into A.
+  };
   ThroughputTask(WhichVersion ver, QObject *parent = nullptr);
   ~ThroughputTask() = default;
   void run();
   // Both should return their "start" time
-  std::chrono::high_resolution_clock::time_point do_sim3();
-  std::chrono::high_resolution_clock::time_point do_core();
+  std::chrono::high_resolution_clock::time_point do_sim3(std::span<const u8> prog);
+  std::chrono::high_resolution_clock::time_point do_core(std::span<const u8> prog);
   u64 maxInstr = 100'000'000;
   bool has_bps = false;
+  TestProgram program = TestProgram::SelfBranch;
 
 private:
   WhichVersion _version;
@@ -40,14 +45,18 @@ private:
 
 void registerThroughput(auto &app, task_factory_t &task, detail::SharedFlags &flags) {
   static auto instrThruSC = app.add_subcommand("mit", "Measure instruction throughput");
-  static ThroughputTask::WhichVersion version = ThroughputTask::WhichVersion::Sim3;
+  static ThroughputTask::WhichVersion version = ThroughputTask::WhichVersion::Core;
+  static ThroughputTask::TestProgram program = ThroughputTask::TestProgram::SelfBranch;
   static u64 maxInstr = 100'000'000;
   static bool has_bps = false;
   auto versionOpt =
       instrThruSC->add_option("-v,--version", version, "Which version to run")
           ->transform(CLI::CheckedTransformer(std::map<std::string, ThroughputTask::WhichVersion>{
               {"sim3", ThroughputTask::WhichVersion::Sim3}, {"core", ThroughputTask::WhichVersion::Core}}));
-
+  auto programOpt =
+      instrThruSC->add_option("-p,--program", program, "Which test program to run")
+          ->transform(CLI::CheckedTransformer(std::map<std::string, ThroughputTask::TestProgram>{
+              {"br", ThroughputTask::TestProgram::SelfBranch}, {"rmw", ThroughputTask::TestProgram::RMW}}));
   static auto maxInstrOpt =
       instrThruSC->add_option("-n,--max-instr", maxInstr, "Maximum number of instructions to run");
   static auto hasBpsOpt =
@@ -60,6 +69,7 @@ void registerThroughput(auto &app, task_factory_t &task, detail::SharedFlags &fl
       auto ret = new ThroughputTask(version, parent);
       ret->maxInstr = maxInstr;
       ret->has_bps = has_bps;
+      ret->program = program;
       return ret;
     };
   });

--- a/core/core/math/geom/interval_set.hpp
+++ b/core/core/math/geom/interval_set.hpp
@@ -22,8 +22,8 @@ public:
   explicit IntervalSet(std::span<const T> points) {
     for (const auto &p : points) insert(p);
   }
-  explicit IntervalSet(const IntervalSet &other) : _intervals(other._intervals) {}
-  explicit IntervalSet(IntervalSet &&other) noexcept : _intervals(std::move(other._intervals)) {}
+  IntervalSet(const IntervalSet &other) : _intervals(other._intervals) {}
+  IntervalSet(IntervalSet &&other) noexcept : _intervals(std::move(other._intervals)) {}
   IntervalSet &operator=(const IntervalSet &) = default;
   IntervalSet &operator=(IntervalSet &&) noexcept = default;
 

--- a/core/core/math/geom/interval_set.hpp
+++ b/core/core/math/geom/interval_set.hpp
@@ -15,6 +15,21 @@ template <std::unsigned_integral T> class IntervalSet {
   std::vector<Interval<T>> _intervals;
 
 public:
+  IntervalSet() = default;
+  explicit IntervalSet(std::span<const Interval<T>> intervals) {
+    for (const auto &i : intervals) insert(i);
+  }
+  explicit IntervalSet(std::span<const T> points) {
+    for (const auto &p : points) insert(p);
+  }
+  explicit IntervalSet(const IntervalSet &other) : _intervals(other._intervals) {}
+  explicit IntervalSet(IntervalSet &&other) noexcept : _intervals(std::move(other._intervals)) {}
+  IntervalSet &operator=(const IntervalSet &) = default;
+  IntervalSet &operator=(IntervalSet &&) noexcept = default;
+
+  void insert(const IntervalSet &other) {
+    for (const auto &i : other._intervals) insert(i);
+  }
   void insert(T lower, T upper) { insert(Interval<T>(lower, upper)); }
   void insert(T point) { insert(Interval<T>(point)); }
   void insert(Interval<T> interval) {

--- a/core/core/math/geom/interval_set.hpp
+++ b/core/core/math/geom/interval_set.hpp
@@ -45,7 +45,7 @@ public:
                                    [value](const Interval<T> &e) { return e.upper() < value; });
     return it != _intervals.end() && pepp::core::contains(*it, value);
   }
-  std::span<const Interval<T>> intervals() const { return _intervals; }
+  const auto &intervals() const { return _intervals; }
   // Keeps the allocation, so a set refilled every repaint stops allocating once it reaches its high-water mark.
   void clear() { _intervals.clear(); }
 

--- a/core/core/sim/api/memory.hpp
+++ b/core/core/sim/api/memory.hpp
@@ -19,6 +19,7 @@
 #include "core/math/bitmanip/span.hpp"
 #include "core/math/bitmanip/swap.hpp"
 #include "core/math/geom/interval.hpp"
+#include "core/math/geom/interval_set.hpp"
 #include "core/sim/api/device.hpp"
 
 using Tick = u32;
@@ -112,10 +113,24 @@ struct Target {
   virtual Result write(Address address, bits::span<const u8> src, Operation op) = 0;
   // If the device is composed of many devices (e.g., a SimpleBus), this method should clear all connected targets.
   virtual void clear(u8 fill) = 0;
-
-  // If dest is larger than maxOffset-minOffset+1, copy bytes from this target
-  // to the span.
+  // If dest is larger than maxOffset-minOffset+1, copy bytes from this target to the span.
   virtual void dump(bits::span<u8> dest) const = 0;
+  // Targets accumulate a set of memory locations whose values have changed since the last call to clear_changes().
+  // This is used by the simulator to repaint the GUI in O(# targets * # changes) time rather than O(trace length).
+  // Programs will often write the same memory locations and those locations tend to be clustered in space.
+  // Every write, regardless of Operation type, should be considered a change.
+  // Prefer passing a "out" parameter rather than returning a value so allocations can be reused across GUI repaints.
+  // Each deriving class has a different implementation of how it tracks changes which is optimized for that target
+  // type. For some targets (like register banks), the target will be conservative and report a change even one did
+  // not occur.
+  //
+  // IntervalSet prefers inserts be performed in a low-to-high order, otherwise insert is O(N^2) rather than
+  // O(NlgN). If you have adjacent changes, consider merging them first if you can merge in O(N) with no auxilliary
+  // memory.
+  virtual void collect_changes(pepp::core::IntervalSet<Address> &changed) const = 0;
+  // Reset the target's internal change tracking so that collect_changes() will return an empty set until the next
+  // write.
+  virtual void clear_changes() = 0;
 
   // These convenience methods are so commonly used that they tend to be declared inline in multiple project locations.
   template <std::integral I, bool byteswap = false> std::pair<Result, I> read(Address address, Operation op) const;

--- a/core/core/sim/cores/cpu/pep_csrbank.cpp
+++ b/core/core/sim/cores/cpu/pep_csrbank.cpp
@@ -47,11 +47,9 @@ void PepCSRBank::set_initiator(Device::ID cpu) {
 }
 
 void PepCSRBank::store(u8 value, Operation op) {
-  // Masked here so the invariant lives with the data: every path in, including a debugger writing the raw byte,
-  // lands in the low nibble.
+  // Extract only the low nibble, which contains the only defined bits.
   const auto masked = static_cast<u8>(value & MASK);
-  // Whole-byte record even when one flag moved: SETREGX names a register, and a field write would have to carry the
-  // field id and a mask to say the same thing in more bytes.
+  // Set whole register rather than separate fields to reduce size of trace.
   if (_traced) _trace.emit_write_register(op, _ref, static_cast<u8>(_nzvc ^ masked));
   _nzvc = masked;
 }
@@ -80,7 +78,6 @@ Device::Type PepCSRBank::type() const {
 }
 
 std::unique_ptr<DeviceSerializer> PepCSRBank::serializer() const {
-  // Should never be called: the CPU builds this with skip_serialize = true.
   throw std::logic_error("PepCSRBank is synthetic and has no serialized form");
 }
 
@@ -90,7 +87,6 @@ void PepCSRBank::trace(bool enabled) { _trace.set_traced(enabled); }
 bool PepCSRBank::traced() const { return _traced; }
 void PepCSRBank::on_traced_changed(bool enabled) { _traced = enabled; }
 
-// One byte, the span the Dense covered.
 AddressSpan PepCSRBank::span() const { return AddressSpan(0, 0); }
 
 Target::Result PepCSRBank::read(Address address, bits::span<u8> dest, Operation op) const {
@@ -113,11 +109,16 @@ Target::Result PepCSRBank::write(Address address, bits::span<const u8> src, Oper
 
 void PepCSRBank::clear(u8 fill) {
   // TODO: emit a "clear" trace to TB.
-  // Masked like every other way in, or clear() would be the one path that can leave bits above the flags set.
   _nzvc = static_cast<u8>(fill & MASK);
 }
 
 void PepCSRBank::dump(bits::span<u8> dest) const {
   if (dest.size() <= 0) throw std::logic_error("dump requires non-0 size");
   dest[0] = _nzvc;
+}
+
+void PepCSRBank::collect_changes(pepp::core::IntervalSet<Address> &changed) const { changed.insert(AddressSpan(0, 0)); }
+
+void PepCSRBank::clear_changes() {
+  // No-op because we always conservatively report that the whole bank changed.
 }

--- a/core/core/sim/cores/cpu/pep_csrbank.hpp
+++ b/core/core/sim/cores/cpu/pep_csrbank.hpp
@@ -87,29 +87,29 @@ public:
   bool traced() const override;
   void on_traced_changed(bool enabled) override;
 
-  // Target interface. The slow, generic path, over the same single byte the Dense covered.
-  using Target::read;
-  using Target::write;
+  // Target interface
   AddressSpan span() const override;
   Result read(Address address, bits::span<u8> dest, Operation op) const override;
   Result write(Address address, bits::span<const u8> src, Operation op) override;
   void clear(u8 fill) override;
   void dump(bits::span<u8> dest) const override;
+  void collect_changes(pepp::core::IntervalSet<Address> &changed) const override;
+  void clear_changes() override;
 
-  // The Operation the typed writers record under. Set once, by the CPU that owns this bank.
+  // ID of the CPU which owns this register bank, which is needed to emit traces to the correct temporary buffer when
+  // not using the Target API.
   void set_initiator(Device::ID cpu);
 
 private:
-  // Record the xor if traced, then store. Always a whole-byte record: a single flag is a field of the packed
-  // register, and SETREGX names the register rather than the field.
+  // Record a trace of the register before storing the new value.
   void store(u8 value, Operation op);
 
   Configuration _config;
   u8 _nzvc = 0;
-  // Filled in by initialize(). SETREGX names its target by scan id, so a write cannot be recorded without it.
+  // Filled in by initialize(), and used to emit traces.
   RegisterScan::RegisterRef _ref{};
   trace::Recorder _trace;
-  // Mirror of the buffer's traced bit, pushed via on_traced_changed(). Read on every write.
+  // Cached value of TraeBuffer::traced(this->id()) to avoid repeated lookups in our hot path.
   bool _traced = false;
   Operation _op = Operation(Operation::Type::Standard, Operation::Kind::data, Device::ID{0});
 };

--- a/core/core/sim/cores/cpu/pep_regbank.cpp
+++ b/core/core/sim/cores/cpu/pep_regbank.cpp
@@ -159,3 +159,9 @@ void PepRegisterBank::dump(bits::span<u8> dest) const {
     dest[i] = is_high_byte(static_cast<Address>(i)) ? static_cast<u8>(value >> 8) : static_cast<u8>(value & 0xFF);
   }
 }
+
+void PepRegisterBank::collect_changes(pepp::core::IntervalSet<Address> &changed) const { changed.insert(span()); }
+
+void PepRegisterBank::clear_changes() {
+  // No-op because we always conservatively report that the whole bank changed.
+}

--- a/core/core/sim/cores/cpu/pep_regbank.hpp
+++ b/core/core/sim/cores/cpu/pep_regbank.hpp
@@ -24,8 +24,7 @@
 
 // The Pep register file, held as C++ membner variables rather than offsets into an array.
 // It replaces the previous Dense* Target. With some optimization, the compiler is better able to elide useless calls to
-// memcpy. Registers are stored in host order for the direct RegisterBank API, but exposed in LE order via Target. This
-// maintains backwards-compatibility with usage of the Dense* register bank.
+// memcpy. Registers are stored in host order for the direct RegisterBank API, but exposed in LE order via Target.
 // From the Target API, register N occupies bytes [N*2, N*2+1]
 //
 // Pep8, Pep9, amd Pep10 declare identical Register enums, so one bank serves all ISAs.
@@ -126,39 +125,36 @@ public:
   bool traced() const override;
   void on_traced_changed(bool enabled) override;
 
-  // Target interface. The slow, generic path: big-endian, bounds checked, byte addressable. Keeps
-  // backwards-compatibility with previus tests / usages.
-  using Target::read;
-  using Target::write;
+  // Target interface, providing big-endian access to the registers as-if they were a contiguous array of bytes.
   AddressSpan span() const override;
   Result read(Address address, bits::span<u8> dest, Operation op) const override;
   Result write(Address address, bits::span<const u8> src, Operation op) override;
   void clear(u8 fill) override;
   void dump(bits::span<u8> dest) const override;
+  void collect_changes(pepp::core::IntervalSet<Address> &changed) const override;
+  void clear_changes() override;
 
-  // The Operation the typed writers record under. Set once, by the CPU that owns this bank.
+  // ID of the CPU which owns this register bank, which is needed to emit traces to the correct temporary buffer when
+  // not using the Target API.
   void set_initiator(Device::ID cpu);
 
 private:
-  // Common tail of every typed write: record the xor if traced, then store. Templated so the recorded packet is the
-  // register's own width rather than a fixed word.
+  // Record a trace and then store the value in-place.
   template <std::integral I> void store(Register reg, I &slot, I value, Operation op) {
-    // The xor is one instruction here, where both values are already in hand -- which is why the recorder takes them
-    // combined rather than fetching the prior value itself.
+    // Cheap to compute new ^ old in a single instruction rather than construct a lambda which does the same thing.
     if (_traced) _trace.emit_write_register(op, _refs[static_cast<u8>(reg)], static_cast<I>(slot ^ value));
     slot = value;
   }
-  // Enum dispatch for the Target path, which has a value and a slot index but no name.
   void write_slot(Register reg, u16 value, Operation op);
 
   Configuration _config;
-  // Host order, always. Nothing here is ever byte swapped in place; the Target path converts on the way out.
+  // Avoid byte-swapping in the non-Target case by using real integers rather than an array of bytes.
   u16 _a = 0, _x = 0, _sp = 0, _pc = 0, _os = 0;
   u8 _is = 0;
-  // Filled in by initialize(). SETREGX names its target by scan id, so a write cannot be recorded without these.
+  // Filled in by initialize(), and used to emit traces.
   std::array<RegisterScan::RegisterRef, REGISTER_COUNT> _refs{};
   trace::Recorder _trace;
-  // Mirror of the buffer's traced bit, pushed via on_traced_changed(). Read on every write.
+  // Cached value of TraeBuffer::traced(this->id()) to avoid repeated lookups in our hot path.
   bool _traced = false;
   Operation _op = Operation(Operation::Type::Standard, Operation::Kind::data, Device::ID{0});
 };

--- a/core/core/sim/memory/bus/simplebus.cpp
+++ b/core/core/sim/memory/bus/simplebus.cpp
@@ -211,6 +211,14 @@ void SimpleBus::clear(u8 fill) {
 
 void SimpleBus::dump(bits::span<u8> dest) const { throw std::logic_error("SimpleBus::dump not implemented"); }
 
+void SimpleBus::collect_changes(pepp::core::IntervalSet<Address> &changed) const {
+  // No-op, since this bus owns no memory directly, and the debugger/system is responsible for walking the device tree.
+}
+
+void SimpleBus::clear_changes() {
+  // No-op, see above.
+}
+
 Target *SimpleBus::device(ID id) const {
   auto it = _devices.find(id);
   if (it != _devices.end()) return it->second;

--- a/core/core/sim/memory/bus/simplebus.hpp
+++ b/core/core/sim/memory/bus/simplebus.hpp
@@ -165,6 +165,8 @@ public:
   Result write(Address address, bits::span<const u8> src, Operation op) override;
   void clear(u8 fill) override;
   void dump(bits::span<u8> dest) const override;
+  void collect_changes(pepp::core::IntervalSet<Address> &changed) const override;
+  void clear_changes() override;
 
 private:
   Target *device(Device::ID id) const;

--- a/core/core/sim/memory/io/fifo.cpp
+++ b/core/core/sim/memory/io/fifo.cpp
@@ -204,6 +204,7 @@ AddressSpan FIFORegister::span() const { return _config.span; }
 void FIFORegister::clear(u8) {
   _input.clear(), _output.clear();
   _input_it = _input.begin();
+  _changed = false;
 }
 
 void FIFORegister::reset() { clear(_config.fill); }
@@ -219,6 +220,12 @@ void FIFORegister::dump(bits::span<u8> dest) const {
   }
   bits::memcpy(dest, bits::span<const u8>{&v, sizeof(v)});
 }
+
+void FIFORegister::collect_changes(pepp::core::IntervalSet<Address> &changed) const {
+  if (_changed) changed.insert(_config.span);
+}
+
+void FIFORegister::clear_changes() { _changed = false; }
 
 Target::Result FIFORegister::read(Address address, bits::span<u8> dest, Operation op) const {
   using namespace bits;
@@ -240,6 +247,7 @@ Target::Result FIFORegister::read(Address address, bits::span<u8> dest, Operatio
     } else src = _input_it.value_or(_config.fill);
     // Record that the read consumed values from the input queue
     if (advances_input) {
+      _changed = true;
       _trace.emit_mm_read(op, address, src);
       if (!(_input_it.at_end())) ++_input_it;
     }
@@ -263,6 +271,7 @@ Target::Result FIFORegister::write(Address address, bits::span<const u8> src, Op
   const bool advances_output = !(op.type == Operation::Type::Application || op.type == Operation::Type::BufferInternal);
   // This is an output reg. Only enqueue value if the operation is not part of an app-internal update.
   if (advances_output && any(_config.direction & FIFORegister::Direction::Output)) {
+    _changed = true;
     _trace.emit_mm_write(op, address, src.front());
     _output.push(src.front());
   }

--- a/core/core/sim/memory/io/fifo.hpp
+++ b/core/core/sim/memory/io/fifo.hpp
@@ -137,9 +137,12 @@ public:
   void clear(u8 fill) override;
   // If output, return most recent value written. Otherwise, return the current value of input.
   void dump(bits::span<u8> dest) const override;
+  void collect_changes(pepp::core::IntervalSet<Address> &changed) const override;
+  void clear_changes() override;
 
 private:
   Configuration _config;
+  mutable bool _changed = false;
   FIFO _input, _output;
   mutable FIFO::Iterator _input_it;
   mutable trace::Recorder _trace;

--- a/core/core/sim/memory/ram/dense.cpp
+++ b/core/core/sim/memory/ram/dense.cpp
@@ -176,3 +176,12 @@ void Dense::dump(bits::span<u8> dest) const {
   if (dest.size() <= 0) throw std::logic_error("dump requires non-0 size");
   bits::memcpy(dest, bits::span<const u8>{_data.data(), std::size_t(_data.size())});
 }
+
+void Dense::collect_changes(pepp::core::IntervalSet<Address> &changed) const {
+  // TODO: conservatively report all-changed for now
+  changed.insert(_config.span);
+}
+
+void Dense::clear_changes() {
+  // TODO: no-op for now
+}

--- a/core/core/sim/memory/ram/dense.cpp
+++ b/core/core/sim/memory/ram/dense.cpp
@@ -41,7 +41,9 @@ void serialize_dense(nlohmann::json &obj, const System *sys, const Device *self)
 } // namespace
 
 Dense::Dense(Configuration config) : Device(), _config(config) {
-  _data.resize(size_inclusive(_config.span), _config.fill);
+  const auto size = size_inclusive(_config.span);
+  _data.resize(size, _config.fill);
+  _dirty.resize(size, false);
 }
 
 std::span<const u8> Dense::data() const { return std::span<const u8>{_data.data(), std::size_t(_data.size())}; }
@@ -143,11 +145,26 @@ Target::Result Dense::write(Address address, bits::span<const u8> src, Operation
   // Switched on the width so the copy length is a constant the compiler can turn into a register operation for common
   // register sizes rather than a trip through the actual C code of memcpy.
   switch (src.size()) {
-  case 1: dest[0] = src[0]; break;
-  case 2: std::memcpy(dest, src.data(), 2); break;
-  case 4: std::memcpy(dest, src.data(), 4); break;
-  case 8: std::memcpy(dest, src.data(), 8); break;
-  default: std::memcpy(dest, src.data(), src.size()); break;
+  case 1:
+    dest[0] = src[0];
+    _dirty[offset] = true;
+    break;
+  case 2:
+    std::memcpy(dest, src.data(), 2);
+    _dirty[offset] = true, _dirty[offset + 1] = true;
+    break;
+  case 4:
+    std::memcpy(dest, src.data(), 4);
+    for (int i = 0; i < 4; i++) _dirty[offset + i] = true;
+    break;
+  case 8:
+    std::memcpy(dest, src.data(), 8);
+    for (int i = 0; i < 8; i++) _dirty[offset + i] = true;
+    break;
+  default:
+    std::memcpy(dest, src.data(), src.size());
+    std::fill(_dirty.begin() + offset, _dirty.begin() + offset + src.size(), true);
+    break;
   }
   if (is_performance_countable(op)) _counters.wr_bytes += src.size();
   return {};
@@ -163,6 +180,7 @@ Target::Result Dense::write_increment(Address address, bits::span<const u8> src,
   auto dest = bits::span<u8>{_data.data(), std::size_t(_data.size())}.subspan(offset);
   if (_may_trace) _trace.emit_write_increment(op, address, dest.first(src.size()), src, order);
   bits::memcpy(dest, src);
+  std::fill(_dirty.begin() + offset, _dirty.begin() + offset + src.size(), true);
   if (is_performance_countable(op)) _counters.wr_bytes += src.size();
   return {};
 }
@@ -170,6 +188,7 @@ Target::Result Dense::write_increment(Address address, bits::span<const u8> src,
 void Dense::clear(u8 fill) {
   // TODO: emit a "clear" trace to TB.
   std::fill(_data.begin(), _data.end(), fill);
+  std::fill(_dirty.begin(), _dirty.end(), false);
 }
 
 void Dense::dump(bits::span<u8> dest) const {
@@ -178,10 +197,19 @@ void Dense::dump(bits::span<u8> dest) const {
 }
 
 void Dense::collect_changes(pepp::core::IntervalSet<Address> &changed) const {
-  // TODO: conservatively report all-changed for now
-  changed.insert(_config.span);
+  // _dirty is indexed by offset, but the API is specified in addresses
+  const auto base = _config.span.lower();
+  const auto size = _dirty.size();
+  for (std::size_t i = 0; i < size;) {
+    if (!_dirty[i]) {
+      ++i;
+      continue;
+    }
+    const std::size_t start = i;
+    while (i < size && _dirty[i]) ++i;
+    // Runs are emitted low-to-high, which is the order IntervalSet prefers.
+    changed.insert(static_cast<Address>(base + start), static_cast<Address>(base + i - 1));
+  }
 }
 
-void Dense::clear_changes() {
-  // TODO: no-op for now
-}
+void Dense::clear_changes() { std::fill(_dirty.begin(), _dirty.end(), false); }

--- a/core/core/sim/memory/ram/dense.hpp
+++ b/core/core/sim/memory/ram/dense.hpp
@@ -72,6 +72,8 @@ public:
 
   void clear(u8 fill) override;
   void dump(bits::span<u8> dest) const override;
+  void collect_changes(pepp::core::IntervalSet<Address> &changed) const override;
+  void clear_changes() override;
 
 private:
   mutable struct PerformanceCounters {

--- a/core/core/sim/memory/ram/dense.hpp
+++ b/core/core/sim/memory/ram/dense.hpp
@@ -75,6 +75,10 @@ public:
   void collect_changes(pepp::core::IntervalSet<Address> &changed) const override;
   void clear_changes() override;
 
+  // Convenience methods to extract host-order integers.
+  using Target::read;
+  using Target::write;
+
 private:
   mutable struct PerformanceCounters {
     u64 rd_bytes = 0;

--- a/core/core/sim/memory/ram/dense.hpp
+++ b/core/core/sim/memory/ram/dense.hpp
@@ -82,6 +82,8 @@ private:
   } _counters = {};
   Configuration _config;
   std::vector<u8> _data;
+  // All types of writes will set _dirty for the spanned bytes.
+  std::vector<bool> _dirty;
   trace::Recorder _trace;
   // If false, then we definitely aren't traced and we can skip the overhead of emit via _trace.
   // If true, we either are traced or we don't know. Either way, we need to try to emit via _trace.

--- a/core/core/sim/memory/ram/sparse.cpp
+++ b/core/core/sim/memory/ram/sparse.cpp
@@ -144,12 +144,18 @@ Target::Result Sparse::write(Address address, bits::span<const u8> src, Operatio
   return {};
 }
 
-// `fill` is the caller's choice for this one operation and deliberately does not become the device's new default:
-// config().fill is the power-on value that reset() reads back, and CLRMEM replaying out of a trace must not be able
-// to redefine it.
 void Sparse::clear(u8 fill) {
   // TODO: emit a "clear" trace to TB.
   _pool.clear(fill);
 }
 
 void Sparse::dump(bits::span<u8> dest) const { ::dump(_pool, dest); }
+
+void Sparse::collect_changes(pepp::core::IntervalSet<Address> &changed) const {
+  // TODO: conservatively report all-changed for now
+  changed.insert(_config.span);
+}
+
+void Sparse::clear_changes() {
+  // TODO:
+}

--- a/core/core/sim/memory/ram/sparse.cpp
+++ b/core/core/sim/memory/ram/sparse.cpp
@@ -140,6 +140,7 @@ Target::Result Sparse::write(Address address, bits::span<const u8> src, Operatio
   // but we don't pay the cost of reading the data.
   _trace.emit_write(op, address, src, [&](bits::span<u8> prior) { _pool.read(offset, prior); });
   _pool.write(offset, src);
+  _changes.insert(address, address + src.size() - 1);
   if (is_performance_countable(op)) _counters.wr_bytes += src.size();
   return {};
 }
@@ -147,15 +148,11 @@ Target::Result Sparse::write(Address address, bits::span<const u8> src, Operatio
 void Sparse::clear(u8 fill) {
   // TODO: emit a "clear" trace to TB.
   _pool.clear(fill);
+  _changes.clear();
 }
 
 void Sparse::dump(bits::span<u8> dest) const { ::dump(_pool, dest); }
 
-void Sparse::collect_changes(pepp::core::IntervalSet<Address> &changed) const {
-  // TODO: conservatively report all-changed for now
-  changed.insert(_config.span);
-}
+void Sparse::collect_changes(pepp::core::IntervalSet<Address> &changed) const { changed.insert(_changes); }
 
-void Sparse::clear_changes() {
-  // TODO:
-}
+void Sparse::clear_changes() { _changes.clear(); }

--- a/core/core/sim/memory/ram/sparse.hpp
+++ b/core/core/sim/memory/ram/sparse.hpp
@@ -63,6 +63,10 @@ public:
   void collect_changes(pepp::core::IntervalSet<Address> &changed) const override;
   void clear_changes() override;
 
+  // Convenience methods to extract host-order integers.
+  using Target::read;
+  using Target::write;
+
 private:
   mutable struct PerformanceCounters {
     u64 rd_bytes = 0;

--- a/core/core/sim/memory/ram/sparse.hpp
+++ b/core/core/sim/memory/ram/sparse.hpp
@@ -60,6 +60,8 @@ public:
   Result write(Address address, bits::span<const u8> src, Operation op) override;
   void clear(u8 fill) override;
   void dump(bits::span<u8> dest) const override;
+  void collect_changes(pepp::core::IntervalSet<Address> &changed) const override;
+  void clear_changes() override;
 
 private:
   mutable struct PerformanceCounters {

--- a/core/core/sim/memory/ram/sparse.hpp
+++ b/core/core/sim/memory/ram/sparse.hpp
@@ -74,5 +74,6 @@ private:
   } _counters = {};
   Configuration _config;
   pepp::bts::PagedPool<u8> _pool;
+  pepp::core::IntervalSet<Address> _changes;
   trace::Recorder _trace;
 };

--- a/test/core/math/geom/interval_set.cpp
+++ b/test/core/math/geom/interval_set.cpp
@@ -242,10 +242,6 @@ std::vector<pepp::core::Interval<uint8_t>> runs_of(const std::bitset<256> &bits)
   return out;
 }
 
-std::vector<pepp::core::Interval<uint8_t>> intervals_of(const pepp::core::IntervalSet<uint8_t> &set) {
-  const auto &intervals = set.intervals();
-  return {intervals.begin(), intervals.end()};
-}
 } // namespace
 
 TEST_CASE("IntervalSet agrees with a bitset oracle", "[scope:core][scope:core.math][kind:unit][arch:*]") {
@@ -261,7 +257,7 @@ TEST_CASE("IntervalSet agrees with a bitset oracle", "[scope:core][scope:core.ma
       int lo = pick(rng), hi = std::min(255, lo + len(rng));
       set.insert(uint8_t(lo), uint8_t(hi));
       for (int v = lo; v <= hi; ++v) oracle.set(v);
-      REQUIRE(intervals_of(set) == runs_of(oracle));
+      REQUIRE(set.intervals() == runs_of(oracle));
     }
     // Check that final result did not add or remove any values.
     std::bitset<256> queried;

--- a/test/core/sim/memory/compare.hpp
+++ b/test/core/sim/memory/compare.hpp
@@ -1,8 +1,23 @@
 #pragma once
 #include "catch.hpp"
 #include "core/integers.h"
+#include "core/sim/api/memory.hpp"
 
 inline void compare(const u8 *lhs, const u8 *rhs, u8 length) {
   if (lhs == nullptr || rhs == nullptr) return;
   for (int it = 0; it < length; it++) CHECK(lhs[it] == rhs[it]);
 };
+
+using Changes = std::vector<AddressSpan>;
+template <typename T> Changes changes_of(const T &dev) {
+  pepp::core::IntervalSet<Address> set;
+  dev.collect_changes(set);
+  return set.intervals();
+}
+
+// Writes `length` bytes of arbitrary-but-deterministic data at `address`.
+template <typename T> void poke(T &dev, Address address, std::size_t length, Operation op) {
+  static const u8 buf[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+  REQUIRE(length <= sizeof(buf));
+  dev.write(address, {buf, length}, op);
+}

--- a/test/core/sim/memory/dense.cpp
+++ b/test/core/sim/memory/dense.cpp
@@ -91,22 +91,6 @@ TEST_CASE("(new) Dense storage out-of-bounds access", "[scope:core][scope:core.s
   REQUIRE_THROWS_AS(dev.write(0x11, {tmp, 1}, op), Error);
 }
 
-namespace {
-using Changes = std::vector<AddressSpan>;
-Changes changes_of(const Dense &dev) {
-  pepp::core::IntervalSet<Address> set;
-  dev.collect_changes(set);
-  return set.intervals();
-}
-
-// Writes `length` bytes of arbitrary-but-deterministic data at `address`.
-void poke(Dense &dev, Address address, std::size_t length) {
-  static const u8 buf[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
-  REQUIRE(length <= sizeof(buf));
-  dev.write(address, {buf, length}, op);
-}
-} // namespace
-
 TEST_CASE("(new) Dense change tracking", "[scope:core][scope:core.sim][kind:unit][arch:*]") {
   // A non-zero lower bound, so that a device offset can never be mistaken for an address.
   static constexpr Address base = 0x10, last = 0xFF;
@@ -130,7 +114,7 @@ TEST_CASE("(new) Dense change tracking", "[scope:core][scope:core.sim][kind:unit
     // 1/2/4/8 cover specialized switch branches, 3/5/16 take the memcpy route.
     auto length = GENERATE(as<std::size_t>{}, 1, 2, 3, 4, 5, 8, 16);
     auto dev = make_dense(span);
-    poke(dev, 0x20, length);
+    poke(dev, 0x20, length, op);
     CHECK(changes_of(dev) == Changes{{0x20, Address(0x20 + length - 1)}});
   }
 
@@ -143,20 +127,20 @@ TEST_CASE("(new) Dense change tracking", "[scope:core][scope:core.sim][kind:unit
   SECTION("handles spans at the extremes") {
     // The run at `last` is terminated by running out of device rather than by a clean byte.
     auto dev = make_dense(span);
-    poke(dev, base, 1);
-    poke(dev, last, 1);
+    poke(dev, base, 1, op);
+    poke(dev, last, 1, op);
     CHECK(changes_of(dev) == Changes{{base, base}, {last, last}});
   }
 
   SECTION("collect_changes does not modify Target") {
     auto dev = make_dense(span);
-    poke(dev, 0x20, 1);
+    poke(dev, 0x20, 1, op);
     CHECK(changes_of(dev) == Changes{{0x20, 0x20}});
     CHECK(changes_of(dev) == Changes{{0x20, 0x20}});
   }
   SECTION("collect_changes does not clear set") {
     auto dev = make_dense(span);
-    poke(dev, 0x20, 1);
+    poke(dev, 0x20, 1, op);
     // Changes are added to whatever the caller already had, so one set can span many devices.
     pepp::core::IntervalSet<Address> set;
     set.insert(0x80, 0x81);
@@ -174,14 +158,14 @@ TEST_CASE("(new) Dense change tracking", "[scope:core][scope:core.sim][kind:unit
 
   SECTION("clear_changes does not affect data") {
     auto dev = make_dense(span);
-    poke(dev, 0x20, 4);
-    poke(dev, 0x40, 1);
+    poke(dev, 0x20, 4, op);
+    poke(dev, 0x40, 1, op);
     dev.clear_changes();
     CHECK(changes_of(dev) == Changes{});
     const u8 truth[4] = {0, 1, 2, 3};
     compare(dev.data().data() + 0x20 - base, truth, 4);
     // Only writes made after the clear are reported.
-    poke(dev, 0x60, 2);
+    poke(dev, 0x60, 2, op);
     CHECK(changes_of(dev) == Changes{{0x60, 0x61}});
   }
 
@@ -192,7 +176,7 @@ TEST_CASE("(new) Dense change tracking", "[scope:core][scope:core.sim][kind:unit
 
   SECTION("clear() discards accumulated changes") {
     auto dev = make_dense(span);
-    poke(dev, 0x20, 4);
+    poke(dev, 0x20, 4, op);
     dev.clear(0x00);
     CHECK(changes_of(dev) == Changes{});
   }

--- a/test/core/sim/memory/dense.cpp
+++ b/test/core/sim/memory/dense.cpp
@@ -16,13 +16,18 @@
 
 #include "core/sim/memory/ram/dense.hpp"
 #include <catch.hpp>
+#include <vector>
 #include "./compare.hpp"
 #include "core/sim/memory/errors.hpp"
 
 namespace {
 auto base_desc = Device::Configuration{.basename = "dev", .fullname = "/dev"};
 auto op = Operation{Operation::Type::Standard, Operation::Kind::data};
-
+Dense make_dense(AddressSpan span, u8 fill = 0xFE) {
+  auto cfg = Dense::Configuration{Device::Configuration{base_desc}};
+  cfg.span = span, cfg.fill = fill, cfg.id = {};
+  return Dense(cfg);
+}
 } // namespace
 
 TEST_CASE("(new) Dense storage in-bounds access", "[scope:core][scope:core.sim][kind:int][arch:*]") {
@@ -36,11 +41,8 @@ TEST_CASE("(new) Dense storage in-bounds access", "[scope:core][scope:core.sim][
       {4, 8},
       {8, 8},
   }));
-  auto span = AddressSpan(offset, 255);
-  auto cfg = Dense::Configuration{Device::Configuration{base_desc}};
-  cfg.span = span, cfg.fill = 0xFE, cfg.id = {};
   // Initialize a memory block to a fixed value
-  Dense dev(cfg);
+  auto dev = make_dense(AddressSpan(offset, 255), 0xFE);
 
   // Create an 8-byte temporary buffer.
   u64 reg = 0;
@@ -87,4 +89,111 @@ TEST_CASE("(new) Dense storage out-of-bounds access", "[scope:core][scope:core.s
   *tmp = 0xfe;
   REQUIRE_THROWS_AS(dev.write(0x9, {tmp, 1}, op), Error);
   REQUIRE_THROWS_AS(dev.write(0x11, {tmp, 1}, op), Error);
+}
+
+namespace {
+using Changes = std::vector<AddressSpan>;
+Changes changes_of(const Dense &dev) {
+  pepp::core::IntervalSet<Address> set;
+  dev.collect_changes(set);
+  return set.intervals();
+}
+
+// Writes `length` bytes of arbitrary-but-deterministic data at `address`.
+void poke(Dense &dev, Address address, std::size_t length) {
+  static const u8 buf[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+  REQUIRE(length <= sizeof(buf));
+  dev.write(address, {buf, length}, op);
+}
+} // namespace
+
+TEST_CASE("(new) Dense change tracking", "[scope:core][scope:core.sim][kind:unit][arch:*]") {
+  // A non-zero lower bound, so that a device offset can never be mistaken for an address.
+  static constexpr Address base = 0x10, last = 0xFF;
+  auto span = AddressSpan(base, last);
+
+  SECTION("device's default state is no changes") {
+    auto dev = make_dense(span);
+    CHECK(changes_of(dev) == Changes{});
+    dev.clear_changes(); // No-op if empty
+    CHECK(changes_of(dev) == Changes{});
+  }
+
+  SECTION("reads do not affect change tracking") {
+    auto dev = make_dense(span);
+    u64 reg = 0;
+    dev.read(base, {(u8 *)&reg, 8}, op);
+    CHECK(changes_of(dev) == Changes{});
+  }
+
+  SECTION("write dirties correct bits") {
+    // 1/2/4/8 cover specialized switch branches, 3/5/16 take the memcpy route.
+    auto length = GENERATE(as<std::size_t>{}, 1, 2, 3, 4, 5, 8, 16);
+    auto dev = make_dense(span);
+    poke(dev, 0x20, length);
+    CHECK(changes_of(dev) == Changes{{0x20, Address(0x20 + length - 1)}});
+  }
+
+  SECTION("write_increment dirties correct bits") {
+    auto dev = make_dense(span);
+    dev.write_increment<u16, false>(0x20, 0xBEEF, op);
+    CHECK(changes_of(dev) == Changes{{0x20, 0x21}});
+  }
+
+  SECTION("handles spans at the extremes") {
+    // The run at `last` is terminated by running out of device rather than by a clean byte.
+    auto dev = make_dense(span);
+    poke(dev, base, 1);
+    poke(dev, last, 1);
+    CHECK(changes_of(dev) == Changes{{base, base}, {last, last}});
+  }
+
+  SECTION("collect_changes does not modify Target") {
+    auto dev = make_dense(span);
+    poke(dev, 0x20, 1);
+    CHECK(changes_of(dev) == Changes{{0x20, 0x20}});
+    CHECK(changes_of(dev) == Changes{{0x20, 0x20}});
+  }
+  SECTION("collect_changes does not clear set") {
+    auto dev = make_dense(span);
+    poke(dev, 0x20, 1);
+    // Changes are added to whatever the caller already had, so one set can span many devices.
+    pepp::core::IntervalSet<Address> set;
+    set.insert(0x80, 0x81);
+    dev.collect_changes(set);
+    CHECK(set.intervals() == Changes{{0x20, 0x20}, {0x80, 0x81}});
+  }
+
+  SECTION("An out-of-bounds write leaves change tracking untouched") {
+    auto dev = make_dense(span);
+    const u8 v = 0xCA;
+    CHECK_THROWS_AS(dev.write(base - 1, {&v, 1}, op), Error);
+    CHECK_THROWS_AS(dev.write(last, {&v, 2}, op), Error);
+    CHECK(changes_of(dev) == Changes{});
+  }
+
+  SECTION("clear_changes does not affect data") {
+    auto dev = make_dense(span);
+    poke(dev, 0x20, 4);
+    poke(dev, 0x40, 1);
+    dev.clear_changes();
+    CHECK(changes_of(dev) == Changes{});
+    const u8 truth[4] = {0, 1, 2, 3};
+    compare(dev.data().data() + 0x20 - base, truth, 4);
+    // Only writes made after the clear are reported.
+    poke(dev, 0x60, 2);
+    CHECK(changes_of(dev) == Changes{{0x60, 0x61}});
+  }
+
+  SECTION("Empty spans") {
+    auto empty = make_dense(AddressSpan{});
+    CHECK(changes_of(empty) == Changes{});
+  }
+
+  SECTION("clear() discards accumulated changes") {
+    auto dev = make_dense(span);
+    poke(dev, 0x20, 4);
+    dev.clear(0x00);
+    CHECK(changes_of(dev) == Changes{});
+  }
 }

--- a/test/core/sim/memory/dense.cpp
+++ b/test/core/sim/memory/dense.cpp
@@ -159,11 +159,9 @@ TEST_CASE("(new) Dense change tracking", "[scope:core][scope:core.sim][kind:unit
   SECTION("clear_changes does not affect data") {
     auto dev = make_dense(span);
     poke(dev, 0x20, 4, op);
-    poke(dev, 0x40, 1, op);
     dev.clear_changes();
     CHECK(changes_of(dev) == Changes{});
-    const u8 truth[4] = {0, 1, 2, 3};
-    compare(dev.data().data() + 0x20 - base, truth, 4);
+    CHECK(dev.read<u32>(0x20, op).second != 0);
     // Only writes made after the clear are reported.
     poke(dev, 0x60, 2, op);
     CHECK(changes_of(dev) == Changes{{0x60, 0x61}});

--- a/test/core/sim/memory/sparse.cpp
+++ b/test/core/sim/memory/sparse.cpp
@@ -22,7 +22,11 @@
 namespace {
 auto base_desc = Device::Configuration{.basename = "dev", .fullname = "/dev"};
 const auto op = Operation{Operation::Type::Standard, Operation::Kind::data};
-
+Sparse make_sparse(AddressSpan span, u8 fill = 0xFE) {
+  auto cfg = Sparse::Configuration{Device::Configuration{base_desc}};
+  cfg.span = span, cfg.fill = fill, cfg.id = {};
+  return Sparse(cfg);
+}
 } // namespace
 
 TEST_CASE("Sparse storage in-bounds access", "[scope:core][scope:core.sim][kind:int][arch:*]") {
@@ -36,11 +40,8 @@ TEST_CASE("Sparse storage in-bounds access", "[scope:core][scope:core.sim][kind:
       {4, 8},
       {8, 8},
   }));
-  auto span = AddressSpan(offset, 0x1000);
-  auto cfg = Sparse::Configuration{Device::Configuration{base_desc}};
-  cfg.span = span, cfg.fill = 0xFE, cfg.id = {};
   // Initialize a memory block to a fixed value
-  Sparse dev(cfg);
+  auto dev = make_sparse(AddressSpan(offset, 0x1000), 0xFE);
 
   // Create an 8-byte temporary buffer.
   u64 reg = 0;
@@ -62,35 +63,85 @@ TEST_CASE("Sparse storage in-bounds access", "[scope:core][scope:core.sim][kind:
   compare(truth, tmp, length);
 }
 
-TEST_CASE("Sparse storage out-of-bounds access", "[scope:core][scope:core.sim][kind:int][arch:*][!throws]") {
-  auto span = AddressSpan(0xFE, 0xFE);
+TEST_CASE("(new) Sparse change tracking", "[scope:core][scope:core.sim][kind:unit][arch:*]") {
+  // A non-zero lower bound, so that a device offset can never be mistaken for an address.
+  static constexpr Address base = 0x10, last = 0xFF;
+  auto span = AddressSpan(base, last);
 
-  auto cfg = Sparse::Configuration{Device::Configuration{base_desc}};
-  cfg.span = span, cfg.fill = 0xFE, cfg.id = {};
-  // Initialize a memory block to a fixed value
-  Sparse dev(cfg);
+  SECTION("device's default state is no changes") {
+    auto dev = make_sparse(span);
+    CHECK(changes_of(dev) == Changes{});
+    dev.clear_changes(); // No-op if empty
+    CHECK(changes_of(dev) == Changes{});
+  }
 
-  // Create an 8-byte temporary buffer.
-  u64 reg = 0;
-  u8 *tmp = (u8 *)&reg;
-  // In-bound read does not throw, and retrives default value.
-  REQUIRE_NOTHROW(dev.read(0xFE, {tmp, 1}, op));
+  SECTION("reads do not affect change tracking") {
+    auto dev = make_sparse(span);
+    u64 reg = 0;
+    dev.read(base, {(u8 *)&reg, 8}, op);
+    CHECK(changes_of(dev) == Changes{});
+  }
 
-  // Initialize tmp to be different than dev default value.
-  // Neither OOB read should update temp.
-  *tmp = 0xCA;
-  REQUIRE_THROWS_AS(dev.read(0xFD, {tmp, 1}, op), Error);
-  CHECK(*tmp == 0xCA);
-  REQUIRE_THROWS_AS(dev.read(0xFF, {tmp, 1}, op), Error);
-  CHECK(*tmp == 0xCA);
-  // Cross a page boundary
-  REQUIRE_THROWS_AS(dev.read(0x100, {tmp, 1}, op), Error);
-  CHECK(*tmp == 0xCA);
+  SECTION("write dirties correct bits") {
+    // 1/2/4/8 cover specialized switch branches, 3/5/16 take the memcpy route.
+    auto length = GENERATE(as<std::size_t>{}, 1, 2, 3, 4, 5, 8, 16);
+    auto dev = make_sparse(span);
+    poke(dev, 0x20, length, op);
+    CHECK(changes_of(dev) == Changes{{0x20, Address(0x20 + length - 1)}});
+  }
 
-  // Neither write will stick, so tmp is meaningless
-  *tmp = 0xfe;
-  REQUIRE_THROWS_AS(dev.write(0xFD, {tmp, 1}, op), Error);
-  REQUIRE_THROWS_AS(dev.write(0xFF, {tmp, 1}, op), Error);
-  // Cross a page boundary
-  REQUIRE_THROWS_AS(dev.write(0x100, {tmp, 1}, op), Error);
+  SECTION("handles spans at the extremes") {
+    // The run at `last` is terminated by running out of device rather than by a clean byte.
+    auto dev = make_sparse(span);
+    poke(dev, base, 1, op);
+    poke(dev, last, 1, op);
+    CHECK(changes_of(dev) == Changes{{base, base}, {last, last}});
+  }
+
+  SECTION("collect_changes does not modify Target") {
+    auto dev = make_sparse(span);
+    poke(dev, 0x20, 1, op);
+    CHECK(changes_of(dev) == Changes{{0x20, 0x20}});
+    CHECK(changes_of(dev) == Changes{{0x20, 0x20}});
+  }
+  SECTION("collect_changes does not clear set") {
+    auto dev = make_sparse(span);
+    poke(dev, 0x20, 1, op);
+    // Changes are added to whatever the caller already had, so one set can span many devices.
+    pepp::core::IntervalSet<Address> set;
+    set.insert(0x80, 0x81);
+    dev.collect_changes(set);
+    CHECK(set.intervals() == Changes{{0x20, 0x20}, {0x80, 0x81}});
+  }
+
+  SECTION("An out-of-bounds write leaves change tracking untouched") {
+    auto dev = make_sparse(span);
+    const u8 v = 0xCA;
+    CHECK_THROWS_AS(dev.write(base - 1, {&v, 1}, op), Error);
+    CHECK_THROWS_AS(dev.write(last, {&v, 2}, op), Error);
+    CHECK(changes_of(dev) == Changes{});
+  }
+
+  SECTION("clear_changes does not affect data") {
+    auto dev = make_sparse(span);
+    poke(dev, 0x20, 4, op);
+    dev.clear_changes();
+    CHECK(changes_of(dev) == Changes{});
+    CHECK(dev.read<u32>(0x20, op).second != 0);
+    // Only writes made after the clear are reported.
+    poke(dev, 0x60, 2, op);
+    CHECK(changes_of(dev) == Changes{{0x60, 0x61}});
+  }
+
+  SECTION("Empty spans") {
+    auto empty = make_sparse(AddressSpan{});
+    CHECK(changes_of(empty) == Changes{});
+  }
+
+  SECTION("clear() discards accumulated changes") {
+    auto dev = make_sparse(span);
+    poke(dev, 0x20, 4, op);
+    dev.clear(0x00);
+    CHECK(changes_of(dev) == Changes{});
+  }
 }

--- a/test/core/sim/memory/sparse.cpp
+++ b/test/core/sim/memory/sparse.cpp
@@ -63,6 +63,39 @@ TEST_CASE("Sparse storage in-bounds access", "[scope:core][scope:core.sim][kind:
   compare(truth, tmp, length);
 }
 
+TEST_CASE("Sparse storage out-of-bounds access", "[scope:core][scope:core.sim][kind:int][arch:*][!throws]") {
+  auto span = AddressSpan(0xFE, 0xFE);
+
+  auto cfg = Sparse::Configuration{Device::Configuration{base_desc}};
+  cfg.span = span, cfg.fill = 0xFE, cfg.id = {};
+  // Initialize a memory block to a fixed value
+  Sparse dev(cfg);
+
+  // Create an 8-byte temporary buffer.
+  u64 reg = 0;
+  u8 *tmp = (u8 *)&reg;
+  // In-bound read does not throw, and retrives default value.
+  REQUIRE_NOTHROW(dev.read(0xFE, {tmp, 1}, op));
+
+  // Initialize tmp to be different than dev default value.
+  // Neither OOB read should update temp.
+  *tmp = 0xCA;
+  REQUIRE_THROWS_AS(dev.read(0xFD, {tmp, 1}, op), Error);
+  CHECK(*tmp == 0xCA);
+  REQUIRE_THROWS_AS(dev.read(0xFF, {tmp, 1}, op), Error);
+  CHECK(*tmp == 0xCA);
+  // Cross a page boundary
+  REQUIRE_THROWS_AS(dev.read(0x100, {tmp, 1}, op), Error);
+  CHECK(*tmp == 0xCA);
+
+  // Neither write will stick, so tmp is meaningless
+  *tmp = 0xfe;
+  REQUIRE_THROWS_AS(dev.write(0xFD, {tmp, 1}, op), Error);
+  REQUIRE_THROWS_AS(dev.write(0xFF, {tmp, 1}, op), Error);
+  // Cross a page boundary
+  REQUIRE_THROWS_AS(dev.write(0x100, {tmp, 1}, op), Error);
+}
+
 TEST_CASE("(new) Sparse change tracking", "[scope:core][scope:core.sim][kind:unit][arch:*]") {
   // A non-zero lower bound, so that a device offset can never be mistaken for an address.
   static constexpr Address base = 0x10, last = 0xFF;


### PR DESCRIPTION
We need to track which locations are modified during program execution so that we can highlight the in the memory dump pane.
We don't want to do a full scan of memory for two reasons:
- An elementwise 64k vs 64k comparison won't be fast
- You can't identify memory locations which were written but unchanged.

In the old simulator, we collected the set of changed addresses by walking the trace.
This approach scales linearly with the number of steps elapsed since the UI last updated.

I would rather an approach which scales with the number of changes, which I expect to be a much smaller number compared to the runtime of the application.


The new approach to change tracking requires that each device contain auxiliary information about the changes.
This incurs overhead on write operations, provides the opportunity for the GUI update operation to be O(changed) rather than O(runtime).

This change only handles the portion where we collect changes to `Target`s as part of the Targets* address space.
An (unwritten) subsequent step needs to project those changes back to the initiator's address space